### PR TITLE
Config file updates: text changes, ...

### DIFF
--- a/data/botserv.example.conf
+++ b/data/botserv.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -131,7 +131,7 @@ botserv
 	#casesensitive = yes
 
 	/*
-	 * Defines the prefixs for fantasy commands in channels. One of these characters will have to be prepended
+	 * Defines the prefixes for fantasy commands in channels. One of these characters will have to be prepended
 	 * to all fantasy commands. If you choose "!", for example, fantasy commands will be "!kick",
 	 * "!op", etc. This directive is optional, if left out, the default fantasy character is "!".
 	 */
@@ -244,7 +244,7 @@ command { service = "BotServ"; name = "KICK"; command = "botserv/kick"; }
  * Provides the commands:
  *   botserv/set/dontkickops - Used for preventing BotServ from kicking channel operators.
  *   botserv/set/dontkickvoices - Used for preventing BotServ from kicking voices.
- *   botserv/set/fantasy - Used for enabling or disabling BotServ's fantaisist commands.
+ *   botserv/set/fantasy - Used for enabling or disabling BotServ's fantasist commands.
  *   botserv/set/greet - Used for enabling or disabling BotServ's greet messages in a channel.
  *   botserv/set/nobot - Used to prohibit specific channels from being assigned BotServ bots.
  *   botserv/set/private - Used to prohibit specific BotServ bots from being assigned to channels.
@@ -252,7 +252,6 @@ command { service = "BotServ"; name = "KICK"; command = "botserv/kick"; }
  * Used for setting options such as kickers and fantasy replies.
  */
 module { name = "bs_set" }
-
 command { service = "BotServ"; name = "SET"; command = "botserv/set"; }
 command { service = "BotServ"; name = "SET DONTKICKOPS"; command = "botserv/set/dontkickops"; }
 command { service = "BotServ"; name = "SET DONTKICKVOICES"; command = "botserv/set/dontkickvoices"; }
