### PR TITLE
Keep the akiller's name when updating the reason.

### DIFF
--- a/modules/commands/os_akill.cpp
+++ b/modules/commands/os_akill.cpp
@@ -153,6 +153,9 @@ class CommandOSAKill : public Command
 		if (targ)
 			mask = "*@" + targ->host;
 
+		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
+			reason = "[" + source.GetNick() + "] " + reason;
+
 		if (!akills->CanAdd(source, mask, expires, reason))
 			return;
 		else if (mask.find_first_not_of("/~@.*?") == Anope::string::npos)
@@ -165,9 +168,6 @@ class CommandOSAKill : public Command
 			source.Reply(BAD_USERHOST_MASK);
 			return;
 		}
-
-		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
-			reason = "[" + source.GetNick() + "] " + reason;
 
 		XLine *x = new XLine(mask, source.GetNick(), expires, reason);
 		if (Config->GetModule("operserv")->Get<bool>("akillids"))

--- a/modules/commands/os_sxline.cpp
+++ b/modules/commands/os_sxline.cpp
@@ -351,6 +351,9 @@ class CommandOSSNLine : public CommandOSSXLineBase
 		if (mask[masklen - 1] == ' ')
 			mask.erase(masklen - 1);
 
+		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
+			reason = "[" + source.GetNick() + "] " + reason;
+
 		if (!this->xlm()->CanAdd(source, mask, expires, reason))
 			return;
 		else if (mask.find_first_not_of("/.*?") == Anope::string::npos)
@@ -358,9 +361,6 @@ class CommandOSSNLine : public CommandOSSXLineBase
 			source.Reply(USERHOST_MASK_TOO_WIDE, mask.c_str());
 			return;
 		}
-
-		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
-			reason = "[" + source.GetNick() + "] " + reason;
 
 		XLine *x = new XLine(mask, source.GetNick(), expires, reason);
 		if (Config->GetModule("operserv")->Get<bool>("akillids"))
@@ -558,6 +558,9 @@ class CommandOSSQLine : public CommandOSSXLineBase
 			}
 		}
 
+		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
+			reason = "[" + source.GetNick() + "] " + reason;
+
 		if (!this->sqlines->CanAdd(source, mask, expires, reason))
 			return;
 		else if (mask.find_first_not_of("./?*") == Anope::string::npos)
@@ -565,9 +568,6 @@ class CommandOSSQLine : public CommandOSSXLineBase
 			source.Reply(USERHOST_MASK_TOO_WIDE, mask.c_str());
 			return;
 		}
-
-		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
-			reason = "[" + source.GetNick() + "] " + reason;
 
 		XLine *x = new XLine(mask, source.GetNick(), expires, reason);
 		if (Config->GetModule("operserv")->Get<bool>("akillids"))


### PR DESCRIPTION
The name of the oper issuing an akill or a sxline could be removed by updating the reason,
even though addkiller was enabled.
