### PR TITLE
SASL: disallow unconfirmed accounts from successfully authenticating

### DIFF
--- a/include/modules/sasl.h
+++ b/include/modules/sasl.h
@@ -88,7 +88,7 @@ namespace SASL
 				return;
 
 			NickAlias *na = NickAlias::Find(GetAccount());
-			if (!na || na->nc->HasExt("NS_SUSPENDED"))
+			if (!na || na->nc->HasExt("NS_SUSPENDED") || na->nc->HasExt("UNCONFIRMED"))
 				return OnFail();
 
 			unsigned int maxlogins = Config->GetModule("ns_identify")->Get<unsigned int>("maxlogins");
@@ -126,6 +126,8 @@ namespace SASL
 				accountstatus = "nonexistent ";
 			else if (na->nc->HasExt("NS_SUSPENDED"))
 				accountstatus = "suspended ";
+			else if (na->nc->HasExt("UNCONFIRMED"))
+				accountstatus = "unconfirmed ";
 
 			Anope::string user = "A user";
 			if (!hostname.empty() && !ip.empty())


### PR DESCRIPTION
The reason for this is that unconfirmed accounts can connect to a network and authenticate using SASL in order to get their account name set, which allows the client to then bypass +R and other popular registration-limited channel modes on many popular IRCds. Clients that identify via NickServ do not have their account names set if they are unconfirmed, and thus are not affected by this.