### PR TITLE
Remove unused commands from oper config.

### DIFF
--- a/data/example.conf
+++ b/data/example.conf
@@ -784,12 +784,7 @@ log
  *   chanserv/drop            chanserv/getkey               chanserv/invite
  *   chanserv/list            chanserv/suspend              chanserv/topic
  *
- *   chanserv/saset/bantype   chanserv/saset/description    chanserv/saset/email       chanserv/saset/keepmodes
- *   chanserv/saset/founder   chanserv/saset/keeptopic      chanserv/saset/restricted
- *   chanserv/saset/peace     chanserv/saset/persist        chanserv/saset/private
- *   chanserv/saset/secure    chanserv/saset/securefounder  chanserv/saset/secureops
- *   chanserv/saset/signkick  chanserv/saset/successor      chanserv/saset/topiclock
- *   chanserv/saset/url       chanserv/saset/noexpire       chanserv/saset/autoop
+ *   chanserv/saset/noexpire
  *
  *   memoserv/sendall        memoserv/staff
  *


### PR DESCRIPTION
It seems to me that these commands have been removed and replaced by the chanserv/administration privilege. So I think that they should no longer mentioned in the config. Please tell me what you all think of this.