### PR TITLE
hybrid.cpp: add our own SendInvite() which sends the channel's timestamp...

### DIFF
--- a/modules/protocol/hybrid.cpp
+++ b/modules/protocol/hybrid.cpp
@@ -51,6 +51,11 @@ class HybridProto : public IRCDProto
 		MaxModes = 4;
 	}
 
+	void SendInvite(const MessageSource &source, const Channel *c, User *u) anope_override
+	{
+		UplinkSocket::Message(source) << "INVITE " << u->GetUID() << " " << c->name << " " << c->creation_time;
+	}
+
 	void SendGlobalNotice(BotInfo *bi, const Server *dest, const Anope::string &msg) anope_override
 	{
 		UplinkSocket::Message(bi) << "NOTICE $$" << dest->GetName() << " :" << msg;


### PR DESCRIPTION
... along the INVITE command. INVITE with channel TS will be mandatory in some future release of ircd-hybrid