@@ -268,7 +267,6 @@ command { service = "BotServ"; name = "SET PRIVATE"; command = "botserv/set/priv
  *
  * Sane defaults are provided below that do not need to be edited unless you wish to change the default behavior.
  */
-
 fantasy { name = "ACCESS"; command = "chanserv/access"; }
 fantasy { name = "AKICK"; command = "chanserv/akick"; }
 fantasy { name = "AOP"; command = "chanserv/aop"; }
@@ -278,19 +276,19 @@ fantasy { name = "DOWN"; command = "chanserv/down"; }
 fantasy { name = "ENFORCE"; command = "chanserv/enforce"; }
 fantasy { name = "ENTRYMSG"; command = "chanserv/entrymsg"; }
 fantasy { name = "FLAGS"; command = "chanserv/flags"; }
-fantasy { name = "HELP"; command = "generic/help"; prepend_channel = false }
+fantasy { name = "HELP"; command = "generic/help"; prepend_channel = false; }
 fantasy { name = "HOP"; command = "chanserv/hop"; }
-fantasy { name = "INFO"; command = "chanserv/info"; prepend_channel = false }
+fantasy { name = "INFO"; command = "chanserv/info"; prepend_channel = false; }
 fantasy { name = "INVITE"; command = "chanserv/invite"; }
 fantasy { name = "K"; command = "chanserv/kick"; }
 fantasy { name = "KB"; command = "chanserv/ban"; }
 fantasy { name = "KICK"; command = "chanserv/kick"; }
 fantasy { name = "LEVELS"; command = "chanserv/levels"; }
-fantasy { name = "LIST"; command = "chanserv/list"; prepend_channel = false }
+fantasy { name = "LIST"; command = "chanserv/list"; prepend_channel = false; }
 fantasy { name = "LOG"; command = "chanserv/log"; }
 fantasy { name = "MODE"; command = "chanserv/mode"; }
 fantasy { name = "QOP"; command = "chanserv/qop"; }
-fantasy { name = "SEEN"; command = "chanserv/seen"; prepend_channel = false }
+fantasy { name = "SEEN"; command = "chanserv/seen"; prepend_channel = false; }
 fantasy { name = "SOP"; command = "chanserv/sop"; }
 fantasy { name = "STATUS"; command = "chanserv/status"; }
 fantasy { name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; }
@@ -301,8 +299,8 @@ fantasy { name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chan
 fantasy { name = "UP"; command = "chanserv/up"; }
 fantasy { name = "VOP"; command = "chanserv/vop"; }
 
-/* Use m_rewrite to rewrite the op, deop, etc. fantasy commands (see chanserv.conf). */
 
+/* Use m_rewrite to rewrite the op, deop, etc. fantasy commands (see chanserv.conf). */
 fantasy { name = "OWNER"; command = "rewrite"; }
 fantasy { name = "DEOWNER"; command = "rewrite"; }
 
@@ -317,4 +315,3 @@ fantasy { name = "DEHALFOP"; command = "rewrite"; }
 
 fantasy { name = "VOICE"; command = "rewrite"; }
 fantasy { name = "DEVOICE"; command = "rewrite"; }
-

--- a/data/chanserv.example.conf
+++ b/data/chanserv.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -117,7 +117,7 @@ chanserv
 	 * The length of time before a suspended channel becomes unsuspended.
 	 *
 	 * This directive is optional.
-	 * If not set, the default is to never.
+	 * If not set, the default is never.
 	 */
 	#suspendexpire = 90d
 
@@ -125,7 +125,7 @@ chanserv
 	 * The lenth of time before a forbidden channel drops.
 	 *
 	 * This directive is optional.
-	 * If not set, the default is to never.
+	 * If not set, the default is never.
 	 */
 	#forbidexpire = 90d
 
@@ -429,7 +429,7 @@ privilege
 /*
  * FOUNDER privilege.
  *
- * Used by botserv/info, chanserv/access, chanserv/akick,
+ * Used by chanserv/access, chanserv/akick,
  * chanserv/drop, chanserv/set/founder,
  * chanserv/set/securefounder, chanserv/set/successor and chanserv/xop.
  *
@@ -869,7 +869,7 @@ command_group
 
 command_group
 {
-	name = "chanserv/admin";
+	name = "chanserv/admin"
 	description = "Services Operator commands"
 }
 
@@ -885,8 +885,8 @@ command { service = "ChanServ"; name = "HELP"; command = "generic/help"; }
  * Used for giving users access in channels.
  */
 module { name = "cs_access" }
-command { service = "ChanServ"; name = "ACCESS"; command = "chanserv/access"; group = "chanserv/access" }
-command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; group = "chanserv/access" }
+command { service = "ChanServ"; name = "ACCESS"; command = "chanserv/access"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; group = "chanserv/access"; }
 
 /*
  * cs_akick
@@ -896,7 +896,7 @@ command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; gr
  * Used for preventing users from joining channels.
  */
 module { name = "cs_akick" }
-command { service = "ChanServ"; name = "AKICK"; command = "chanserv/akick"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "AKICK"; command = "chanserv/akick"; group = "chanserv/management"; }
 
 /*
  * cs_ban
@@ -916,7 +916,7 @@ command { service = "ChanServ"; name = "BAN"; command = "chanserv/ban"; }
  * Used for copying channel settings from one channel to another.
  */
 module { name = "cs_clone" }
-command { service = "ChanServ"; name = "CLONE"; command = "chanserv/clone"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "CLONE"; command = "chanserv/clone"; group = "chanserv/management"; }
 
 /*
  * cs_drop
@@ -936,7 +936,7 @@ command { service = "ChanServ"; name = "DROP"; command = "chanserv/drop"; }
  * Used to enforce various channel settings such as secureops and restricted.
  */
 module { name = "cs_enforce" }
-command { service = "ChanServ"; name = "ENFORCE"; command = "chanserv/enforce"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "ENFORCE"; command = "chanserv/enforce"; group = "chanserv/management"; }
 
 /*
  * cs_entrymsg
@@ -946,7 +946,7 @@ command { service = "ChanServ"; name = "ENFORCE"; command = "chanserv/enforce"; 
  * Used to configure entry messages sent to users when they join a channel.
  */
 module { name = "cs_entrymsg" }
-command { service = "ChanServ"; name = "ENTRYMSG"; command = "chanserv/entrymsg"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "ENTRYMSG"; command = "chanserv/entrymsg"; group = "chanserv/management"; }
 cs_entrymsg
 {
 	/* The maximum number of entrymsgs allowed per channel. If not set, defaults to 5. */
@@ -962,7 +962,7 @@ cs_entrymsg
  * Used for giving users access in channels.
  */
 module { name = "cs_flags" }
-command { service = "ChanServ"; name = "FLAGS"; command = "chanserv/flags"; group = "chanserv/access" }
+command { service = "ChanServ"; name = "FLAGS"; command = "chanserv/flags"; group = "chanserv/access"; }
 
 /*
  * cs_getkey
@@ -1012,7 +1012,7 @@ command { service = "ChanServ"; name = "KICK"; command = "chanserv/kick"; }
  * Used for retrieving and searching the registered channel list.
  */
 module { name = "cs_list" }
-command { service = "ChanServ"; name = "LIST"; command = "chanserv/list"; permission = "chanserv/list"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "LIST"; command = "chanserv/list"; permission = "chanserv/list"; group = "chanserv/admin"; }
 
 /*
  * cs_log
@@ -1022,7 +1022,7 @@ command { service = "ChanServ"; name = "LIST"; command = "chanserv/list"; permis
  * Use for configuring what actions on channels are logged and where.
  */
 module { name = "cs_log" }
-command { service = "ChanServ"; name = "LOG"; command = "chanserv/log"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "LOG"; command = "chanserv/log"; group = "chanserv/management"; }
 
 /*
  * cs_mode
@@ -1032,7 +1032,7 @@ command { service = "ChanServ"; name = "LOG"; command = "chanserv/log"; group = 
  * Used for changing mode locks and changing modes.
  */
 module { name = "cs_mode" }
-command { service = "ChanServ"; name = "MODE"; command = "chanserv/mode"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "MODE"; command = "chanserv/mode"; group = "chanserv/management"; }
 
 /*
  * cs_register
@@ -1053,13 +1053,13 @@ command { service = "ChanServ"; name = "REGISTER"; command = "chanserv/register"
  * Also allows administrators to view stats about seen data and purge the database.
  */
 module { name = "cs_seen" }
-command { service = "OperServ"; name = "SEEN"; command = "operserv/seen"; }
+command { service = "OperServ"; name = "SEEN"; command = "operserv/seen"; permission = "operserv/seen"; }
 cs_seen
 {
 	/* Sets the time to keep seen entries in the seen database. */
 	purgetime = "30d"
 
-	/* Sets the delay between checks for expired seen entries */
+	/* Sets the delay between checks for expired seen entries. */
 	expiretimeout = "1d"
 }
 
@@ -1069,9 +1069,9 @@ cs_seen
  * Provides the commands:
  *   chanserv/set and chanserv/saset - Dummy help wrappers for the SET and SASET commands.
  *   chanserv/set/autoop - Used for configuring whether or not ChanServ automatically gives channel status to users.
- *   chanserv/set/bantype - Used for controlling what format bans are placed on channels.
+ *   chanserv/set/bantype - Used for controlling what format of bans are placed on channels.
  *   chanserv/set/description - Used for changing channels descriptions.
- *   chanserv/set/founder - Used for changing a channels founder.
+ *   chanserv/set/founder - Used for changing a channel's founder.
  *   chanserv/set/keeptopic -  Used for configuring if ChanServ is to restore the channel topic when a channel is created.
  *   chanserv/set/peace - Used for configuring if users are able to kick other users with higher access than them.
  *   chanserv/set/persist - Used for setting whether ChanServ should stay in channels after the last user leaves.
@@ -1081,62 +1081,61 @@ cs_seen
  *   chanserv/set/securefounder - Used for setting whether users with founder level access in channels have true founder or not.
  *   chanserv/set/secureops - Used for restricting who can have channel op privilege in a channel to those whom have access in the channel.
  *   chanserv/set/signkick - Used for setting signkick, which appends the kicker's name to kicks sent through ChanServ.
- *   chanserv/set/successor - Used for setting channel successors, which become channel founders if the founders account expires.
+ *   chanserv/set/successor - Used for setting channel successors, which become channel founders if the founders' account expires.
  *   chanserv/saset/noexpire - Used for setting noexpire, which prevents channels from expiring.
  *
- * Is a dummy command to provide a help wrapper for the various SET commands.
+ * This is a dummy command to provide a help wrapper for the various SET and SASET commands.
  */
 module { name = "cs_set" }
 
-command { service = "ChanServ"; name = "SET"; command = "chanserv/set"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET"; command = "chanserv/saset"; permission = "chanserv/saset/"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET"; command = "chanserv/set"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET"; command = "chanserv/saset"; permission = "chanserv/saset/"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET AUTOOP"; command = "chanserv/set/autoop"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET AUTOOP"; command = "chanserv/set/autoop"; permission = "chanserv/saset/autoop"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET AUTOOP"; command = "chanserv/set/autoop"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET AUTOOP"; command = "chanserv/set/autoop"; permission = "chanserv/saset/autoop"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET BANTYPE"; command = "chanserv/set/bantype"; group = "chanserv/management"}
-command { service = "ChanServ"; name = "SASET BANTYPE"; command = "chanserv/set/bantype"; permission = "chanserv/saset/bantype"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET BANTYPE"; command = "chanserv/set/bantype"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET BANTYPE"; command = "chanserv/set/bantype"; permission = "chanserv/saset/bantype"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET DESCRIPTION"; command = "chanserv/set/description"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SET DESC"; command = "chanserv/set/description"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "SET DESCRIPTION"; command = "chanserv/set/description"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SET DESC"; command = "chanserv/set/description"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET DESCRIPTION"; command = "chanserv/set/description"; permission = "chanserv/saset/description"; group = "chanserv/admin"; }
+command { service = "ChanServ"; name = "SASET DESC"; command = "chanserv/set/description"; permission = "chanserv/saset/description"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SASET DESCRIPTION"; command = "chanserv/set/description"; permission = "chanserv/saset/description"; group = "chanserv/admin" }
-command { service = "ChanServ"; name = "SASET DESC"; command = "chanserv/set/description"; permission = "chanserv/saset/description"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET FOUNDER"; command = "chanserv/set/founder"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET FOUNDER"; command = "chanserv/set/founder"; permission = "chanserv/saset/founder"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET FOUNDER"; command = "chanserv/set/founder"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET FOUNDER"; command = "chanserv/set/founder"; permission = "chanserv/saset/founder"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET KEEPTOPIC"; command = "chanserv/set/keeptopic"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET KEEPTOPIC"; command = "chanserv/set/keeptopic"; permission = "chanserv/saset/keeptopic"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET KEEPTOPIC"; command = "chanserv/set/keeptopic"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET KEEPTOPIC"; command = "chanserv/set/keeptopic"; permission = "chanserv/saset/keeptopic"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET PEACE"; command = "chanserv/set/peace"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET PEACE"; command = "chanserv/set/peace"; permission = "chanserv/saset/peace"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET PEACE"; command = "chanserv/set/peace"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET PEACE"; command = "chanserv/set/peace"; permission = "chanserv/saset/peace"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET PERSIST"; command = "chanserv/set/persist"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET PERSIST"; command = "chanserv/set/persist"; permission = "chanserv/saset/persist"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET PERSIST"; command = "chanserv/set/persist"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET PERSIST"; command = "chanserv/set/persist"; permission = "chanserv/saset/persist"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET PRIVATE"; command = "chanserv/set/private"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET PRIVATE"; command = "chanserv/set/private"; permission = "chanserv/saset/private"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET PRIVATE"; command = "chanserv/set/private"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET PRIVATE"; command = "chanserv/set/private"; permission = "chanserv/saset/private"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET RESTRICTED"; command = "chanserv/set/restricted"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET RESTRICTED"; command = "chanserv/set/restricted"; permission = "chanserv/saset/restricted"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET RESTRICTED"; command = "chanserv/set/restricted"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET RESTRICTED"; command = "chanserv/set/restricted"; permission = "chanserv/saset/restricted"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET SECURE"; command = "chanserv/set/secure"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET SECURE"; command = "chanserv/set/secure"; permission = "chanserv/saset/secure"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET SECURE"; command = "chanserv/set/secure"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET SECURE"; command = "chanserv/set/secure"; permission = "chanserv/saset/secure"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET SECUREFOUNDER"; command = "chanserv/set/securefounder"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET SECUREFOUNDER"; command = "chanserv/set/securefounder"; permission = "chanserv/saset/securefounder"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET SECUREFOUNDER"; command = "chanserv/set/securefounder"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET SECUREFOUNDER"; command = "chanserv/set/securefounder"; permission = "chanserv/saset/securefounder"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET SECUREOPS"; command = "chanserv/set/secureops"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET SECUREOPS"; command = "chanserv/set/secureops"; permission = "chanserv/saset/secureops"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET SECUREOPS"; command = "chanserv/set/secureops"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET SECUREOPS"; command = "chanserv/set/secureops"; permission = "chanserv/saset/secureops"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET SIGNKICK"; command = "chanserv/set/signkick"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET SIGNKICK"; command = "chanserv/set/signkick"; permission = "chanserv/saset/signkick"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET SIGNKICK"; command = "chanserv/set/signkick"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET SIGNKICK"; command = "chanserv/set/signkick"; permission = "chanserv/saset/signkick"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SET SUCCESSOR"; command = "chanserv/set/successor"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SASET SUCCESSOR"; command = "chanserv/set/successor"; permission = "chanserv/saset/successor"; group = "chanserv/admin"; }
 
-command { service = "ChanServ"; name = "SET SUCCESSOR"; command = "chanserv/set/successor"; group = "chanserv/management" }
-command { service = "ChanServ"; name = "SASET SUCCESSOR"; command = "chanserv/set/successor"; permission = "chanserv/saset/successor"; group = "chanserv/admin" }
-
-command { service = "ChanServ"; name = "SASET NOEXPIRE"; command = "chanserv/saset/noexpire"; permission = "chanserv/saset/noexpire"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SASET NOEXPIRE"; command = "chanserv/saset/noexpire"; permission = "chanserv/saset/noexpire"; group = "chanserv/admin"; }
 
 /*
  * cs_set_misc
@@ -1144,11 +1143,13 @@ command { service = "ChanServ"; name = "SASET NOEXPIRE"; command = "chanserv/sas
  * Provides the command chanserv/set/misc.
  *
  * Allows you to create arbitrary commands to set data, and have that data show up in chanserv/info.
- * A field named misc_description may be given for use with help output. 
+ * A field named misc_description may be given for use with help output.
  */
 module { name = "cs_set_misc" }
-command { service = "ChanServ"; name = "SET URL"; command = "chanserv/set/misc"; group = "chanserv/management"; misc_description = _("Associate a URL with the channel") }
-command { service = "ChanServ"; name = "SET EMAIL"; command = "chanserv/set/misc"; group = "chanserv/management"; misc_description = _("Associate an E-mail address with the channel") }
+command { service = "ChanServ"; name = "SET URL"; command = "chanserv/set/misc"; group = "chanserv/management"; misc_description = _("Associate a URL with the channel"); }
+command { service = "ChanServ"; name = "SASET URL"; command = "chanserv/set/misc"; group = "chanserv/management"; misc_description = _("Associate a URL with the channel"); permission = "chanserv/saset/url"; group = "chanserv/admin"; }
+command { service = "ChanServ"; name = "SET EMAIL"; command = "chanserv/set/misc"; group = "chanserv/management"; misc_description = _("Associate an E-mail address with the channel"); }
+command { service = "ChanServ"; name = "SASET EMAIL"; command = "chanserv/set/misc"; group = "chanserv/management"; misc_description = _("Associate an E-mail address with the channel"); permission = "chanserv/saset/email"; group = "chanserv/admin"; }
 
 /*
  * cs_status
@@ -1169,8 +1170,8 @@ command { service = "ChanServ"; name = "STATUS"; command = "chanserv/status"; }
  * Used for suspending and unsuspending channels. Suspended channels can not be used but their settings are stored.
  */
 module { name = "cs_suspend" }
-command { service = "ChanServ"; name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; group = "chanserv/admin" }
-command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chanserv/suspend"; group = "chanserv/admin" }
+command { service = "ChanServ"; name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
+command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
 
 /*
  * cs_sync
@@ -1180,17 +1181,17 @@ command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspen
  * Used to sync users channel status modes with what access they have.
  */
 module { name = "cs_sync" }
-command { service = "ChanServ"; name = "SYNC"; command = "chanserv/sync"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "SYNC"; command = "chanserv/sync"; group = "chanserv/management"; }
 
 /*
  * cs_topic
  *
  * Provides the command chanserv/topic.
  *
- * Used for changing the channel topic. Usedful in conjunction with chanserv/set/topiclock.
+ * Used for changing the channel topic. Useful in conjunction with chanserv/set/topiclock.
  */
 module { name = "cs_topic" }
-command { service = "ChanServ"; name = "TOPIC"; command = "chanserv/topic"; group = "chanserv/management" }
+command { service = "ChanServ"; name = "TOPIC"; command = "chanserv/topic"; group = "chanserv/management"; }
 
 /*
  * cs_unban
@@ -1210,8 +1211,8 @@ command { service = "ChanServ"; name = "UNBAN"; command = "chanserv/unban"; }
  * Used for setting or removing your status modes on a channel.
  */
 module { name = "cs_updown" }
-command { service = "ChanServ"; name = "DOWN"; command = "chanserv/down"; group = "chanserv/status" }
-command { service = "ChanServ"; name = "UP"; command = "chanserv/up"; group = "chanserv/status" }
+command { service = "ChanServ"; name = "DOWN"; command = "chanserv/down"; group = "chanserv/status"; }
+command { service = "ChanServ"; name = "UP"; command = "chanserv/up"; group = "chanserv/status"; }
 
 /*
  * cs_xop
@@ -1222,14 +1223,16 @@ command { service = "ChanServ"; name = "UP"; command = "chanserv/up"; group = "c
  * Used for giving users access in channels.
  */
 module { name = "cs_xop" }
-command { service = "ChanServ"; name = "QOP"; command = "chanserv/qop"; group = "chanserv/access" }
-command { service = "ChanServ"; name = "SOP"; command = "chanserv/sop"; group = "chanserv/access" }
-command { service = "ChanServ"; name = "AOP"; command = "chanserv/aop"; group = "chanserv/access" }
-command { service = "ChanServ"; name = "HOP"; command = "chanserv/hop"; group = "chanserv/access" }
-command { service = "ChanServ"; name = "VOP"; command = "chanserv/vop"; group = "chanserv/access"  }
+command { service = "ChanServ"; name = "QOP"; command = "chanserv/qop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "SOP"; command = "chanserv/sop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "AOP"; command = "chanserv/aop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "HOP"; command = "chanserv/hop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "VOP"; command = "chanserv/vop"; group = "chanserv/access"; }
+
 
 /* Use m_rewrite to rewrite the op, deop, etc. commands (see modules.conf). */
 
+/* OWNER and DEOWNER commands */
 command
 {
 	service = "ChanServ"; name = "OWNER"; command = "rewrite"; group = "chanserv/status"
@@ -1238,7 +1241,7 @@ command
 	rewrite_source = "OWNER $"
 	rewrite_target = "MODE $1 SET +q $2"
 
-	rewrite_description = _("Gives you owner status on channel")
+	rewrite_description = _("Gives you or a specified nick owner status on a channel")
 }
 command
 {
@@ -1247,10 +1250,11 @@ command
 	rewrite = true
 	rewrite_source = "DEOWNER $"
 	rewrite_target = "MODE $1 SET -q $2"
-	
-	rewrite_description = _("Removes your owner status on a channel")
+
+	rewrite_description = _("Removes owner status from you or a specified nick on a channel")
 }
 
+/* PROTECT and DEPROTECT commands */
 command
 {
 	service = "ChanServ"; name = "PROTECT"; command = "rewrite"; group = "chanserv/status"
@@ -1258,8 +1262,8 @@ command
 	rewrite = true
 	rewrite_source = "PROTECT $"
 	rewrite_target = "MODE $1 SET +a $2"
-	
-	rewrite_description = _("Protects a selected nick on a channel")
+
+	rewrite_description = _("Protects you or a specified nick on a channel")
 }
 command
 {
@@ -1268,10 +1272,11 @@ command
 	rewrite = true
 	rewrite_source = "DEPROTECT $"
 	rewrite_target = "MODE $1 SET -a $2"
-	
-	rewrite_description = _("Deprotects a selected nick on a channel")
+
+	rewrite_description = _("Deprotects you or a specified nick on a channel")
 }
 
+/* OP and DEOP commands */
 command
 {
 	service = "ChanServ"; name = "OP"; command = "rewrite"; group = "chanserv/status"
@@ -1279,10 +1284,9 @@ command
 	rewrite = true
 	rewrite_source = "OP $"
 	rewrite_target = "MODE $1 SET +o $2"
-	
-	rewrite_description = _("Gives Op status to a selected nick on a channel")
-}
 
+	rewrite_description = _("Gives operator status to you or a specified nick on a channel")
+}
 command
 {
 	service = "ChanServ"; name = "DEOP"; command = "rewrite"; group = "chanserv/status"
@@ -1290,8 +1294,8 @@ command
 	rewrite = true
 	rewrite_source = "DEOP $"
 	rewrite_target = "MODE $1 SET -o $2";
-	
-	rewrite_description = _("Deops a selected nick on a channel")
+
+	rewrite_description = _("Deops you or a specified nick on a channel")
 }
 
 /* HALFOP and DEHALFOP commands */
@@ -1302,8 +1306,8 @@ command
 	rewrite = true
 	rewrite_source = "HALFOP $"
 	rewrite_target = "MODE $1 SET +h $2"
-	
-	rewrite_description = _("Halfops a selected nick on a channel")
+
+	rewrite_description = _("Halfops you or a specified nick on a channel")
 
 }
 command
@@ -1313,8 +1317,8 @@ command
 	rewrite = true
 	rewrite_source = "DEHALFOP $"
 	rewrite_target = "MODE $1 SET -h $2"
-	
-	rewrite_description = _("Dehalfops a selected nick on a channel")
+
+	rewrite_description = _("Dehalfops you or a specified nick on a channel")
 }
 
 /* VOICE and DEVOICE commands */
@@ -1325,10 +1329,9 @@ command
 	rewrite = true
 	rewrite_source = "VOICE $"
 	rewrite_target = "MODE $1 SET +v $2"
-	
-	rewrite_description = _("Voices a selected nick on a channel")
-}
 
+	rewrite_description = _("Voices you or a specified nick on a channel")
+}
 command
 {
 	service = "ChanServ"; name = "DEVOICE"; command = "rewrite"; group = "chanserv/status"
@@ -1337,7 +1340,7 @@ command
 	rewrite_source = "DEVOICE $"
 	rewrite_target = "MODE $1 SET -v $2"
 
-	rewrite_description = _("Devoices a selected nick on a channel")
+	rewrite_description = _("Devoices you or a specified nick on a channel")
 }
 
 
