### PR TITLE
protocol/inspircd: Match servername as well on ENCAP

### DIFF
--- a/modules/protocol/inspircd12.cpp
+++ b/modules/protocol/inspircd12.cpp
@@ -873,7 +873,7 @@ struct IRCDMessageEncap : IRCDMessage
 
 	void Run(MessageSource &source, const std::vector<Anope::string> &params) anope_override
 	{
-		if (Anope::Match(Me->GetSID(), params[0]) == false)
+		if (!Anope::Match(Me->GetSID(), params[0]) && !Anope::Match(Me->GetName(), params[0]))
 			return;
 
 		if (SASL::sasl && params[1] == "SASL" && params.size() >= 6)

--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -776,7 +776,7 @@ struct IRCDMessageEncap : IRCDMessage
 
 	void Run(MessageSource &source, const std::vector<Anope::string> &params) anope_override
 	{
-		if (Anope::Match(Me->GetSID(), params[0]) == false)
+		if (!Anope::Match(Me->GetSID(), params[0]) && !Anope::Match(Me->GetName(), params[0]))
 			return;
 
 		if (params[1] == "CHGIDENT")


### PR DESCRIPTION
This is necessary, for example, with InspIRCd's m_sasl config option `target="services.mynet"`. The ENCAP message contains the target (server name) instead of the ServerID.