### PR TITLE
Dead code in config.cpp

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -876,12 +876,6 @@ void Conf::LoadConf(File &file)
 					if (b)
 						Log(LOG_DEBUG) << "ln " << linenumber << " EOL: s='" << b->name << "' '" << itemname << "' set to '" << wordbuffer << "'";
 
-					if (itemname.empty())
-					{
-						file.Close();
-						throw ConfigException("Item without a name: " + file.GetName() + ":" + stringify(linenumber));
-					}
-
 					/* Check defines */
 					for (int i = 0; i < this->CountBlock("define"); ++i)
 					{


### PR DESCRIPTION
Remove useless check against itemname after having already checked whether it's empty.
