### PR TITLE
Use "cmake --version" instead of "which cmake" to detect CMake.

### DIFF
--- a/Config
+++ b/Config
@@ -166,7 +166,7 @@ done
 # Check for CMake and (optionally) install it
 ###########################################################################
 
-which cmake > /dev/null
+cmake --version 2>&1 > /dev/null
 if [ $? -ne 0 ] ; then
 	clear
 	echo "Anope requires CMake 2.4 or newer, which can be downloaded at http://cmake.org or through your system's package manager."


### PR DESCRIPTION
Some spartan systems don't include which which resulted in misleading error messages.