### PR TITLE
Anope will now fork even when not started from a tty, like init scripts.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -440,7 +440,7 @@ void Anope::Init(int ac, char **av)
 	Log(LOG_TERMINAL) << "Using configuration file " << Anope::ConfigDir << "/" << ServicesConf.GetName();
 
 	/* Fork to background */
-	if (!Anope::NoFork && Anope::AtTerm())
+	if (!Anope::NoFork)
 	{
 		/* Install these before fork() - it is possible for the child to
 		 * connect and kill() the parent before it is able to install the
@@ -524,7 +524,7 @@ void Anope::Init(int ac, char **av)
 
 #ifndef _WIN32
 	/* We won't background later, so we should setuid now */
-	if (Anope::NoFork || !Anope::AtTerm())
+	if (Anope::NoFork)
 		setuidgid();
 #endif
 

--- a/src/servers.cpp
+++ b/src/servers.cpp
@@ -287,7 +287,7 @@ void Server::Sync(bool sync_links)
 
 		FOREACH_MOD(OnUplinkSync, (this));
 
-		if (!Anope::NoFork && Anope::AtTerm())
+		if (!Anope::NoFork)
 		{
 			Log(LOG_TERMINAL) << "Successfully linked, launching into background...";
 			Anope::Fork();


### PR DESCRIPTION
It is useful for init systems or startup scripts, because it allows easily waiting until services connect to the uplink, without them forking it wouldn't be possible to tell if they finished initialization or not unless they would communicate directly with init systems like systemd.
