### PR TITLE
Remove 'expiretimeout' from chanserv.example.conf

### DIFF
--- a/data/chanserv.example.conf
+++ b/data/chanserv.example.conf
@@ -1121,9 +1121,6 @@ module
 
 	/* Sets the time to keep seen entries in the seen database. */
 	purgetime = "30d"
-
-	/* Sets the delay between checks for expired seen entries. */
-	expiretimeout = "1d"
 }
 command { service = "OperServ"; name = "SEEN"; command = "operserv/seen"; permission = "operserv/seen"; }
 


### PR DESCRIPTION
As seen within this [commit](https://github.com/anope/anope/commit/22658d63bdb1e52a66f4514af45fa55ca5891345)
'expiretimeout' is no longer set within cs_seen and I can't see it used elsewhere to be needed in the config.