### PR TITLE
Did it send? BotServ Enhancement

### DIFF
--- a/modules/commands/bs_control.cpp
+++ b/modules/commands/bs_control.cpp
@@ -56,6 +56,7 @@ class CommandBSSay : public Command
 		}
 
 		IRCD->SendPrivmsg(*ci->bi, ci->name, "%s", text.c_str());
+		source.Reply("Sent message to channel", ci->name);
 		ci->bi->lastmsg = Anope::CurTime;
 
 		bool override = !source.AccessFor(ci).HasPriv("SAY");
@@ -114,6 +115,7 @@ class CommandBSAct : public Command
 			return;
 
 		IRCD->SendAction(*ci->bi, ci->name, "%s", message.c_str());
+		source.Reply("Sent message to channel", ci->name);
 		ci->bi->lastmsg = Anope::CurTime;
 
 		bool override = !source.AccessFor(ci).HasPriv("SAY");

--- a/modules/commands/bs_control.cpp
+++ b/modules/commands/bs_control.cpp
@@ -56,7 +56,7 @@ class CommandBSSay : public Command
 		}
 
 		IRCD->SendPrivmsg(*ci->bi, ci->name, "%s", text.c_str());
-		source.Reply("Sent message to channel", ci->name);
+		source.Reply("Sent message to channel");
 		ci->bi->lastmsg = Anope::CurTime;
 
 		bool override = !source.AccessFor(ci).HasPriv("SAY");
@@ -115,7 +115,7 @@ class CommandBSAct : public Command
 			return;
 
 		IRCD->SendAction(*ci->bi, ci->name, "%s", message.c_str());
-		source.Reply("Sent message to channel", ci->name);
+		source.Reply("Sent message to channel");
 		ci->bi->lastmsg = Anope::CurTime;
 
 		bool override = !source.AccessFor(ci).HasPriv("SAY");


### PR DESCRIPTION
Some may say this is pointless, but I think it adds a good touch. When using "/bs say" or "/bs action" it will tell the user via notice if the message has sent instead of just staring into blank nothing. Some newer users may think the services are broken when they're just not checking the right tab.

->BotServ<- say #Test This is a test!
<ChanServ> This is a test!
-BotServ- Sent message to channel