### PR TITLE
os_akill: Sanity check AKILLing before modifing the akill list

### DIFF
--- a/modules/commands/os_akill.cpp
+++ b/modules/commands/os_akill.cpp
@@ -156,19 +156,6 @@ class CommandOSAKill : public Command
 		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
 			reason = "[" + source.GetNick() + "] " + reason;
 
-		if (!akills->CanAdd(source, mask, expires, reason))
-			return;
-		else if (mask.find_first_not_of("/~@.*?") == Anope::string::npos)
-		{
-			source.Reply(USERHOST_MASK_TOO_WIDE, mask.c_str());
-			return;
-		}
-		else if (mask.find('@') == Anope::string::npos)
-		{
-			source.Reply(BAD_USERHOST_MASK);
-			return;
-		}
-
 		XLine *x = new XLine(mask, source.GetNick(), expires, reason);
 		if (Config->GetModule("operserv")->Get<bool>("akillids"))
 			x->id = XLineManager::GenerateUID();
@@ -186,6 +173,19 @@ class CommandOSAKill : public Command
 			delete x;
 			return;
 		}
+
+		if (mask.find_first_not_of("/~@.*?") == Anope::string::npos)
+		{
+			source.Reply(USERHOST_MASK_TOO_WIDE, mask.c_str());
+			return;
+		}
+		else if (mask.find('@') == Anope::string::npos)
+		{
+			source.Reply(BAD_USERHOST_MASK);
+			return;
+		}
+		else if (!akills->CanAdd(source, mask, expires, reason))
+			return;
 
 		EventReturn MOD_RESULT;
 		FOREACH_RESULT(OnAddXLine, MOD_RESULT, (source, x, akills));

--- a/modules/commands/os_akill.cpp
+++ b/modules/commands/os_akill.cpp
@@ -156,6 +156,17 @@ class CommandOSAKill : public Command
 		if (Config->GetModule("operserv")->Get<bool>("addakiller", "yes") && !source.GetNick().empty())
 			reason = "[" + source.GetNick() + "] " + reason;
 
+		if (mask.find_first_not_of("/~@.*?") == Anope::string::npos)
+		{
+			source.Reply(USERHOST_MASK_TOO_WIDE, mask.c_str());
+			return;
+		}
+		else if (mask.find('@') == Anope::string::npos)
+		{
+			source.Reply(BAD_USERHOST_MASK);
+			return;
+		}
+
 		XLine *x = new XLine(mask, source.GetNick(), expires, reason);
 		if (Config->GetModule("operserv")->Get<bool>("akillids"))
 			x->id = XLineManager::GenerateUID();
@@ -174,17 +185,7 @@ class CommandOSAKill : public Command
 			return;
 		}
 
-		if (mask.find_first_not_of("/~@.*?") == Anope::string::npos)
-		{
-			source.Reply(USERHOST_MASK_TOO_WIDE, mask.c_str());
-			return;
-		}
-		else if (mask.find('@') == Anope::string::npos)
-		{
-			source.Reply(BAD_USERHOST_MASK);
-			return;
-		}
-		else if (!akills->CanAdd(source, mask, expires, reason))
+		if (!akills->CanAdd(source, mask, expires, reason))
 			return;
 
 		EventReturn MOD_RESULT;


### PR DESCRIPTION
When a user issues an AKILL, CommandOSAkill::DoAdd checks against XLineManager::CanAdd before the mask can completely be dry tested. This creates the issue that if the mask fails dry tests past XLineManager::CanAdd, XLineManager has already removed any matching masks while DoAdd still fails the final result (entry). This patch reorders the dry checks and places the call to XLineManager::CanAdd as the final check before proceeding to add. That way, if it fails a dry check prior to CanAdd, there is no risk of modifying the current AKILL list.