@@ -1352,4 +1355,3 @@ command
  * channel's access list is modified.
  */
 module { name = "cs_statusupdate" }
-

--- a/data/chanstats.example.conf
+++ b/data/chanstats.example.conf
@@ -4,12 +4,11 @@
  */
 
 module { name = "m_chanstats" }
-
 chanstats
 {
-	/* 
+	/*
 	 * The name of this engine.
-	 * This must match with the name of a SQL engine block
+	 * This must match with the name of an SQL engine block.
 	 */
 
 	engine = "mysql/main"
@@ -20,21 +19,20 @@ chanstats
 	 */
 	prefix = "anope_"
 
-	smileyshappy = ":) :-) ;) :D :-D"
+	smileyshappy = ":) :-) ;) ;-) :D :-D :P :-P"
 	smileyssad = ":( :-( ;( ;-("
-	smileysother = ":/"
+	smileysother = ":/ :-/"
 
 	/*
-	 * Enable Chanstats for new registered nicks / channels 
-	 * set it to 0 to disable it.
+	 * Enable Chanstats for newly registered nicks / channels.
+	 * Set it to 0 to disable it.
 	 */
 	NSDefChanstats = 1
 	CSDefChanstats = 1
 }
-
 command { service = "ChanServ"; name = "SET CHANSTATS"; command = "chanserv/set/chanstats"; }
 command { service = "NickServ"; name = "SET CHANSTATS"; command = "nickserv/set/chanstats"; }
