### PR TITLE
Remove references to cmake-bin which was removed ages ago.

### DIFF
--- a/extras
+++ b/extras
@@ -148,12 +148,7 @@ while (1)
 
 	if ($input eq "q") {
 		if (-e "build/CMakeFiles") {
-			if (-e "cmake-bin") {
-				my $cmake_path = `find cmake-bin -name cmake -print0`;
-				system($cmake_path, "build/.");
-			} else {
-				system("cmake", "build/.");
-			}
+			system("cmake", "build/.");
 			print "\nNow cd build, then run make to build Anope.\n\n";
 		} else {
 			print "\nBuild directory not found. You should run ./Config now.\n\n"


### PR DESCRIPTION
This is fairly harmless but it could cause issues for some people who are building from old git clones.