### PR TITLE
Allow opers with chanserv/access/list to view the levels list

### DIFF
--- a/modules/commands/cs_access.cpp
+++ b/modules/commands/cs_access.cpp
@@ -758,12 +758,20 @@ class CommandCSLevels : public Command
 			return;
 		}
 
+		bool has_access = false;
+		if (source.HasPriv("chanserv/access/modify"))
+			has_access = true;
+		else if (cmd.equals_ci("LIST") && source.HasPriv("chanserv/access/list"))
+			has_access = true;
+		else if (source.AccessFor(ci).HasPriv("FOUNDER"))
+			has_access = true;
+
 		/* If SET, we want two extra parameters; if DIS[ABLE] or FOUNDER, we want only
 		 * one; else, we want none.
 		 */
 		if (cmd.equals_ci("SET") ? s.empty() : (cmd.substr(0, 3).equals_ci("DIS") ? (what.empty() || !s.empty()) : !what.empty()))
 			this->OnSyntaxError(source, cmd);
-		else if (!source.AccessFor(ci).HasPriv("FOUNDER") && !source.HasPriv("chanserv/access/modify"))
+		else if (!has_access)
 			source.Reply(ACCESS_DENIED);
 		else if (Anope::ReadOnly && !cmd.equals_ci("LIST"))
 			source.Reply(READ_ONLY_MODE);


### PR DESCRIPTION
Commit 96583892c6a0bc48029348ddcf86b1afc5a9915d introduced the `chanserv/access/list` privilege for the `/cs access list` command. This commit reuses it for `/cs levels list` to provide opers with a read-only access to the levels, in addition to the `chanserv/access/modify` privilege which already provides read and write access.