### PR TITLE
Fixed ns_set_misc not showing help for its SASET commands

### DIFF
--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -551,9 +551,12 @@ command { service = "NickServ"; name = "SASET NOEXPIRE"; command = "nickserv/sas
 module { name = "ns_set_misc" }
 command { service = "NickServ"; name = "SET URL"; command = "nickserv/set/misc"; misc_description = _("Associate a URL with your account"); }
 command { service = "NickServ"; name = "SASET URL"; command = "nickserv/saset/misc"; misc_description = _("Associate a URL with this account"); permission = "nickserv/saset/url"; group = "nickserv/admin"; }
-#command { service = "NickServ"; name = "SET ICQ"; command = "nickserv/set/misc"; }
-#command { service = "NickServ"; name = "SET TWITTER"; command = "nickserv/set/misc"; }
-#command { service = "NickServ"; name = "SET FACEBOOK"; command = "nickserv/set/misc"; }
+#command { service = "NickServ"; name = "SET ICQ"; command = "nickserv/set/misc"; misc_description = _("Associate an ICQ account with your account"); }
+#command { service = "NickServ"; name = "SASET ICQ"; command = "nickserv/saset/misc"; misc_description = _("Associate an ICQ account with this account"); permission = "nickserv/saset/icq"; group = "nickserv/admin"; }
+#command { service = "NickServ"; name = "SET TWITTER"; command = "nickserv/set/misc"; misc_description = _("Associate a Twitter account with your account"); }
+#command { service = "NickServ"; name = "SASET TWITTER"; command = "nickserv/saset/misc"; misc_description = _("Associate a Twitter account with this account"); permission = "nickserv/saset/twitter"; group = "nickserv/admin"; }
+#command { service = "NickServ"; name = "SET FACEBOOK"; command = "nickserv/set/misc"; misc_description = _("Associate a Facebook URL with your account"); }
+#command { service = "NickServ"; name = "SASET FACEBOOK"; command = "nickserv/saset/misc"; misc_description = _("Associate a Facebook URL with this account"); permission = "nickserv/saset/facebook"; group = "nickserv/admin"; }
 
 /*
  * ns_status

--- a/modules/commands/ns_set_misc.cpp
+++ b/modules/commands/ns_set_misc.cpp
@@ -173,7 +173,7 @@ class NSSetMisc : public Module
 
 		for (int i = 0; i < config.Enumerate("command"); ++i)
 		{
-			if (config.ReadValue("command", "command", "", i) != "nickserv/set/misc")
+			if (config.ReadValue("command", "command", "", i) != "nickserv/set/misc" && config.ReadValue("command", "command", "", i) != "nickserv/saset/misc")
 				continue;
 
 			Anope::string cname = config.ReadValue("command", "name", "", i);


### PR DESCRIPTION
Fixed ns_set_misc not showing help for its SASET commands.
Added descriptions and SASETs for the remaining commented ns_set_misc examples, without a description they won't show up in HELP if someone actually enabled those.