-command { service = "NIckServ"; name = "SASET CHANSTATS"; command = "nickserv/saset/chanstats"; }
+command { service = "NickServ"; name = "SASET CHANSTATS"; command = "nickserv/saset/chanstats"; }
 
 module { name = "cs_fantasy_stats" }
 command { service = "ChanServ"; name = "STATS"; command = "chanserv/stats"; }

--- a/data/example.conf
+++ b/data/example.conf
@@ -1,6 +1,6 @@
 /*
  * Example configuration file for Services. After making the appropriate
- * changes to this file, place it in the Services data directory (as
+ * changes to this file, place it in the Services conf directory (as
  * specified in the "configure" script, default /home/username/services/conf)
  * under the name "services.conf".
  *
@@ -340,8 +340,8 @@ options
 	 * entity (nickname name) with which it is associated. When set, however,
 	 * Services will also check that the password is at least five
 	 * characters long, and in the future will probably check other things
-	 * as well. 
-	 * 
+	 * as well.
+	 *
 	 * This directive is optional, but recommended.
 	 */
 	strictpasswords = yes
@@ -353,7 +353,7 @@ options
 	 * during a single IRC session (subject to badpasstimeout, below), Services
 	 * will issues a /KILL for the user. If not given, Services will ignore
 	 * failed password attempts (though they will be logged in any case).
-	 * 
+	 *
 	 * This directive is optional, but recommended.
 	 */
 	badpasslimit = 5
@@ -488,7 +488,7 @@ options
 
 	/*
 	 * The number of LOGON/OPER news items to display when a user logs on.
-	 * 
+	 *
 	 * This directive is optional, if no set it will default to 3.
 	 */
 	#newscount = 3
@@ -627,7 +627,7 @@ include
 }
 
 /*
- * [RECOMMENDED] Logging Configuration 
+ * [RECOMMENDED] Logging Configuration
  *
  * This section is used for configuring what is logged and where it is logged to.
  * You may have multiple log blocks if you wish. Remember to properly secure any
@@ -644,7 +644,7 @@ log
 	target = "services.log"
 
 	/* Log to both services.log and the channel #services
-	 * 
+	 *
 	 * Note that some older IRCds, such as Ratbox, require services to be in the
 	 * log channel to be able to message it. To do this, configure service:channels to
 	 * join your logging channel.
@@ -716,7 +716,7 @@ log
 log
 {
 	target = "globops"
-	admin = "global/* operserv/mode operserv/kick operserv/akill operserv/s*line operserv/noop operserv/jupe operserv/oline operserv/set operserv/svsnick operserv/svsjoin operserv/svspart nickserv/getpass */drop"
+	admin = "global/* operserv/global operserv/mode operserv/kick operserv/akill operserv/s*line operserv/noop operserv/jupe operserv/oline operserv/set operserv/svsnick operserv/svsjoin operserv/svspart nickserv/getpass */drop"
 	servers = "squit"
 	users = "oper"
 	other = "expire/* bados akill/*"
@@ -762,25 +762,25 @@ log
  *   chanserv/saset/peace     chanserv/saset/persist        chanserv/saset/private
  *   chanserv/saset/secure    chanserv/saset/securefounder  chanserv/saset/secureops
  *   chanserv/saset/signkick  chanserv/saset/successor      chanserv/saset/topiclock
- *   chanserv/saset/url       chanserv/saset/noexpire
+ *   chanserv/saset/url       chanserv/saset/noexpire       chanserv/saset/autoop
  *
  *   memoserv/sendall        memoserv/staff
  *
  *   nickserv/getpass        nickserv/getemail      nickserv/suspend
  *   nickserv/resetpass      nickserv/release       nickserv/list
  *
- *   nickserv/saset/autoop   nickserv/saset/email   nickserv/saset/greet
- *   nickserv/saset/icq      nickserv/saset/kill    nickserv/saset/language nickserv/saset/message
- *   nickserv/saset/private  nickserv/saset/secure  nickserv/saset/url      nickserv/saset/noexpire
+ *   nickserv/saset/autoop   nickserv/saset/email   nickserv/saset/greet     nickserv/saset/password
+ *   nickserv/saset/display  nickserv/saset/kill    nickserv/saset/language  nickserv/saset/message
+ *   nickserv/saset/private  nickserv/saset/secure  nickserv/saset/url       nickserv/saset/noexpire
  *
- *   hostserv/set            hostserv/del
+ *   hostserv/set            hostserv/del           hostserv/list
  *
  *   global/global
  *
- *   operserv/news         operserv/stats        operserv/kick       operserv/exception
- *   operserv/mode         operserv/session      operserv/modlist    operserv/ignore
+ *   operserv/news         operserv/stats        operserv/kick       operserv/exception    operserv/seen
+ *   operserv/mode         operserv/session      operserv/modinfo    operserv/ignore
  *   operserv/chankill     operserv/akill        operserv/sqline     operserv/snline
- *   operserv/szline       operserv/oper         operserv/config     operserv/umode
+ *   operserv/global       operserv/oper         operserv/config     operserv/umode
  *   operserv/modload      operserv/jupe         operserv/set        operserv/noop
  *   operserv/quit         operserv/update       operserv/reload     operserv/restart
  *   operserv/shutdown     operserv/svs          operserv/oline      operserv/kill
@@ -812,7 +812,7 @@ opertype
 	inherits = "Helper, Another Helper"
 
 	/* What commands (see above) this opertype may use */
-	commands = "chanserv/list chanserv/suspend chanserv/topic memoserv/staff nickserv/list nickserv/resetpass nickserv/suspend operserv/mode operserv/chankill operserv/szline operserv/akill operserv/session operserv/modlist operserv/sqline operserv/oper operserv/kick operserv/ignore operserv/snline"
+	commands = "chanserv/list chanserv/suspend chanserv/topic memoserv/staff nickserv/list nickserv/resetpass nickserv/suspend operserv/mode operserv/chankill operserv/akill operserv/session operserv/modinfo operserv/sqline operserv/oper operserv/kick operserv/ignore operserv/snline"
 
 	/* What privs (see above) this opertype has */
 	privs = "chanserv/auspex chanserv/no-register-limit memoserv/* nickserv/auspex nickserv/confirm"
@@ -871,17 +871,17 @@ oper
 	 */
 	require_oper = yes
 
-	/* An optional password. If defined the user must login using /operserv login first */
+	/* An optional password. If defined the user must login using "/msg OperServ LOGIN" first */
 	#password = "secret"
 
-	/* An optional SSL fingerprint. If defined is required to use this opertype. */
+	/* An optional SSL fingerprint. If defined, it's required to be able to use this opertype. */
 	#certfp = "ed3383b3f7d74e89433ddaa4a6e5b2d7"
 
 	/* An optional list of user@host masks. If defined the user must be connected from one of them */
 	#host = "*@*.anope.org ident@*"
 
-	/* An optional vhost to set on users who identify for this oper block.
-	 * This will override HostServ vhosts, and may not be available on all IRCds
+	/* An optional vHost to set on users who identify for this oper block.
+	 * This will override HostServ vHosts, and may not be available on all IRCds
 	 */
 	#vhost = "oper.mynet"
 }
@@ -941,7 +941,8 @@ mail
 	sendfrom = "services@localhost.net"
 
 	/*
-	 * If set, SENDPASS and RESETPASS will be restricted to IRC operators.
+	 * If set, RESETPASS will be restricted to services operators with access to
+	 * nickserv/resetpass in their opertype:commands.
 	 * This directive is optional.
 	 *
 	 * WARNING: If you choose to not enable this option, you should limit the
@@ -975,13 +976,14 @@ mail
 	/*
 	 * The subject and message of emails sent to users when they register accounts.
 	 */
-	registration_subject = "Nickname Registration for %n"
+	registration_subject = "Nickname registration for %n"
 	registration_message = "Hi,
 
 				You have requested to register the nickname %n on %N.
