### PR TITLE
Added kickcheck override for users with protected privs

### DIFF
--- a/modules/commands/cs_set.cpp
+++ b/modules/commands/cs_set.cpp
@@ -1252,7 +1252,7 @@ class CSSet : public Module
 
 	EventReturn OnCheckKick(User *u, Channel *c, Anope::string &mask, Anope::string &reason) anope_override
 	{
-		if (!c->ci || !restricted.HasExt(c->ci) || c->MatchesList(u, "EXCEPT"))
+		if (!c->ci || !restricted.HasExt(c->ci) || c->MatchesList(u, "EXCEPT") || u->IsProtected())
 			return EVENT_CONTINUE;
 
 		if (c->ci->AccessFor(u).empty() && (!c->ci->GetFounder() || u->Account() != c->ci->GetFounder()))


### PR DESCRIPTION
I think should be useful having this override for users with protected privs (Can not be kicked from channels by Services)