### PR TITLE
Implement support for SASL 3.2 mechanism lists.

### DIFF
--- a/include/protocol.h
+++ b/include/protocol.h
@@ -227,6 +227,7 @@ class CoreExport IRCDProto : public Service
 	 */
 	virtual void SendOper(User *u);
 
+	virtual void SendSASLMechanisms(std::vector<Anope::string> &) { }
 	virtual void SendSASLMessage(const SASL::Message &) { }
 	virtual void SendSVSLogin(const Anope::string &uid, const Anope::string &acc) { }
 

--- a/modules/m_sasl.cpp
+++ b/modules/m_sasl.cpp
@@ -266,6 +266,21 @@ class ModuleSASL : public Module
 	Plain plain;
 	External *external;
 
+	std::vector<Anope::string> mechs;
+
+	void CheckMechs()
+	{
+		std::vector<Anope::string> newmechs = ::Service::GetServiceKeys("SASL::Mechanism");
+		if (newmechs == mechs)
+			return;
+
+		mechs = newmechs;
+
+		// If we are connected to the network then broadcast the mechlist.
+		if (Me && Me->IsSynced())
+			IRCD->SendSASLMechanisms(mechs);
+	}
+
  public:
 	ModuleSASL(const Anope::string &modname, const Anope::string &creator) : Module(modname, creator, VENDOR),
 		sasl(this), plain(this), external(NULL)
@@ -273,6 +288,7 @@ class ModuleSASL : public Module
 		try
 		{
 			external = new External(this);
+			CheckMechs();
 		}
 		catch (ModuleException &) { }
 	}
@@ -280,6 +296,22 @@ class ModuleSASL : public Module
 	~ModuleSASL()
 	{
 		delete external;
+	}
+
+	void OnModuleLoad(User *, Module *) anope_override
+	{
+		CheckMechs();
+	}
+
+	void OnModuleUnload(User *, Module *) anope_override
+	{
+		CheckMechs();
+	}
+
+	void OnPreUplinkSync(Server *) anope_override
+	{
+		// We have not yet sent a mechanism list so always do it here.
+		IRCD->SendSASLMechanisms(mechs);
 	}
 };
 

--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -42,6 +42,15 @@ class InspIRCd20Proto : public IRCDProto
 		insp12->SendConnect();
 	}
 
+	void SendSASLMechanisms(std::vector<Anope::string> &mechanisms) anope_override
+	{
+		Anope::string mechlist;
+		for (unsigned i = 0; i < mechanisms.size(); ++i)
+			mechlist += "," + mechanisms[i];
+
+		UplinkSocket::Message(Me) << "METADATA * saslmechlist :" << (mechanisms.empty() ? "" : mechlist.substr(1));
+	}
+
 	void SendSVSKillInternal(const MessageSource &source, User *user, const Anope::string &buf) anope_override { insp12->SendSVSKillInternal(source, user, buf); }
 	void SendGlobalNotice(BotInfo *bi, const Server *dest, const Anope::string &msg) anope_override { insp12->SendGlobalNotice(bi, dest, msg); }
 	void SendGlobalPrivmsg(BotInfo *bi, const Server *dest, const Anope::string &msg) anope_override { insp12->SendGlobalPrivmsg(bi, dest, msg); }


### PR DESCRIPTION
The protocol side is implemented for InspIRCd but not for other daemons (i.e. @charybdis-ircd) as i'm not familiar enough with their protocols to implement it.
