### PR TITLE
Add support for sending messages in the context of a channel.

### DIFF
--- a/data/example.conf
+++ b/data/example.conf
@@ -262,6 +262,15 @@ module
 	name = "inspircd20"
 
 	/*
+	 * Some protocol modules can send entry messages which appear in the channel window rather than in
+	 * a private message. This prevents the problem of clients receiving dozens of private notices when
+	 * they join channels on connecting to a server.
+	 *
+	 * If the protocol module you have loaded does not support this, this setting will have no effect.
+	 */
+	use_channel_context_messages = no
+
+	/*
 	 * Some protocol modules can enforce mode locks server-side. This reduces the spam caused by
 	 * services immediately reversing mode changes for locked modes.
 	 *

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -144,6 +144,9 @@ class CoreExport IRCDProto : public Service
 	virtual void SendAction(const MessageSource &source, const Anope::string &dest, const char *fmt, ...);
 	virtual void SendCTCP(const MessageSource &source, const Anope::string &dest, const char *fmt, ...);
 
+	virtual void SendContextNotice(BotInfo *source, const User *dest, const Channel *chan, const Anope::string &msg);
+	virtual void SendContextPrivmsg(BotInfo *source, const User *dest, const Channel *chan, const Anope::string &msg);
+
 	virtual void SendGlobalNotice(BotInfo *bi, const Server *dest, const Anope::string &msg) = 0;
 	virtual void SendGlobalPrivmsg(BotInfo *bi, const Server *desc, const Anope::string &msg) = 0;
 

--- a/include/users.h
+++ b/include/users.h
@@ -186,6 +186,14 @@ class CoreExport User : public virtual Base, public Extensible, public CommandRe
 	void SetRealname(const Anope::string &realname);
 
 	/**
+	 * Send a message (notice or privmsg, depending on settings) to a user in the context of a channel.
+	 * @param source Sender
+	 * @param chan Channel context.
+	 * @params msg Message to send.
+	 */
+	void SendContextMessage(BotInfo *source, Channel *chan, const Anope::string &msg) anope_override;
+
+	/**
 	 * Send a message (notice or privmsg, depending on settings) to a user
 	 * @param source Sender
 	 * @param fmt Format of the Message

--- a/modules/commands/cs_entrymsg.cpp
+++ b/modules/commands/cs_entrymsg.cpp
@@ -281,7 +281,7 @@ class CSEntryMessage : public Module
 
 			if (messages != NULL)
 				for (unsigned i = 0; i < (*messages)->size(); ++i)
-					u->SendMessage(c->ci->WhoSends(), "[%s] %s", c->ci->name.c_str(), (*messages)->at(i)->message.c_str());
+					u->SendContextMessage(c->ci->WhoSends(), c, (*messages)->at(i)->message);
 		}
 	}
 };

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -339,6 +339,16 @@ void IRCDProto::SendCTCP(const MessageSource &source, const Anope::string &dest,
 	SendCTCPInternal(source, dest, buf);
 }
 
+void IRCDProto::SendContextNotice(BotInfo *source, const User *dest, const Channel *chan, const Anope::string &msg)
+{
+	SendNotice(source, dest->GetUID(), "[%s] %s", chan->ci->name.c_str(), msg.c_str());
+}
+
+void IRCDProto::SendContextPrivmsg(BotInfo *source, const User *dest, const Channel *chan, const Anope::string &msg)
+{
+	SendPrivmsg(source, dest->GetUID(), "[%s] %s", chan->ci->name.c_str(), msg.c_str());
+}
+
 void IRCDProto::SendNumeric(int numeric, const Anope::string &dest, const char *fmt, ...)
 {
 	va_list args;

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -319,6 +319,19 @@ User::~User()
 	FOREACH_MOD(OnPostUserLogoff, (this));
 }
 
+void User::SendContextMessage(BotInfo *source, Channel *chan, const Anope::string &msg)
+{
+	/* Send privmsg instead of notice if:
+	 * - UsePrivmsg is enabled
+	 * - The user is not registered and NSDefMsg is enabled
+	 * - The user is registered and has set /ns set msg on
+	 */
+	if (Config->UsePrivmsg && ((!this->nc && Config->DefPrivmsg) || (this->nc && this->nc->HasExt("MSG"))))
+		IRCD->SendContextPrivmsg(source, this, chan, msg);
+	else
+		IRCD->SendContextNotice(source, this, chan, msg	);
+}
+
 void User::SendMessage(BotInfo *source, const char *fmt, ...)
 {
 	va_list args;


### PR DESCRIPTION
Such messages appear in the channel window but are only sent to the user. This prevents the problem of getting spammed with private messages when connecting to a server and joining a ton of channels.

Presently only support for InspIRCd is implemented as that is the only protocol which I am familiar with. Servers which do not support this will fall back to the old method.