### PR TITLE
Allow nickserv/update to be called from XMLRPC

### DIFF
--- a/modules/commands/ns_update.cpp
+++ b/modules/commands/ns_update.cpp
@@ -23,14 +23,14 @@ class CommandNSUpdate : public Command
 	{
 		User *u = source.GetUser();
 
-        // XMLRPC: Try to look up the user from their nick
-        if (!u)
-            u = User::Find(source.GetNick(), true);
+		// XMLRPC: Try to look up the user from their nick
+		if (!u)
+			u = User::Find(source.GetNick(), true);
 
-        if (!u)
-        {
-            return;
-        }
+		if (!u)
+		{
+			return;
+		}
 
 		NickAlias *na = NickAlias::Find(u->nick);
 

--- a/modules/commands/ns_update.cpp
+++ b/modules/commands/ns_update.cpp
@@ -17,12 +17,21 @@ class CommandNSUpdate : public Command
 	CommandNSUpdate(Module *creator) : Command(creator, "nickserv/update", 0, 0)
 	{
 		this->SetDesc(_("Updates your current status, i.e. it checks for new memos"));
-		this->RequireUser(true);
 	}
 
 	void Execute(CommandSource &source, const std::vector<Anope::string> &params) anope_override
 	{
 		User *u = source.GetUser();
+
+        // XMLRPC: Try to look up the user from their nick
+        if (!u)
+            u = User::Find(source.GetNick(), true);
+
+        if (!u)
+        {
+            return;
+        }
+
 		NickAlias *na = NickAlias::Find(u->nick);
 
 		if (na && na->nc == source.GetAccount())

--- a/modules/commands/ns_update.cpp
+++ b/modules/commands/ns_update.cpp
@@ -28,9 +28,7 @@ class CommandNSUpdate : public Command
 			u = User::Find(source.GetNick(), true);
 
 		if (!u)
-		{
 			return;
-		}
 
 		NickAlias *na = NickAlias::Find(u->nick);
 


### PR DESCRIPTION
This PR allows the update command to lookup the online user from the supplied username context in an XMLRPC call, instead of silently failing.