### PR TITLE
Add the channel name to reply of cs-status, useful for applications

### DIFF
--- a/modules/commands/cs_status.cpp
+++ b/modules/commands/cs_status.cpp
@@ -50,7 +50,7 @@ public:
 			if (ag.super_admin)
 				source.Reply(_("\002%s\002 is a super administrator."), nick.c_str());
 			else if (ag.founder)
-				source.Reply(_("\002%s\002 is the channel founder."), nick.c_str());
+				source.Reply(_("\002%s\002 is the founder of \002%s\002."), nick.c_str(), ci->name.c_str());
 			else  if (ag.empty())
 				source.Reply(_("\002%s\002 has no access on \002%s\002."), nick.c_str(), ci->name.c_str());
 			else
@@ -72,13 +72,13 @@ public:
 				if (autokick->nc)
 				{
 					if (na && *autokick->nc == na->nc)
-						source.Reply(_("\002%s\002 is on the auto kick list (%s)."), na->nc->display.c_str(), autokick->reason.c_str());
+						source.Reply(_("\002%s\002 is on the auto kick list of \002%s\002 (%s)."), na->nc->display.c_str(), ci->name.c_str(), autokick->reason.c_str());
 				}
 				else if (u != NULL)
 				{
 					Entry akick_mask("", autokick->mask);
 					if (akick_mask.Matches(u))
-						source.Reply(_("\002%s\002 matches auto kick entry %s (%s)."), u->nick.c_str(), autokick->mask.c_str(), autokick->reason.c_str());
+						source.Reply(_("\002%s\002 matches auto kick entry %s on \002%s\002 (%s)."), u->nick.c_str(), autokick->mask.c_str(), ci->name.c_str(), autokick->reason.c_str());
 				}
 			}
 		}


### PR DESCRIPTION
This change makes cs/status return the channel name in replies. This is pretty useful for applications where you're seeing what privileges a user has on a channel, and the user submits multiple requests in a short time.

I can throw up a use case if needed, it's mostly in the space of trying to write an asynchronous way of checking whether a user is a founder of a specified channel. Without the channel name in the reply, an application would need to worry about not submitting two cs/status requests on two different channels at the same time, lest the replies get mixed up. With this info right in the reply, it's trivial for the application to submit multiple requests in a close space of time, without having to worry about getting the replies mixed up.
