### PR TITLE
IPv6 support for m_dnsbl and sockaddrs::reverse()

### DIFF
--- a/include/sockets.h
+++ b/include/sockets.h
@@ -57,6 +57,11 @@ union CoreExport sockaddrs
 	 */
 	Anope::string addr() const;
 
+	/** Get the reverse address represented by this addr
+	 * @return The reverse address
+	 */
+	Anope::string reverse() const;
+
 	/* Is this address ipv6? */
 	bool ipv6() const;
 

--- a/modules/m_dns.cpp
+++ b/modules/m_dns.cpp
@@ -296,32 +296,16 @@ class Packet : public Query
 				if (!ip.valid())
 					throw SocketException("Invalid IP");
 
-				if (q.name.find(':') != Anope::string::npos)
+				switch (ip.family())
 				{
-					const char *const hex = "0123456789abcdef";
-					char reverse_ip[128];
-					unsigned reverse_ip_count = 0;
-					for (int j = 15; j >= 0; --j)
-					{
-						reverse_ip[reverse_ip_count++] = hex[ip.sa6.sin6_addr.s6_addr[j] & 0xF];
-						reverse_ip[reverse_ip_count++] = '.';
-						reverse_ip[reverse_ip_count++] = hex[ip.sa6.sin6_addr.s6_addr[j] >> 4];
-						reverse_ip[reverse_ip_count++] = '.';
-					}
-					reverse_ip[reverse_ip_count++] = 0;
-
-					q.name = reverse_ip;
-					q.name += "ip6.arpa";
-				}
-				else
-				{
-					unsigned long forward = ip.sa4.sin_addr.s_addr;
-					in_addr reverse;
-					reverse.s_addr = forward << 24 | (forward & 0xFF00) << 8 | (forward & 0xFF0000) >> 8 | forward >> 24;
-
-					ip.ntop(AF_INET, &reverse);
-
-					q.name = ip.addr() + ".in-addr.arpa";
+					case AF_INET6:
+						q.name = ip.reverse() + ".ip6.arpa";
+						break;
+					case AF_INET:
+						q.name = ip.reverse() + ".in-addr.arpa";
+						break;
+					default:
+						throw SocketException("Unsupported IP Family");
 				}
 			}
 

--- a/modules/m_dnsbl.cpp
+++ b/modules/m_dnsbl.cpp
@@ -160,9 +160,8 @@ class ModuleDNSBL : public Module
 		if (!this->check_on_netburst && !user->server->IsSynced())
 			return;
 
-		/* At this time we only support IPv4 */
-		if (!user->ip.valid() || user->ip.sa.sa_family != AF_INET)
-			/* User doesn't have a valid IPv4 IP (ipv6/spoof/etc) */
+		if (!user->ip.valid())
+			/* User doesn't have a valid IP (spoof/etc) */
 			return;
 
 		if (this->blacklists.empty())
@@ -174,17 +173,13 @@ class ModuleDNSBL : public Module
 			return;
 		}
 
-		const unsigned long &ip = user->ip.sa4.sin_addr.s_addr;
-		unsigned long reverse_ip = (ip << 24) | ((ip & 0xFF00) << 8) | ((ip & 0xFF0000) >> 8) | (ip >> 24);
-
-		sockaddrs reverse = user->ip;
-		reverse.sa4.sin_addr.s_addr = reverse_ip;
+		Anope::string reverse = user->ip.reverse();
 
 		for (unsigned i = 0; i < this->blacklists.size(); ++i)
 		{
 			const Blacklist &b = this->blacklists[i];
 
-			Anope::string dnsbl_host = reverse.addr() + "." + b.name;
+			Anope::string dnsbl_host = reverse + "." + b.name;
 			DNSBLResolver *res = NULL;
 			try
 			{

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -95,6 +95,41 @@ Anope::string sockaddrs::addr() const
 	return "";
 }
 
+Anope::string sockaddrs::reverse() const
+{
+	char address[128];
+
+	switch (sa.sa_family)
+	{
+		case AF_INET6:
+		{
+			static const char hex[] = "0123456789abcdef";
+			unsigned reverse_ip_count = 0;
+			for (int j = 15; j >= 0; --j)
+			{
+				address[reverse_ip_count++] = hex[sa6.sin6_addr.s6_addr[j] & 0xF];
+				address[reverse_ip_count++] = '.';
+				address[reverse_ip_count++] = hex[sa6.sin6_addr.s6_addr[j] >> 4];
+				address[reverse_ip_count++] = '.';
+			}
+			/* Remove the last '.' */
+			address[reverse_ip_count - 1] = 0;
+			return address;
+		}
+		case AF_INET:
+		{
+			unsigned long forward = sa4.sin_addr.s_addr;
+			in_addr rev;
+			rev.s_addr = forward << 24 | (forward & 0xFF00) << 8 | (forward & 0xFF0000) >> 8 | forward >> 24;
+			if (inet_ntop(AF_INET, &rev, address, sizeof(address)))
+				return address;
+			break;
+		}
+	}
+
+	return "";
+}
+
 bool sockaddrs::ipv6() const
 {
 	return sa.sa_family == AF_INET6;


### PR DESCRIPTION
Moved m_dns's reverse ip method to sockaddrs::reverse().
(Since m_dnsbl also relies on it, I thought it would be easier to move it to there where it belongs in order to save duplicate code on something generic)
Updated m_dnsbl to support ipv6.