-				Please type \" /msg NickServ confirm %c \" to complete registration.
+				Please type \" /msg NickServ CONFIRM %c \" to complete registration.
 
 				If you don't know why this mail was sent to you, please ignore it silently.
+
 				%N administrators."
 
 	/*
@@ -1004,22 +1006,23 @@ mail
 	emailchange_message = "Hi,
 
 			You have requested to change your email address to %e.
-			Please type \" /msg NickServ confirm %c \" to confirm this change.
+			Please type \" /msg NickServ CONFIRM %c \" to confirm this change.
 
 			If you don't know why this mail was sent to you, please ignore it silently.
 
 			%N administrators."
 
 	/*
-	 * The subject and message of emails sent to users when they recieve a new memo.
+	 * The subject and message of emails sent to users when they receive a new memo.
 	 */
 	memo_subject = "New memo"
-	memo_message = "Hi %n
-		You've just received a new memo from %s. This is memo number %d.
+	memo_message = "Hi %n,
 
-		Memo text:
+			You've just received a new memo from %s. This is memo number %d.
 
-		%t"
+			Memo text:
+
+			%t"
 }
 
 /*
@@ -1080,9 +1083,9 @@ db_flatfile
 
 	/*
 	 * If enabled, services will fork a child process to save databases.
-	 * 
+	 *
 	 * This is only useful with very large databases, with hundreds
-	 * of thousands of objects, that have a noticable delay from
+	 * of thousands of objects, that have a noticeable delay from
 	 * writing databases.
 	 */
 	fork = no
@@ -1131,15 +1134,15 @@ db_sql
  * The encryption modules are used when dealing with passwords. This determines how
  * the passwords are stored in the databases, and does not add any security as
  * far as transmitting passwords over the network goes.
- * 
+ *
  * Without any encryption modules loaded users will not be able to authenticate unless
  * there is another module loaded that provides authentication checking, such as
  * m_ldap_authentication or m_sql_authentication.
  *
- * With enc_none, passwords will be stored in plain text, allowing
- * for passwords to be recovered later but isn't secure therefore is not recommended. 
- * 
- * The other encryption modules use one-way encryption, so the passwords can not 
+ * With enc_none, passwords will be stored in plain text, allowing for passwords
+ * to be recovered later but it isn't secure and therefore is not recommended.
+ *
+ * The other encryption modules use one-way encryption, so the passwords can not
  * be recovered later if those are used.
  *
  * The first encryption module loaded is the primary encryption module. All new passwords are
@@ -1164,7 +1167,7 @@ module { name = "enc_sha256" }
 
 /*
  * When using enc_none, passwords will be stored without encryption. This isn't secure
- * therefore it is not recommended. 
+ * therefore it is not recommended.
  */
 #module { name = "enc_none" }
 

--- a/data/global.example.conf
+++ b/data/global.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -90,7 +90,7 @@ global
 	globaloncycleup = "Services are now back online - have a nice day"
 
 	/*
-	 * If set, Services will hide the IRC operator's nick in a global
+	 * If set, Services will hide the IRC Operator's nick in a global
 	 * message/notice.
 	 *
 	 * This directive is optional.
@@ -122,4 +122,3 @@ command { service = "Global"; name = "HELP"; command = "generic/help"; }
 module { name = "gl_global" }
 command { service = "OperServ"; name = "GLOBAL"; command = "global/global"; permission = "operserv/global"; }
 command { service = "Global"; name = "GLOBAL"; command = "global/global"; permission = "global/global"; }
-

--- a/data/hostserv.example.conf
+++ b/data/hostserv.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -69,9 +69,9 @@ hostserv
 	name = "HostServ"
 
 	/*
-	 * The characters allowed in a vhost. Changing this is not recommended unless
+	 * The characters allowed in a vHost. Changing this is not recommended unless
 	 * you know for sure your IRCd supports whatever characters you are wanting to use.
-	 * Telling services to set a vhost containing characters your IRCd disallows could
+	 * Telling services to set a vHost containing characters your IRCd disallows could
 	 * potentially break the IRCd and/or Services. Note these are 1 byte characters, so
 	 * UTF-8 characters will not work.
 	 *
@@ -80,7 +80,7 @@ hostserv
 	vhost_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-"
 
 	/*
-	 * If set, allows vhosts to not contain dots (.).
+	 * If set to true, allows vHosts to not contain dots (.).
 	 * Newer IRCds generally do not have a problem with this, but the same warning as
 	 * vhost_chars applies.
 	 *
@@ -90,7 +90,7 @@ hostserv
 
 	/*
 	 * The characters that are not allowed to be at the very beginning or very ending
-	 * of a vhost. The same warning as vhost_chars applies.
+	 * of a vHost. The same warning as vhost_chars applies.
 	 *
 	 * It is recommended you DON'T change this.
 	 */
@@ -116,7 +116,7 @@ command { service = "HostServ"; name = "HELP"; command = "generic/help"; }
  *
  * Provides the commands hostserv/del and hostserv/delall.
  *
- * Used for removing users vHosts.
+ * Used for removing users' vHosts.
  */
 module { name = "hs_del" }
 command { service = "HostServ"; name = "DEL"; command = "hostserv/del"; permission = "hostserv/del"; }
@@ -167,7 +167,7 @@ command { service = "HostServ"; name = "ON"; command = "hostserv/on"; }
  *
  * Provides the commands hostserv/request, hostserv/active, hostserv/reject, and hostserv/waiting.
  *
- * Used to manage vhosts requested by users.
+ * Used to manage vHosts requested by users.
  */
 module { name = "hs_request" }
 command { service = "HostServ"; name = "REQUEST"; command = "hostserv/request"; }
@@ -193,9 +193,8 @@ hs_request
  *
  * Provides the commands hostserv/set and hostserv/setall.
  *
- * Used for setting users vhosts.
+ * Used for setting users' vHosts.
  */
 module { name = "hs_set" }
 command { service = "HostServ"; name = "SET"; command = "hostserv/set"; permission = "hostserv/set"; }
 command { service = "HostServ"; name = "SETALL"; command = "hostserv/setall"; permission = "hostserv/set"; }
-

--- a/data/memoserv.example.conf
+++ b/data/memoserv.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -190,7 +190,7 @@ command { service = "MemoServ"; name = "READ"; command = "memoserv/read"; }
  * Provides the command memoserv/rsend.
  *
  * Used to send a memo requiring a receipt be sent back once it is read.
- * 
+ *
  * Requires configuring memoserv:memoreceipt.
  */
 #module { name = "ms_rsend" }
@@ -199,7 +199,7 @@ command { service = "MemoServ"; name = "READ"; command = "memoserv/read"; }
 /*
  * ms_send
  *
- * Provides the command memoserv/send
+ * Provides the command memoserv/send.
  *
  * Used to send memos.
  */
@@ -209,7 +209,7 @@ command { service = "MemoServ"; name = "SEND"; command = "memoserv/send"; }
 /*
  * ms_sendall
  *
- * Provides the command memoserv/sendall
+ * Provides the command memoserv/sendall.
  *
  * Used to send a mass memo to every registered user.
  */
@@ -235,4 +235,3 @@ command { service = "MemoServ"; name = "SET"; command = "memoserv/set"; }
  */
 module { name = "ms_staff" }
 command { service = "MemoServ"; name = "STAFF"; command = "memoserv/staff"; permission = "memoserv/staff"; }
-

--- a/data/modules.example.conf
+++ b/data/modules.example.conf
@@ -1,4 +1,3 @@
-
 /*
  * [OPTIONAL] Non-Core Modules
  *
@@ -12,7 +11,7 @@
  *
  * Provides commands generic/help
  *
- * Is a generic help command that can be used with any client.
+ * This is a generic help command that can be used with any client.
  */
 module { name = "help" }
 
@@ -25,18 +24,19 @@ module { name = "help" }
 #module { name = "m_dns" }
 dns
 {
-	/* 
+	/*
 	 * The nameserver to use for resolving hostnames, must be an IP or a resolver configuration file.
 	 * The below should work fine on all unix like systems. Windows users will have to find their nameservers
-	 * from ipconfig /all and put the IP here
+	 * from ipconfig /all and put the IP here.
 	 */
 	nameserver = "/etc/resolv.conf"
 	#nameserver = "127.0.0.1"
 
 	/*
-	 * How long to wait in seconds before a DNS query has timed out
+	 * How long to wait in seconds before a DNS query has timed out.
 	 */
 	timeout = 5
+
 
 	/* Only edit below if you are expecting to use os_dns or otherwise answer DNS queries. */
 
@@ -50,16 +50,21 @@ dns
 	ip = "0.0.0.0"
 	port = 53
 
+
 	/*
 	 * SOA record information.
 	 */
-	 admin = "admin@example.com"
-	 /* This should be the names of the public facing nameserver serving the records */
-	 nameservers = "ns1.example.com ns2.example.com"
-	 /* The time slave servers are allowed to cache. This should be reasonably low
-	  * if you want your records to be updated without much delay.
-	  */
-	 refresh = 3600
+
+	/* E-mail address of the DNS administrator. */
+	admin = "admin@example.com"
+
+	/* This should be the names of the public facing nameservers serving the records. */
+	nameservers = "ns1.example.com ns2.example.com"
+
+	/* The time slave servers are allowed to cache. This should be reasonably low
+	 * if you want your records to be updated without much delay.
+	 */
+	refresh = 3600
 }
 
 /*
@@ -94,10 +99,10 @@ m_dnsbl
 }
 blacklist
 {
-	/* Name of the blacklist */
+	/* Name of the blacklist. */
 	name = "rbl.efnetrbl.org"
 
