### PR TITLE
Optionally strip variable build date from compiled program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,11 @@ option(USE_PCH "Use precompiled headers" OFF)
 # source include directory so the precompiled headers work correctly.
 include_directories(${Anope_BINARY_DIR}/include ${Anope_SOURCE_DIR}/include ${Anope_BINARY_DIR}/language ${Anope_SOURCE_DIR}/modules/pseudoclients)
 
+# Pass on REPRODUCIBLE_BUILD
+if(REPRODUCIBLE_BUILD)
+  add_definitions(-DREPRODUCIBLE_BUILD)
+endif(REPRODUCIBLE_BUILD)
+
 # If using Windows, always add the _WIN32 define
 if(WIN32)
   add_definitions(-D_WIN32)

--- a/include/anope.h
+++ b/include/anope.h
@@ -336,7 +336,9 @@ namespace Anope
 	template<typename T> class multimap : public std::multimap<string, T, ci::less> { };
 	template<typename T> class hash_map : public TR1NS::unordered_map<string, T, hash_ci, compare> { };
 
+#ifndef REPRODUCIBLE_BUILD
 	static const char *const compiled = __TIME__ " " __DATE__;
+#endif
 
 	/** The time Anope started.
 	 */

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -632,7 +632,11 @@ Anope::string Anope::VersionShort()
 
 Anope::string Anope::VersionBuildString()
 {
+#ifdef REPRODUCIBLE_BUILD
+	Anope::string s = "build #" + stringify(BUILD);
+#else
 	Anope::string s = "build #" + stringify(BUILD) + ", compiled " + Anope::compiled;
+#endif
 	Anope::string flags;
 
 #ifdef DEBUG_BUILD


### PR DESCRIPTION
To aid build reproducibility, don't include the build date/time if
-DREPRODUCIBLE_BUILD is defined.

Based on the patch provided by Alexis Bienvenüe in the Debian report.

Bug-Debian: https://bugs.debian.org/820152
Patch-Name: reproducible_datetime.diff