### PR TITLE
Update ns_maxemail.cpp

### DIFF
--- a/modules/ns_maxemail.cpp
+++ b/modules/ns_maxemail.cpp
@@ -18,26 +18,19 @@ class NSMaxEmail : public Module
 	{
 		int NSEmailMax = Config->GetModule(this)->Get<int>("maxemails");
 
-		if (NSEmailMax < 1 || email.empty())
+		if (NSEmailMax < 1 || email.empty() || this->CountEmail(email, source.nc) < NSEmailMax)
 			return false;
-
-		if (this->CountEmail(email, source.nc) < NSEmailMax)
-			return false;
-
-		if (NSEmailMax == 1)
-			source.Reply(_("The email address \002%s\002 has reached its usage limit of 1 user."), email.c_str());
-		else
-			source.Reply(_("The email address \002%s\002 has reached its usage limit of %d users."), email.c_str(), NSEmailMax);
-
+			
+		source.Reply(_("The email address \002%s\002 has reached its usage limit of %d users."), email.c_str(), NSEmailMax);
 		return true;
 	}
 
 	int CountEmail(const Anope::string &email, NickCore *unc)
 	{
-		int count = 0;
-
 		if (email.empty())
 			return 0;
+			
+		int count = 0;
 
 		for (nickcore_map::const_iterator it = NickCoreList->begin(), it_end = NickCoreList->end(); it != it_end; ++it)
 		{


### PR DESCRIPTION
Remove redundant logic for writing that the email limit was reached.  The print will always print 1 or greater so there doesn't need to be a separate case for printing the same text with the number 1 filled in instead of NSEmailMax which has already been initialized.
Places the if (email.empty()) return 0; before initializing int count to save on allocating space and then deallocating when returning instead of counting.