-	/* How long to set the ban for */
+	/* How long to set the ban for. */
 	time = 4h
 
 	/* Reason for akill.
@@ -111,7 +116,7 @@ blacklist
 	 */
 	reason = "You are listed in the efnet RBL, visit http://rbl.efnetrbl.org/?i=%i for info"
 
-	/* Replies to ban and their reason. If this is totally ommited all replies get banned */
+	/* Replies to ban and their reason. If this is totally ommited all replies get banned. */
 	1 = "Open Proxy"
 	/* Don't ban for result 2 or 3 */
 	#2 = "spamtrap666"
@@ -150,13 +155,16 @@ httpd
 {
 	/* Name of this service */
 	name = "httpd/main"
-	
+
 	/* IP to listen on */
 	ip = "0.0.0.0"
+
 	/* Port to listen on */
 	port = 8080
+
 	/* Time before connections to this server are timed out */
 	timeout = 30
+
 	/* Listen using SSL. Requires m_ssl. */
 	#ssl = yes
 
@@ -205,14 +213,14 @@ m_ldap_authentication
 
 	/*
 	 * The search filter used to look up users's accounts.
-	 * %account is replaced with the user's account
+	 * %account is replaced with the user's account.
 	 * %object_class is replaced with the object_class configured below.
 	 */
 	search_filter = "(&(uid=%account)(objectClass=%object_class))"
 
 	/*
 	 * The object class used by LDAP to store user account information.
-	 * Used for adding new users to LDAP if disable_ns_register is false
+	 * Used for adding new users to LDAP if disable_ns_register is false.
 	 */
 	object_class = "anopeUser"
 
@@ -242,7 +250,7 @@ m_ldap_authentication
 	 * The reason to give the users who try to /ns register if
 	 * disable_ns_register is enabled.
 	 */
-	#disable_reason = "To register on this network visit http://some.misconfigured.site/register"
+	#disable_reason = "To register on this network, visit http://some.misconfigured.site/register"
 }
 
 /*
@@ -323,7 +331,7 @@ m_proxyscan
 	 * avaiable IP that remote proxies can connect to.
 	 */
 	#target_ip = "127.0.0.1"
-	
+
 	/*
 	 * The port services tells the proxy to connect to.
 	 */
@@ -344,7 +352,7 @@ m_proxyscan
 	/*
 	 * An optional notice sent to clients upon connect.
 	 */
-	#connect_notice = "We will now scan your host for insecure proxies. If you do not consent to this scan please disconnect immediately"
+	#connect_notice = "We will now scan your host for insecure proxies. If you do not consent to this scan please disconnect immediately."
 
 	/*
 	 * Who the notice should be sent from.
@@ -353,7 +361,7 @@ m_proxyscan
 
 	/*
 	 * If set, OperServ will add infected clients to the akill list. Without it, OperServ simply sends
-	 * a timed G/K-line to the IRCd and forgets about it. Can be useful if your akill list is being fill up by bots.
+	 * a timed G/K-line to the IRCd and forgets about it. Can be useful if your akill list is being filled up by bots.
 	 */
 	add_to_akill = yes
 
@@ -400,28 +408,28 @@ m_sql_authentication
 	engine = "mysql/main"
 
 	/* Query to execute to authenticate. A non empty result from this query is considered a success,
-	* and the user will be authenticated.
-	* 
-	* @a@ is replaced with the user's account name
-	* @p@ is replaced with the user's password
-	* @n@ is replaced with the user's nickname
-	* @i@ is replaced with the user's IP
-	*
-	* Note that @n@ and @i@ may not always exist in the case of a user identifying outside of the normal
-	* nickserv/identify command, such as through the web panel.
-	*
-	* Furthermore, if a field named email is returned from this query the user's email is
-	* set to its value.
-	*
-	*
-	* We've included some example queries for some popular website/forum systems.
-	*
-	* Drupal 6: "SELECT `mail` AS `email` FROM `users` WHERE `name` = @a@ AND `pass` = MD5(@p@) AND `status` = 1"
-	* e107 cms: "SELECT `user_email` AS `email` FROM `e107_user` WHERE `user_loginname` = @a@ AND `user_password` = MD5(@p@)"
-	* SMF Forum: "SELECT `email_address` AS `email` FROM `smf_members` WHERE `member_name` = @a@ AND `passwd` = SHA1(CONCAT(LOWER(@a@), @p@))"
-	* vBulletin: "SELECT `email` FROM `user` WHERE `username` = @a@ AND `password` = MD5(CONCAT(MD5(@p@), `salt`))"
-	* IP.Board: "SELECT `email` FROM `ibf_members` WHERE `name` = @a@ AND `members_pass_hash` = MD5(CONCAT(MD5(`members_pass_salt`), MD5(@p@)))"
-	*/
+	 * and the user will be authenticated.
+	 *
+	 * @a@ is replaced with the user's account name
+	 * @p@ is replaced with the user's password
+	 * @n@ is replaced with the user's nickname
+	 * @i@ is replaced with the user's IP
+	 *
+	 * Note that @n@ and @i@ may not always exist in the case of a user identifying outside of the normal
+	 * nickserv/identify command, such as through the web panel.
+	 *
+	 * Furthermore, if a field named email is returned from this query the user's email is
+	 * set to its value.
+	 *
+	 *
+	 * We've included some example queries for some popular website/forum systems.
+	 *
+	 * Drupal 6: "SELECT `mail` AS `email` FROM `users` WHERE `name` = @a@ AND `pass` = MD5(@p@) AND `status` = 1"
+	 * e107 cms: "SELECT `user_email` AS `email` FROM `e107_user` WHERE `user_loginname` = @a@ AND `user_password` = MD5(@p@)"
+	 * SMF Forum: "SELECT `email_address` AS `email` FROM `smf_members` WHERE `member_name` = @a@ AND `passwd` = SHA1(CONCAT(LOWER(@a@), @p@))"
+	 * vBulletin: "SELECT `email` FROM `user` WHERE `username` = @a@ AND `password` = MD5(CONCAT(MD5(@p@), `salt`))"
+	 * IP.Board: "SELECT `email` FROM `ibf_members` WHERE `name` = @a@ AND `members_pass_hash` = MD5(CONCAT(MD5(`members_pass_salt`), MD5(@p@)))"
+	 */
 	query = "SELECT `email_addr` AS `email` FROM `my_users` WHERE `username` = @a@ AND `password` = MD5(CONCAT('salt', @p@))"
 
 	/*
@@ -439,7 +447,7 @@ m_sql_authentication
 /*
  * m_sql_oper
  *
- * This module allows granting users services operator privileges and possibly IRC operator
+ * This module allows granting users services operator privileges and possibly IRC Operator
  * privileges based on an external SQL database using a custom query.
  */
 #module { name = "m_sql_oper" }
@@ -458,7 +466,7 @@ m_sql_oper
 	 * @a@ is replaced with the user's account name
 	 * @i@ is replaced with the user's IP
 	 */
-	 query = "SELECT `opertype` FROM `my_users` WHERE `user_name` = @a@"
+	query = "SELECT `opertype` FROM `my_users` WHERE `user_name` = @a@"
 }
 
 /*
@@ -471,6 +479,7 @@ sqlite
 {
 	/* The name of this service */
 	name = "sqlite/main"
+
 	/* The database name, it will be created if it does not exist. */
 	database = "anope.db"
 }
@@ -500,9 +509,7 @@ module { name = "m_regex_pcre" }
 /*
  * m_rewrite
  *
- * Provides the command rewrite.
- *
- * Allows rewriting commands sent to clients.
+ * Allows rewriting commands sent to/from clients.
  */
 module { name = "m_rewrite" }
 #command
@@ -532,7 +539,7 @@ module { name = "m_rewrite" }
 /*
  * m_ssl
  *
- * This module uses SSL to connect to the uplink server(s)
+ * This module uses SSL to connect to the uplink server(s).
  */
 #module { name = "m_ssl" }
 ssl
@@ -549,7 +556,7 @@ ssl
 	key = "data/anope.key"
 }
 
-/* 
+/*
  * m_xmlrpc
  *
  * Allows remote applications (websites) to execute queries in real time to retrieve data from Anope.
@@ -590,9 +597,7 @@ webcpanel
 
 	/* Page title */
 	title = "Anope IRC Services";
-	
+
 	/* Whether or not to use https on redirecting URLS */
 	ssl = no
 }
-
-

--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -70,7 +70,7 @@ nickserv
 
 	/*
 	 * Force users to give an e-mail address when they register a nick.
-	 * 
+	 *
 	 * This directive is recommended to be enabled, and required if e-mail registration is enabled.
 	 */
 	forceemail = yes
@@ -89,11 +89,11 @@ nickserv
 	registration = "none"
 
 	/*
-	 * A message sent to users on connect if they user an unregistered nick.
+	 * A message sent to users on connect if they use an unregistered nick.
 	 *
 	 * This directive is optional.
 	 */
