### PR TITLE
Do not translate command parameters that do not have translatable strings in them, or are not meant to be translated in the first place.

### DIFF
--- a/modules/commands/ns_info.cpp
+++ b/modules/commands/ns_info.cpp
@@ -135,7 +135,7 @@ class CommandNSSetHide : public Command
 	CommandNSSetHide(Module *creator, const Anope::string &sname = "nickserv/set/hide", size_t min = 2) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Hide certain pieces of nickname information"));
-		this->SetSyntax(_("{EMAIL | STATUS | USERMASK | QUIT} {ON | OFF}"));
+		this->SetSyntax("{EMAIL | STATUS | USERMASK | QUIT} {ON | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param, const Anope::string &arg)

--- a/modules/commands/ns_list.cpp
+++ b/modules/commands/ns_list.cpp
@@ -184,7 +184,7 @@ class CommandNSSetPrivate : public Command
 	CommandNSSetPrivate(Module *creator, const Anope::string &sname = "nickserv/set/private", size_t min = 1) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Prevent the nickname from appearing in the LIST command"));
-		this->SetSyntax(_("{ON | OFF}"));
+		this->SetSyntax("{ON | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param)

--- a/modules/commands/ns_set.cpp
+++ b/modules/commands/ns_set.cpp
@@ -227,7 +227,7 @@ class CommandNSSetAutoOp : public Command
 	CommandNSSetAutoOp(Module *creator, const Anope::string &sname = "nickserv/set/autoop", size_t min = 1) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Sets whether services should set channel status modes on you automatically."));
-		this->SetSyntax(_("{ON | OFF}"));
+		this->SetSyntax("{ON | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param)
@@ -537,7 +537,7 @@ class CommandNSSetKeepModes : public Command
 	CommandNSSetKeepModes(Module *creator, const Anope::string &sname = "nickserv/set/keepmodes", size_t min = 1) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Enable or disable keep modes"));
-		this->SetSyntax(_("{ON | OFF}"));
+		this->SetSyntax("{ON | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param)
@@ -624,7 +624,7 @@ class CommandNSSetKill : public Command
 	CommandNSSetKill(Module *creator, const Anope::string &sname = "nickserv/set/kill", size_t min = 1) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Turn protection on or off"));
-		this->SetSyntax(_("{ON | QUICK | IMMED | OFF}"));
+		this->SetSyntax("{ON | QUICK | IMMED | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param)
@@ -871,7 +871,7 @@ class CommandNSSetMessage : public Command
 	CommandNSSetMessage(Module *creator, const Anope::string &sname = "nickserv/set/message", size_t min = 1) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Change the communication method of Services"));
-		this->SetSyntax(_("{ON | OFF}"));
+		this->SetSyntax("{ON | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param)
@@ -975,7 +975,7 @@ class CommandNSSetSecure : public Command
 	CommandNSSetSecure(Module *creator, const Anope::string &sname = "nickserv/set/secure", size_t min = 1) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Turn nickname security on or off"));
-		this->SetSyntax(_("{ON | OFF}"));
+		this->SetSyntax("{ON | OFF}");
 	}
 
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param)

--- a/modules/commands/ns_status.cpp
+++ b/modules/commands/ns_status.cpp
@@ -32,18 +32,18 @@ class CommandNSStatus : public Command
 		{
 			User *u2 = User::Find(nickbuf, true);
 			if (!u2) /* Nick is not online */
-				source.Reply(_("STATUS %s %d %s"), nickbuf.c_str(), 0, "");
+				source.Reply("STATUS %s %d %s", nickbuf.c_str(), 0, "");
 			else if (u2->IsIdentified() && na && na->nc == u2->Account()) /* Nick is identified */
-				source.Reply(_("STATUS %s %d %s"), nickbuf.c_str(), 3, u2->Account()->display.c_str());
+				source.Reply("STATUS %s %d %s", nickbuf.c_str(), 3, u2->Account()->display.c_str());
 			else if (u2->IsRecognized()) /* Nick is recognised, but NOT identified */
-				source.Reply(_("STATUS %s %d %s"), nickbuf.c_str(), 2, u2->Account() ? u2->Account()->display.c_str() : "");
+				source.Reply("STATUS %s %d %s", nickbuf.c_str(), 2, u2->Account() ? u2->Account()->display.c_str() : "");
 			else if (!na) /* Nick is online, but NOT a registered */
-				source.Reply(_("STATUS %s %d %s"), nickbuf.c_str(), 0, "");
+				source.Reply("STATUS %s %d %s", nickbuf.c_str(), 0, "");
 			else
 				/* Nick is not identified for the nick, but they could be logged into an account,
 				 * so we tell the user about it
 				 */
-				source.Reply(_("STATUS %s %d %s"), nickbuf.c_str(), 1, u2->Account() ? u2->Account()->display.c_str() : "");
+				source.Reply("STATUS %s %d %s", nickbuf.c_str(), 1, u2->Account() ? u2->Account()->display.c_str() : "");
 		}
 		return;
 	}

--- a/modules/commands/os_stats.cpp
+++ b/modules/commands/os_stats.cpp
@@ -194,7 +194,7 @@ class CommandOSStats : public Command
 		akills("XLineManager", "xlinemanager/sgline"), snlines("XLineManager", "xlinemanager/snline"), sqlines("XLineManager", "xlinemanager/sqline")
 	{
 		this->SetDesc(_("Show status of Services and network"));
-		this->SetSyntax(_("[AKILL | HASH | UPLINK | UPTIME | ALL | RESET]"));
+		this->SetSyntax("[AKILL | HASH | UPLINK | UPTIME | ALL | RESET]");
 	}
 
 	void Execute(CommandSource &source, const std::vector<Anope::string> &params) anope_override

--- a/modules/stats/m_chanstats.cpp
+++ b/modules/stats/m_chanstats.cpp
@@ -61,7 +61,7 @@ class CommandNSSetChanstats : public Command
 	CommandNSSetChanstats(Module *creator, const Anope::string &sname = "nickserv/set/chanstats", size_t min = 1 ) : Command(creator, sname, min, min + 1)
 	{
 		this->SetDesc(_("Turn chanstats statistics on or off"));
-		this->SetSyntax(_("{ON | OFF}"));
+		this->SetSyntax("{ON | OFF}");
 	}
 	void Run(CommandSource &source, const Anope::string &user, const Anope::string &param, bool saset = false)
 	{


### PR DESCRIPTION
Do not translate command parameters that do not have translatable strings in them, or are not meant to be translated in the first place.
