### PR TITLE
Allow calls to XMLRPC to impersonate supplied user, if online

### DIFF
--- a/modules/m_xmlrpc_main.cpp
+++ b/modules/m_xmlrpc_main.cpp
@@ -108,16 +108,7 @@ class MyXMLRPCEvent : public XMLRPCEvent
 				}
 				reply(out);
 
-				User *u = NULL;
-				if (!user.empty())
-				{
-					Log(LOG_DEBUG) << "m_xmlrpc_main: user context requested: " << user;
-					u = User::Find(user, true);
-
-					if (u)
-						Log(LOG_DEBUG) << "m_xmlrpc_main: executing as currently online user: " << u->nick;
-				}
-
+				User *u = User::Find(user, true);
 				CommandSource source(user, u, na ? *na->nc : NULL, &reply, bi);
 				Command::Run(source, command);
 

--- a/modules/m_xmlrpc_main.cpp
+++ b/modules/m_xmlrpc_main.cpp
@@ -109,7 +109,8 @@ class MyXMLRPCEvent : public XMLRPCEvent
 				reply(out);
 
 				User *u = NULL;
-				if (user) {
+				if (!user.empty())
+				{
 					Log(LOG_DEBUG) << "m_xmlrpc_main: user context requested: " << user;
 					u = User::Find(user, true);
 

--- a/modules/m_xmlrpc_main.cpp
+++ b/modules/m_xmlrpc_main.cpp
@@ -108,7 +108,11 @@ class MyXMLRPCEvent : public XMLRPCEvent
 				}
 				reply(out);
 
-				CommandSource source(user, NULL, na ? *na->nc : NULL, &reply, bi);
+				User *u = User::Find(user, true);
+				if (u)
+					Log(LOG_DEBUG) << "m_xmlrpc_main: executing as currently online user: " << u->nick;
+
+				CommandSource source(user, u, na ? *na->nc : NULL, &reply, bi);
 				Command::Run(source, command);
 
 				if (!out.empty())

--- a/modules/m_xmlrpc_main.cpp
+++ b/modules/m_xmlrpc_main.cpp
@@ -108,9 +108,14 @@ class MyXMLRPCEvent : public XMLRPCEvent
 				}
 				reply(out);
 
-				User *u = User::Find(user, true);
-				if (u)
-					Log(LOG_DEBUG) << "m_xmlrpc_main: executing as currently online user: " << u->nick;
+				User *u = NULL;
+				if (user) {
+					Log(LOG_DEBUG) << "m_xmlrpc_main: user context requested: " << user;
+					u = User::Find(user, true);
+
+					if (u)
+						Log(LOG_DEBUG) << "m_xmlrpc_main: executing as currently online user: " << u->nick;
+				}
 
 				CommandSource source(user, u, na ? *na->nc : NULL, &reply, bi);
 				Command::Run(source, command);


### PR DESCRIPTION
Some calls require a user object to work properly (NS/UPDATE, NS/GROUP, etc). This PR allows m_xmlrpc_main to lookup user objects by nickname and impersonate that user if they are online, allowing these calls to work.