### PR TITLE
.Travis: enable container and test for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: cpp
+sudo: false
 
 compiler:
   - gcc
+  - clang
 
 before_script:
   - mkdir build
@@ -9,8 +11,10 @@ before_script:
   - cmake -DINSTDIR:STRING=~/services -DDEFUMASK:STRING=077 -DCMAKE_BUILD_TYPE:STRING=DEBUG -DUSE_RUN_CC_PL:BOOLEAN=ON ..
 
 script:
-  - make
+  - make -j$(nproc)
 
 notifications:
   irc:
     - "irc.anope.org#anope-devel"
+matrix:
+    fast_finish: true


### PR DESCRIPTION
* disable sudo, so container based builds are used. I don't see sudo
  used anywhere in .travis.yml so it should just make starting tests
  faster.
* also test for clang which is widely used on BSD side and seems to also
  be becoming popular on Linux.
* if one build fails, inform about it before waiting for all builds to
  finish.