### PR TITLE
Fix a low risk privilege escalation exploit on InspIRCd with m_autoop.

### DIFF
--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -77,6 +77,21 @@ class InspIRCd20Proto : public IRCDProto
 	bool IsIdentValid(const Anope::string &ident) anope_override { return insp12->IsIdentValid(ident); }
 };
 
+class InspIRCdAutoOpMode : public ChannelModeList
+{
+ public:
+	InspIRCdAutoOpMode(char mode) : ChannelModeList("AUTOOP", mode)
+	{
+	}
+
+	bool IsValid(Anope::string &mask) const anope_override
+	{
+		// We can not validate this because we don't know about the
+		// privileges of the setter so just reject attempts to set it.
+		return false;
+	}
+};
+
 class InspIRCdExtBan : public ChannelModeVirtual<ChannelModeList>
 {
 	char ext;
@@ -395,6 +410,8 @@ struct IRCDMessageCapab : Message::Capab
 				}
 				else if (modename.equals_cs("auditorium"))
 					cm = new ChannelMode("AUDITORIUM", modechar[0]);
+				else if (modename.equals_cs("autoop"))
+					cm = new InspIRCdAutoOpMode(modechar[0]);
 				else if (modename.equals_cs("ban"))
 					cm = new ChannelModeList("BAN", modechar[0]);
 				else if (modename.equals_cs("banexception"))


### PR DESCRIPTION
It isn't as serious as it sounds as you need access to change channel modes via ChanServ to perform the escalation which by default requires channel operator privileges. However, if you have those privileges and the server has status modes higher than op (i.e. +Yyao) enabled then you can set +w masks to give people those any of those status modes.

Workaround for this bug is to unload m_autoop on InspIRCd. You don't need it anyway if you're using Anope.