### PR TITLE
Remove max password length from Anope

### DIFF
--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -203,13 +203,6 @@ module
 	 * If set, Services do not allow ownership of nick names, only ownership of accounts.
 	 */
 	nonicknameownership = no
-
-	/*
-	 * The maximum length of passwords
-	 *
-	 * This directive is optional. If not set it defaults to 32.
-	 */
-	passlen = 32
 }
 
 /*

--- a/include/language.h
+++ b/include/language.h
@@ -74,7 +74,6 @@ namespace Language
 #define MORE_OBSCURE_PASSWORD		_("Please try again with a more obscure password. Passwords should be at least\n" \
 						"five characters long, should not be something easily guessed\n" \
 						"(e.g. your real name or your nick), and cannot contain the space or tab characters.")
-#define PASSWORD_TOO_LONG		_("Your password is too long. It must not exceed %u characters.")
 #define NICK_NOT_REGISTERED		_("Your nick isn't registered.")
 #define NICK_X_NOT_REGISTERED		_("Nick \002%s\002 isn't registered.")
 #define NICK_X_NOT_IN_USE		_("Nick \002%s\002 isn't currently in use.")

--- a/modules/commands/ns_register.cpp
+++ b/modules/commands/ns_register.cpp
@@ -170,8 +170,6 @@ class CommandNSRegister : public Command
 				}
 			}
 
-		unsigned int passlen = Config->GetModule("nickserv")->Get<unsigned>("passlen", "32");
-
 		if (Config->GetModule("nickserv")->Get<bool>("forceemail", "yes") && email.empty())
 			this->OnSyntaxError(source, "");
 		else if (u && Anope::CurTime < u->lastnickreg + reg_delay)
@@ -180,8 +178,6 @@ class CommandNSRegister : public Command
 			source.Reply(NICK_ALREADY_REGISTERED, u_nick.c_str());
 		else if (pass.equals_ci(u_nick) || (Config->GetBlock("options")->Get<bool>("strictpasswords") && pass.length() < 5))
 			source.Reply(MORE_OBSCURE_PASSWORD);
-		else if (pass.length() > passlen)
-			source.Reply(PASSWORD_TOO_LONG, passlen);
 		else if (!email.empty() && !Mail::Validate(email))
 			source.Reply(MAIL_X_INVALID, email.c_str());
 		else

--- a/modules/commands/ns_set.cpp
+++ b/modules/commands/ns_set.cpp
@@ -134,13 +134,6 @@ class CommandNSSetPassword : public Command
 			return;
 		}
 
-		unsigned int passlen = Config->GetModule("nickserv")->Get<unsigned>("passlen", "32");
-		if (len > passlen)
-		{
-			source.Reply(PASSWORD_TOO_LONG, passlen);
-			return;
-		}
-
 		Log(LOG_COMMAND, source, this) << "to change their password";
 
 		Anope::Encrypt(param, source.nc->pass);
@@ -197,13 +190,6 @@ class CommandNSSASetPassword : public Command
 		if (nc->display.equals_ci(params[1]) || (Config->GetBlock("options")->Get<bool>("strictpasswords") && len < 5))
 		{
 			source.Reply(MORE_OBSCURE_PASSWORD);
-			return;
-		}
-
-		unsigned int passlen = Config->GetModule("nickserv")->Get<unsigned>("passlen", "32");
-		if (len > passlen)
-		{
-			source.Reply(PASSWORD_TOO_LONG, passlen);
 			return;
 		}
 


### PR DESCRIPTION
I'm not sure why this was implemented, but a max password length is considered bad practice in any case since it is irrelevant for hashed passwords anyways.