### PR TITLE
Support for cloning ChanServ levels between channels

### DIFF
--- a/include/regchannel.h
+++ b/include/regchannel.h
@@ -198,6 +198,11 @@ class CoreExport ChannelInfo : public Serializable, public Extensible
 	 */
 	void ClearAkick();
 
+	/** Get the level entries for the current channel.
+	 * @return The levels for the specified channel.
+	 */
+	const Anope::map<int16_t> &GetLevelEntries();
+
 	/** Get the level for a privilege
 	 * @param priv The privilege name
 	 * @return the level

--- a/modules/commands/cs_clone.cpp
+++ b/modules/commands/cs_clone.cpp
@@ -177,6 +177,17 @@ public:
 
 			source.Reply(_("All badword entries from \002%s\002 have been cloned to \002%s\002."), channel.c_str(), target.c_str());
 		}
+		else if (what.equals_ci("LEVELS"))
+		{
+			Anope::map<int16_t> cilevels = ci->GetLevelEntries();
+
+			for(Anope::map<int16_t>::const_iterator it = cilevels.begin(); it != cilevels.end(); ++it)
+			{
+				target_ci->SetLevel(it->first, it->second);
+			}
+
+			source.Reply(_("%d level entries from \002%s\002 have been cloned into \002%s\002"), cilevels.size(), channel.c_str(), target.c_str());
+		}
 		else
 		{
 			this->OnSyntaxError(source, "");
@@ -191,7 +202,7 @@ public:
 		this->SendSyntax(source);
 		source.Reply(" ");
 		source.Reply(_("Copies all settings, access, akicks, etc from \002channel\002 to the\n"
-				"\002target\002 channel. If \037what\037 is \002ACCESS\002, \002AKICK\002, or \002BADWORDS\002\n"
+				"\002target\002 channel. If \037what\037 is \002ACCESS\002, \002AKICK\002, \002BADWORDS\002, or \002LEVELS\002\n"
 				"then only the respective settings are cloned.\n"
 				"You must be the founder of \037channel\037 and \037target\037."));
 		return true;

--- a/src/regchannel.cpp
+++ b/src/regchannel.cpp
@@ -575,6 +575,11 @@ void ChannelInfo::ClearAkick()
 		delete this->akick->back();
 }
 
+const Anope::map<int16_t> &ChannelInfo::GetLevelEntries()
+{
+	return this->levels;
+}
+
 int16_t ChannelInfo::GetLevel(const Anope::string &priv) const
 {
 	if (PrivilegeManager::FindPrivilege(priv) == NULL)


### PR DESCRIPTION
I needed a way to clone levels between two channels, so I modified cs_clone and a core header (and associated source) file to add this functionality.

Modification compiles and runs smoothly on my network.

Sorry for the bad commit name in the diff. I tried to edit it, but it didn't take apparently.