### PR TITLE
- Update hybrid protocol module:

### DIFF
--- a/modules/protocol/hybrid.cpp
+++ b/modules/protocol/hybrid.cpp
@@ -204,7 +204,7 @@ class HybridProto : public IRCDProto
 
 		SendServer(Me);
 
-		UplinkSocket::Message() << "SVINFO 6 5 0 :" << Anope::CurTime;
+		UplinkSocket::Message(Me) << "SVINFO 6 5 0 :" << Anope::CurTime;
 	}
 
 	void SendClientIntroduction(User *u) anope_override
@@ -252,12 +252,15 @@ class HybridProto : public IRCDProto
 
 	void SendForceNickChange(User *u, const Anope::string &newnick, time_t when) anope_override
 	{
-		UplinkSocket::Message(Me) << "SVSNICK " << u->nick << " " << newnick << " " << when;
+		UplinkSocket::Message(Me) << "SVSNICK " << u->GetUID() << " " << newnick << " " << when;
 	}
 
-	void SendSVSJoin(const MessageSource &source, User *u, const Anope::string &chan, const Anope::string &) anope_override
+	void SendSVSJoin(const MessageSource &source, User *u, const Anope::string &chan, const Anope::string &param) anope_override
 	{
-		UplinkSocket::Message(source) << "SVSJOIN " << u->GetUID() << " " << chan;
+                if (!param.empty())
+                        UplinkSocket::Message(source) << "SVSJOIN " << u->GetUID() << " " << chan << " :" << param;
+                else
+                        UplinkSocket::Message(source) << "SVSJOIN " << u->GetUID() << " " << chan;
 	}
 
 	void SendSVSPart(const MessageSource &source, User *u, const Anope::string &chan, const Anope::string &param) anope_override
@@ -640,7 +643,7 @@ class ProtoHybrid : public Module
 		ModeManager::AddChannelMode(new ChannelModeList("EXCEPT", 'e'));
 		ModeManager::AddChannelMode(new ChannelModeList("INVITEOVERRIDE", 'I'));
 
-		/* v/h/o/a/q */
+		/* v/h/o/ */
 		ModeManager::AddChannelMode(new ChannelModeStatus("VOICE", 'v', '+', 0));
 		ModeManager::AddChannelMode(new ChannelModeStatus("HALFOP", 'h', '%', 1));
 		ModeManager::AddChannelMode(new ChannelModeStatus("OP", 'o', '@', 2));


### PR DESCRIPTION
- SVSJOIN to a +k channel requires to send the channel key within the SVSJOIN command
- SVINFO can be prefixed wit the server's name
- Use UID for SVSNICK if possible
