### PR TITLE
Load sasl module by default.

### DIFF
--- a/data/modules.example.conf
+++ b/data/modules.example.conf
@@ -540,7 +540,7 @@ module { name = "help" }
  * authenticating users through this mechanism. Supported mechanisms are:
  * PLAIN, EXTERNAL.
  */
-#module { name = "m_sasl" }
+module { name = "m_sasl" }
 
 /*
  * m_ssl_gnutls [EXTRA]


### PR DESCRIPTION
I noticed the SASL module is not loaded by default.
May I suggest changing data/modules.example.conf, from:
#module { name = "m_sasl" }
To:
module { name = "m_sasl" }
So more users will benefit from SASL by default?
Together with the saslmechlist (see other report) I'm seriously considering at UnrealIRCd, if no set::sasl-server is set, to automatically set the sasl-server to services-server if the saslmechlist is received from said services-server, since it's a reliable way to tell that SASL is available.

Current SASL support is quite dramatic, see http://ircstats.org/server-features/cap
I want to bump it from the current 9% (and only 3% for UnrealIRCd) to a lot more, but I need your help for this as well.