-	#unregistered_notice = "Your nickname is not registered. To register it use /nickserv register password email."
+	#unregistered_notice = "Your nickname is not registered. To register it, use: /msg NickServ REGISTER password email"
 
 	/*
 	 * The default options for newly registered nicks. Note that changing these options
@@ -113,8 +113,8 @@ nickserv
 	 * -  memo_signon: Notify user if they have a new memo when they sign into the nick
 	 * - memo_receive: Notify user if they have a new memo as soon as it's received
 	 * -       autoop: User will be automatically opped in channels they enter and have access to
-	 * -          msg: Services messages will be sent as PRIVMSGs instead of NOTICEs, requires UsePrivmsg
-	 *                   to be enabled as well
+	 * -          msg: Services messages will be sent as PRIVMSGs instead of NOTICEs, requires
+	 *                   options:useprivmsg to be enabled as well
 	 *
 	 * This directive is optional, if left blank, the options will default to secure, memo_signon, and
 	 * memo_receive. If you really want no defaults, use "none" by itself as the option.
@@ -150,7 +150,7 @@ nickserv
 	resenddelay = 90s
 
 	/*
-	 * The length of time before a nick registration expires.
+	 * The length of time before a nick's registration expires.
 	 *
 	 * This directive is optional, but recommended. If not set, the default is 21 days.
 	 */
@@ -159,7 +159,7 @@ nickserv
 	/*
 	 * The length of time before a suspended nick becomes unsuspended.
 	 *
-	 * This directive is optional. If not set, the default is to never.
+	 * This directive is optional. If not set, the default is never.
 	 */
 	#suspendexpire = 90d
 
@@ -185,7 +185,7 @@ nickserv
 
 	/*
 	 * The username (and possibly hostname) used for the fake user created when NickServ collides
-	 * a user. Should be in the user@host format.
+	 * a user.
 	 */
 	enforceruser = "enforcer"
 	enforcerhost = "localhost.net"
@@ -232,7 +232,7 @@ nickserv
 
 	/*
 	 * If set, any user wanting to use the privileges of Services Root, Services Admin, or Services
-	 * Operator must have been logged as an IRC Operator with the /oper command.
+	 * Operator must have been logged as an IRC Operator with the /OPER command.
 	 *
 	 * This directive is optional, but recommended.
 	 */
@@ -303,7 +303,7 @@ nickserv
  *
  * Additionally, you may provide a permission name that must be in the opertype of users executing the command.
  *
- * Sane defaults are provided below that do not need to be edited unless you wish to change the default behaviour.
+ * Sane defaults are provided below that do not need to be edited unless you wish to change the default behavior.
  */
 
 /* Command group configuration for NickServ.
@@ -313,7 +313,7 @@ nickserv
  */
 command_group
 {
-	name = "nickserv/admin";
+	name = "nickserv/admin"
 	description = "Services Operator commands"
 }
 
@@ -378,7 +378,7 @@ command { service = "NickServ"; name = "DROP"; command = "nickserv/drop"; }
  * Used for getting registered accounts by searching for emails.
  */
 module { name = "ns_getemail" }
-command { service = "NickServ"; name = "GETEMAIL"; command = "nickserv/getemail"; permission = "nickserv/getemail"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "GETEMAIL"; command = "nickserv/getemail"; permission = "nickserv/getemail"; group = "nickserv/admin"; }
 
 /*
  * ns_getpass
@@ -412,7 +412,7 @@ command { service = "NickServ"; name = "UNGROUP"; command = "nickserv/ungroup"; 
  * Used for identifying to accounts.
  */
 module { name = "ns_identify" }
-command { service = "NickServ"; name = "ID"; command = "nickserv/identify"; hide = true }
+command { service = "NickServ"; name = "ID"; command = "nickserv/identify"; hide = true; }
 command { service = "NickServ"; name = "IDENTIFY"; command = "nickserv/identify"; }
 
 /*
@@ -433,7 +433,7 @@ command { service = "NickServ"; name = "INFO"; command = "nickserv/info"; }
  * Used for retrieving and searching the registered account list.
  */
 module { name = "ns_list" }
-command { service = "NickServ"; name = "LIST"; command = "nickserv/list"; command = "nickserv/admin" }
+command { service = "NickServ"; name = "LIST"; command = "nickserv/list"; command = "nickserv/admin"; }
 
 /*
  * ns_logout
@@ -494,51 +494,51 @@ command { service = "NickServ"; name = "RESETPASS"; command = "nickserv/resetpas
  *   nickserv/set/language, nickserv/saset/language - Used for configuring what language services use.
  *   nickserv/set/message, nickserv/saset/message - Used to configure how services send messages to you.
  *   nickserv/set/password, nickserv/saset/password  - Used for changing a users greet password.
- *   nickserv/set/private, nickserv/saset/privatee - Used for configuring whether or a users account shows up in nickserv/list.
+ *   nickserv/set/private, nickserv/saset/private - Used for configuring whether or a users account shows up in nickserv/list.
  *   nickserv/set/secure, nickserv/saset/secure - Used for configuring whether a user can identify by simply being recognized by nickserv/access.
  *   nickserv/saset/noexpire - Used for configuring noexpire, which prevents nicks from expiring.
  *
- * Used as a help wrapper for the SET and SASET commands, and provides many other set commands.
+ * This is a dummy command to provide a help wrapper for the various SET and SASET commands.
  */
 module { name = "ns_set" }
 
 command { service = "NickServ"; name = "SET"; command = "nickserv/set"; }
