### PR TITLE
ns_ajoin: Check for RESTRICTED and that a user is on the access list, as to not SVSJOIN the user only to kick him/her out again.

### DIFF
--- a/modules/commands/ns_ajoin.cpp
+++ b/modules/commands/ns_ajoin.cpp
@@ -287,6 +287,8 @@ class NSAJoin : public Module
 				if (ci->HasExt("CS_SUSPENDED"))
 					continue;
 				u_access = ci->AccessFor(u);
+				if (ci->HasExt("RESTRICTED") && u_access.empty())
+					continue;
 			}
 			if (c != NULL)
 			{


### PR DESCRIPTION
ns_ajoin: Check for RESTRICTED and that a user is on the access list, as to not SVSJOIN the user only to kick him/her out again.
