### PR TITLE
ngIRCd protocol module: fix servertoken

### DIFF
--- a/modules/protocol/ngircd.cpp
+++ b/modules/protocol/ngircd.cpp
@@ -448,7 +448,14 @@ struct IRCDMessageNick : IRCDMessage
 		else if (params.size() == 7)
 		{
 			// a new user is connecting to the network
-			User::OnIntroduce(params[0], params[2], params[3], "", "", source.GetServer(), params[6], Anope::CurTime, params[5], "", NULL);
+			Server *s = Server::Find(params[4]);
+			if (s == NULL)
+			{
+				Log(LOG_DEBUG) << "User " << params[0] << " introduced from nonexistant server " << params[4] << "?";
+				return;
+			}
+			User::OnIntroduce(params[0], params[2], params[3], "", "", s, params[6], Anope::CurTime, params[5], "", NULL);
+			Log(LOG_DEBUG) << "Registered nick \"" << params[0] << "\" on server " << s->GetName() << ".";
 		}
 		else
 		{


### PR DESCRIPTION
Fix server token assignment of servers in the network and correctly assign nicks to their respective host servers.

Thanks to DukePyrolator for helping tracking this down!