-command { service = "NickServ"; name = "SASET"; command = "nickserv/saset"; permission = "nickserv/saset/"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET"; command = "nickserv/saset"; permission = "nickserv/saset/"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET AUTOOP"; command = "nickserv/set/autoop"; }
-command { service = "NickServ"; name = "SASET AUTOOP"; command = "nickserv/saset/autoop"; permission = "nickserv/saset/autoop"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET AUTOOP"; command = "nickserv/saset/autoop"; permission = "nickserv/saset/autoop"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET DISPLAY"; command = "nickserv/set/display"; }
-command { service = "NickServ"; name = "SASET DISPLAY"; command = "nickserv/saset/display"; permission = "nickserv/saset/display"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET DISPLAY"; command = "nickserv/saset/display"; permission = "nickserv/saset/display"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET EMAIL"; command = "nickserv/set/email"; }
-command { service = "NickServ"; name = "SASET EMAIL"; command = "nickserv/saset/email"; permission = "nickserv/saset/email"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET EMAIL"; command = "nickserv/saset/email"; permission = "nickserv/saset/email"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET GREET"; command = "nickserv/set/greet"; }
-command { service = "NickServ"; name = "SASET GREET"; command = "nickserv/saset/greet"; permission = "nickserv/saset/greet"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET GREET"; command = "nickserv/saset/greet"; permission = "nickserv/saset/greet"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET HIDE"; command = "nickserv/set/hide"; }
-command { service = "NickServ"; name = "SASET HIDE"; command = "nickserv/saset/hide"; permission = "nickserv/saset/hide"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET HIDE"; command = "nickserv/saset/hide"; permission = "nickserv/saset/hide"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET KILL"; command = "nickserv/set/kill"; }
-command { service = "NickServ"; name = "SASET KILL"; command = "nickserv/saset/kill"; permission = "nickserv/saset/kill";  group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET KILL"; command = "nickserv/saset/kill"; permission = "nickserv/saset/kill";  group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET LANGUAGE"; command = "nickserv/set/language"; }
-command { service = "NickServ"; name = "SASET LANGUAGE"; command = "nickserv/saset/language"; permission = "nickserv/saset/language"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET LANGUAGE"; command = "nickserv/saset/language"; permission = "nickserv/saset/language"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET MESSAGE"; command = "nickserv/set/message"; }
-command { service = "NickServ"; name = "SASET MESSAGE"; command = "nickserv/saset/message"; permission = "nickserv/saset/message"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET MESSAGE"; command = "nickserv/saset/message"; permission = "nickserv/saset/message"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET PASSWORD"; command = "nickserv/set/password"; }
-command { service = "NickServ"; name = "SASET PASSWORD"; command = "nickserv/saset/password"; permission = "nickserv/saset/password"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET PASSWORD"; command = "nickserv/saset/password"; permission = "nickserv/saset/password"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET PRIVATE"; command = "nickserv/set/private"; }
-command { service = "NickServ"; name = "SASET PRIVATE"; command = "nickserv/saset/private"; permission = "nickserv/saset/private"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET PRIVATE"; command = "nickserv/saset/private"; permission = "nickserv/saset/private"; group = "nickserv/admin"; }
 
 command { service = "NickServ"; name = "SET SECURE"; command = "nickserv/set/secure"; }
-command { service = "NickServ"; name = "SASET SECURE"; command = "nickserv/saset/secure"; permission = "nickserv/saset/secure"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET SECURE"; command = "nickserv/saset/secure"; permission = "nickserv/saset/secure"; group = "nickserv/admin"; }
 
-command { service = "NickServ"; name = "SASET NOEXPIRE"; command = "nickserv/saset/noexpire"; permission = "nickserv/saset/noexpire"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SASET NOEXPIRE"; command = "nickserv/saset/noexpire"; permission = "nickserv/saset/noexpire"; group = "nickserv/admin"; }
 
 /*
  * ns_set_misc
@@ -549,7 +549,8 @@ command { service = "NickServ"; name = "SASET NOEXPIRE"; command = "nickserv/sas
  * A field named misc_description may be given for use with help output.
  */
 module { name = "ns_set_misc" }
-command { service = "NickServ"; name = "SET URL"; command = "nickserv/set/misc"; misc_description = _("Associate a URL with your account") }
+command { service = "NickServ"; name = "SET URL"; command = "nickserv/set/misc"; misc_description = _("Associate a URL with your account"); }
+command { service = "NickServ"; name = "SASET URL"; command = "nickserv/saset/misc"; misc_description = _("Associate a URL with this account"); permission = "nickserv/saset/url"; group = "nickserv/admin"; }
 #command { service = "NickServ"; name = "SET ICQ"; command = "nickserv/set/misc"; }
 #command { service = "NickServ"; name = "SET TWITTER"; command = "nickserv/set/misc"; }
 #command { service = "NickServ"; name = "SET FACEBOOK"; command = "nickserv/set/misc"; }
@@ -569,11 +570,11 @@ command { service = "NickServ"; name = "STATUS"; command = "nickserv/status"; }
  *
  * Provides the commands nickserv/suspend and nickserv/unsuspend.
  *
- * Used to suspend and unsuspend nicknames. Suspended nicknames can not be used but their settings are stored.
+ * Used to suspend and unsuspend nicknames. Suspended nicknames can not be used but their settings are preserved.
  */
 module { name = "ns_suspend" }
-command { service = "NickServ"; name = "SUSPEND"; command = "nickserv/suspend"; permission = "nickserv/suspend"; group = "nickserv/admin" }
-command { service = "NickServ"; name = "UNSUSPEND"; command = "nickserv/unsuspend"; permission = "nickserv/suspend"; group = "nickserv/admin" }
+command { service = "NickServ"; name = "SUSPEND"; command = "nickserv/suspend"; permission = "nickserv/suspend"; group = "nickserv/admin"; }
+command { service = "NickServ"; name = "UNSUSPEND"; command = "nickserv/unsuspend"; permission = "nickserv/suspend"; group = "nickserv/admin"; }
 
 /*
  * ns_update
@@ -584,6 +585,7 @@ command { service = "NickServ"; name = "UNSUSPEND"; command = "nickserv/unsuspen
  */
 module { name = "ns_update" }
 command { service = "NickServ"; name = "UPDATE"; command = "nickserv/update"; }
+
 
 /*
  * Extra NickServ related modules.
@@ -605,4 +607,3 @@ ns_maxemail
 	 */
 	#maxemails = 1
 }
-

--- a/data/operserv.example.conf
+++ b/data/operserv.example.conf
@@ -35,8 +35,8 @@ service
 	 * These modes are very IRCd specific. If left commented, sane defaults
 	 * are used based on what protocol module you have loaded.
 	 *
-	 * Note that setting this option incorrectly could potentially BREAK some if
-	 * not all usefulness of the client. We will not support you if this client is
+	 * Note that setting this option incorrectly could potentially BREAK some, if
+	 * not all, usefulness of the client. We will not support you if this client is
 	 * unable to do certain things if this option is enabled.
 	 */
 	#modes = "+o"
@@ -46,7 +46,7 @@ service
 	 * of log channels this is not very useful, as the service will just idle in the
 	 * specified channels, and will not accept any types of commands.
 	 *
-	 * Prefixes may be given to the channels in the form of mode character or prefix symbol.
+	 * Prefixes may be given to the channels in the form of mode characters or prefix symbols.
 	 */
 	#channels = "@#services,#mychan"
 }
@@ -84,7 +84,6 @@ operserv
 	chankillexpiry = 30d
 	snlineexpiry = 30d
 	sqlineexpiry = 30d
-	szlineexpiry = 30d
 
 	/*
 	 * If set, this option will make Services send an AKILL command immediately after it has been
@@ -305,7 +304,7 @@ defcon
 	 * the mode setting selected, Services will set the reverse on all channels, e.g. if this setting
 	 * is +RN when DefCon is used, all channels will be set to +RN, when DefCon is removed, all
 	 * channels will be set to -RN. You don't want to set this to +k for example, because when DefCon
-	 * is removed all channels with -k.
+	 * is removed, all channels are set -k, removing the key from previously keyed channels.
 	 *
 	 * Note 2: MLOCKed modes will not be lost.
 	 */
@@ -397,7 +396,7 @@ os_dns
 	 */
 	user_drop_mark = 50
 
-	/* The time used for user_drop_mark */
+	/* The time used for user_drop_mark. */
 	user_drop_time = 1m
 
 	/* When a server is removed from the zone for dropping users, it is readded after this time.
@@ -405,10 +404,10 @@ os_dns
 	 */
 	user_drop_readd_time = 5m
 
-	/* If set, if a server splits it is automatically removed from the zone */
+	/* If set, when a server splits, it is automatically removed from the zone. */
 	remove_split_servers = yes
 
-	/* If set, when a server connects to the network it will be automatically added to
+	/* If set, when a server connects to the network, it will be automatically added to
 	 * the zone if it is a known server.
 	 */
 	readd_connected_servers = no
@@ -521,8 +520,8 @@ logsearch
  * Used to change user and channel modes.
  */
 module { name = "os_mode" }
-command { service = "OperServ"; name = "MODE"; command = "operserv/mode"; permission = "operserv/mode"; }
 command { service = "OperServ"; name = "UMODE"; command = "operserv/umode"; permission = "operserv/umode"; }
+command { service = "OperServ"; name = "MODE"; command = "operserv/mode"; permission = "operserv/mode"; }
 
 /*
  * os_modinfo
@@ -532,8 +531,8 @@ command { service = "OperServ"; name = "UMODE"; command = "operserv/umode"; perm
  * Used to show information about loaded modules.
  */
 module { name = "os_modinfo" }
-command { service = "OperServ"; name = "MODINFO"; command = "operserv/modinfo"; }
-command { service = "OperServ"; name = "MODLIST"; command = "operserv/modlist"; permission = "operserv/modlist"; }
+command { service = "OperServ"; name = "MODINFO"; command = "operserv/modinfo"; permission = "operserv/modinfo"; }
+command { service = "OperServ"; name = "MODLIST"; command = "operserv/modlist"; permission = "operserv/modinfo"; }
 
 /*
  * os_module
@@ -582,7 +581,7 @@ command { service = "OperServ"; name = "OLINE"; command = "operserv/oline"; perm
 
 /*
  * os_oper
- * 
+ *
  * Provides the command operserv/oper.
  *
  * Used to configure opers and show information about opertypes.
@@ -645,7 +644,7 @@ command { service = "OperServ"; name = "STATS"; command = "operserv/stats"; perm
 
 /*
  * os_svs
- * 
+ *
  * Provides the commands operserv/svsnick, operserv/svsjoin, and operserv/svspart.
  *
  * Used to force users to change nicks, join and part channels.
@@ -669,10 +668,9 @@ command { service = "OperServ"; name = "SQLINE"; command = "operserv/sqline"; pe
 /*
  * os_update
  *
- * Provides the opersev/update command.
+ * Provides the operserv/update command.
  *
  * Use to immediately update the databases.
  */
 module { name = "os_update" }
 command { service = "OperServ"; name = "UPDATE"; command = "operserv/update"; permission = "operserv/update"; }
-

--- a/modules/commands/bs_info.cpp
+++ b/modules/commands/bs_info.cpp
@@ -89,7 +89,7 @@ class CommandBSInfo : public Command
 		}
 		else if ((ci = ChannelInfo::Find(query)))
 		{
-			if (!source.AccessFor(ci).HasPriv("FOUNDER") && !source.HasPriv("botserv/administration"))
+			if (!source.AccessFor(ci).HasPriv("INFO") && !source.HasPriv("botserv/administration"))
 			{
 				source.Reply(ACCESS_DENIED);
 				return;

--- a/modules/commands/ns_set.cpp
+++ b/modules/commands/ns_set.cpp
@@ -424,7 +424,7 @@ class CommandNSSASetDisplay : public CommandNSSetDisplay
 		this->SendSyntax(source);
 		source.Reply(" ");
 		source.Reply(_("Changes the display used to refer to the nickname group in \n"
-				"Services. The new display MUST be a nick of your group."));
+				"Services. The new display MUST be a nick of the group."));
 		return true;
 	}
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -56,7 +56,7 @@ ServerConfig::ServerConfig()
 			if (option.equals_ci("msg"))
 			{
 				if (!this->UsePrivmsg)
-					Log() << "msg in <nickserv:defaults> can only be used when UsePrivmsg is set";
+					Log() << "msg in <nickserv:defaults> can only be used when options:useprivmsg is set";
 				else
 					this->NSDefFlags.insert(option.upper());
 			}


### PR DESCRIPTION
Some configuration file updates: Removed now non-existing settings. Redid some existing settings to look more consistent/uniform. Added some missing commands/permissions.

Merged operserv/modlist permission into operserv/modinfo.
Fixed ChanServ INFO privilege to actually work for /BotServ INFO too for those users who have it, instead of only for founders.
Fixed some typos aswell as removed whitespaces along the way.
