### PR TITLE
Added a Date field to the Header

### DIFF
--- a/src/tools/anopesmtp.cpp
+++ b/src/tools/anopesmtp.cpp
@@ -107,6 +107,18 @@ static std::string get_logname(struct tm *tm = NULL)
 	return name;
 }
 
+/* TimeStamp for Email Header */
+static std::string GetTimeStamp()
+{
+	char tbuf[256];
+	time_t t = time(NULL);
+	struct tm *tm = localtime(&t);
+
+	strftime(tbuf, sizeof(tbuf) - 1, "%a, %d %b %Y %H:%M:%S %z", tm);
+
+	return tbuf;
+}
+
 /* Log stuff to the log file with a datestamp.  Note that errno is
  * preserved by this routine and log_perror().
  */
@@ -417,7 +429,7 @@ int main(int argc, char *argv[])
 
 	if (argc == 1)
 		return 0;
-	
+
 	if (argc == 3 && !strcmp(argv[2], "--debug"))
 		smtp_debug = 1;
 
@@ -468,6 +480,7 @@ int main(int argc, char *argv[])
 				break;
 			else
 			{
+				smail.smtp_headers.push_back("Date: " + GetTimeStamp() + "\r\n");
 				headers_done = true;
 				smail.smtp_body.push_back(strip(buf) + "\r\n");
 			}


### PR DESCRIPTION
Was seeing Anope's emails (through anopesmtp) getting flagged as spam due to missing the required Date header line:
`X-Amavis-Alert  BAD HEADER SECTION, Missing required header field: "Date"`
Adding the Date header line has cleared up the spam flagging.