### PR TITLE
ratbox: fix RESVs

### DIFF
--- a/modules/protocol/charybdis.cpp
+++ b/modules/protocol/charybdis.cpp
@@ -31,20 +31,6 @@ class ChannelModeLargeBan : public ChannelMode
 
 class CharybdisProto : public IRCDProto
 {
-	BotInfo *FindIntroduced()
-	{
-		BotInfo *bi = Config->GetClient("OperServ");
-		
-		if (bi && bi->introduced)
-			return bi;
-		
-		for (botinfo_map::iterator it = BotListByNick->begin(), it_end = BotListByNick->end(); it != it_end; ++it)
-			if (it->second->introduced)
-				return it->second;
-			
-		return NULL;
-	}
-
  public:
 	
 	CharybdisProto(Module *creator) : IRCDProto(creator, "Charybdis 3.4+")
@@ -70,6 +56,8 @@ class CharybdisProto : public IRCDProto
 	void SendSGLineDel(const XLine *x) anope_override { ratbox->SendSGLineDel(x); }
 	void SendAkill(User *u, XLine *x) anope_override { ratbox->SendAkill(u, x); }
 	void SendAkillDel(const XLine *x) anope_override { ratbox->SendAkillDel(x); }
+	void SendSQLine(User *u, const XLine *x) anope_override { ratbox->SendSQLine(u, x); }
+	void SendSQLineDel(const XLine *x) anope_override { ratbox->SendSQLineDel(x); }
 	void SendJoin(User *user, Channel *c, const ChannelStatus *status) anope_override { ratbox->SendJoin(user, c, status); }
 	void SendServer(const Server *server) anope_override { ratbox->SendServer(server); }
 	void SendChannel(Channel *c) anope_override { ratbox->SendChannel(c); }
@@ -88,22 +76,6 @@ class CharybdisProto : public IRCDProto
 		}
 		
 		UplinkSocket::Message(Me) << "ENCAP * MECHLIST :" << (mechanisms.empty() ? "" : mechlist.substr(1));
-	}
-
-	void SendSQLine(User *, const XLine *x) anope_override
-	{
-		/* Calculate the time left before this would expire, capping it at 2 days */
-		time_t timeleft = x->expires - Anope::CurTime;
-		
-		if (timeleft > 172800 || !x->expires)
-			timeleft = 172800;
-		
-		UplinkSocket::Message(FindIntroduced()) << "ENCAP * RESV " << timeleft << " " << x->mask << " 0 :" << x->GetReason();
-	}
-	
-	void SendSQLineDel(const XLine *x) anope_override
-	{
-		UplinkSocket::Message(Config->GetClient("OperServ")) << "ENCAP * UNRESV " << x->mask;
 	}
 
 	void SendConnect() anope_override


### PR DESCRIPTION
Also, enable channel support because it wasn't specified already and point charybdis to these methods instead.