### PR TITLE
Updated Travis build process for Anope 2.1 Redux... again!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
 language: cpp
-
+dist: trusty
 before_script:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
+  - sudo sed -i 's/us-central1.gce/us-central1.gce.clouds/' /etc/apt/sources.list && sudo apt-get update
   - sudo apt-get install -y g++-4.8
   - export CXX="g++-4.8" CC="gcc-4.8"
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - mkdir build
   - cd build
   - cmake -DINSTDIR:STRING=~/services -DDEFUMASK:STRING=077 -DCMAKE_BUILD_TYPE:STRING=DEBUG -DUSE_RUN_CC_PL:BOOLEAN=ON ..
+ 
+addons:
+apt:
+ sources:
+ - ubuntu-toolchain-r-test
+ packages:
+ - g++-4.8
+ - gcc-4.8
+ - cmake
+ - cmake-data
 
 script:
-  - make
+   - make
 
 notifications:
   irc:


### PR DESCRIPTION
Updated travis.yml to work on 14.04, along with additional workaround for GCE builds failing due to apt-get failures. Note: Builds will pass but if one attempts to view the console while Travis CI builds, the 10k log limit is quickly broken, forcing you to download the raw logs. It will still pass, nonetheless.

Should work nicely this time round.
