### PR TITLE
hs_group: Prevent sending duplicate activated messages

### DIFF
--- a/modules/commands/hs_group.cpp
+++ b/modules/commands/hs_group.cpp
@@ -28,7 +28,7 @@ class CommandHSGroup : public Command
 		for (unsigned i = 0; i < na->nc->aliases->size(); ++i)
 		{
 			NickAlias *nick = na->nc->aliases->at(i);
-			if (nick)
+			if (nick && nick != na)
 			{
 				nick->SetVhost(na->GetVhostIdent(), na->GetVhostHost(), na->GetVhostCreator());
 				FOREACH_MOD(OnSetVhost, (nick));


### PR DESCRIPTION
To expand on the commit message a bit:
The duplicate message (as a result of HostServCore::OnSetVhost being called twice for the same NickAlias) happens when `synconset` is enabled and a vHost is set through HostServ (SET, ACTIVATE). Skipping the NickAlias given to Sync() prevents this from happening. As a side effect, `syncongroup` and HostServ GROUP will no longer re-set/activate an already set/active vHost on the NickCore display or command source, respectively. This should still be proper behavior as there's no reason (afaik) to re-set their vHosts.