### PR TITLE
ngircd protocol module: Fix NJOIN, actually join users to the channel

### DIFF
--- a/modules/protocol/ngircd.cpp
+++ b/modules/protocol/ngircd.cpp
@@ -489,6 +489,7 @@ struct IRCDMessageNJoin : IRCDMessage
 				Log(LOG_DEBUG) << "NJOIN for nonexistant user " << buf << " on " << params[0];
 				continue;
 			}
+			users.push_back(sju);
 		} 
 
 		Message::Join::SJoin(source, params[0], 0, "", users);


### PR DESCRIPTION
Bug introduced by commit d33a0f75: "Pretty large coding style cleanup,
in source doc cleanup, and allow protocol mods to depend on each other":
Since then, the NJOIN command has been "ignored", no users were added
to channels at all while linking ...
