### PR TITLE
Add InspIRCd 1.2 and 2.0 SVSJOIN workaround

### DIFF
--- a/modules/commands/ns_recover.cpp
+++ b/modules/commands/ns_recover.cpp
@@ -246,13 +246,16 @@ class NSRecover : public Module
 				{
 					Channel *c = Channel::Find(it->first);
 					const Anope::string &cname = it->first;
+					Anope::string key;
 					++it;
 
 					/* User might already be on the channel */
 					if (u->FindChannel(c))
 						this->OnJoinChannel(u, c);
-					else if (IRCD->CanSVSJoin)
-						IRCD->SendSVSJoin(NickServ, u, cname, "");
+					else if (IRCD->CanSVSJoin) {
+						c->GetParam("KEY", key);
+						IRCD->SendSVSJoin(NickServ, u, cname, key);
+					}
 				}
 		}
 

--- a/modules/commands/os_svs.cpp
+++ b/modules/commands/os_svs.cpp
@@ -89,6 +89,7 @@ class CommandOSSVSJoin : public Command
 
 		User *target = User::Find(params[0], true);
 		Channel *c = Channel::Find(params[1]);
+		Anope::string key;
 		if (target == NULL)
 			source.Reply(NICK_X_NOT_IN_USE, params[0].c_str());
 		else if (source.GetUser() != target && (target->IsProtected() || target->server == Me))
@@ -99,7 +100,8 @@ class CommandOSSVSJoin : public Command
 			source.Reply(_("\002%s\002 is already in \002%s\002."), target->nick.c_str(), c->name.c_str());
 		else
 		{
-			IRCD->SendSVSJoin(*source.service, target, params[1], "");
+			c->GetParam("KEY", key);
+			IRCD->SendSVSJoin(*source.service, target, params[1], key);
 			Log(LOG_ADMIN, source, this) << "to force " << target->nick << " to join " << params[1];
 			source.Reply(_("\002%s\002 has been joined to \002%s\002."), target->nick.c_str(), params[1].c_str());
 		}

--- a/modules/protocol/inspircd12.cpp
+++ b/modules/protocol/inspircd12.cpp
@@ -339,8 +339,14 @@ class InspIRCd12Proto : public IRCDProto
 		SendAddLine("Z", x->GetHost(), timeleft, x->by, x->GetReason());
 	}
 
-	void SendSVSJoin(const MessageSource &source, User *u, const Anope::string &chan, const Anope::string &) anope_override
+	void SendSVSJoin(const MessageSource &source, User *u, const Anope::string &chan, const Anope::string &param) anope_override
 	{
+		/* InspIRCd 1.2 and 2.0 have a bug where SVSJOIN cannot join
+		 * users into +k channels. Work around this with sending an
+		 * INVITE message first.
+		 */
+		if (!param.empty())
+			UplinkSocket::Message(source) << "INVITE " << u->GetUID() << " " << chan;
 		UplinkSocket::Message(source) << "SVSJOIN " << u->GetUID() << " " << chan;
 	}
 


### PR DESCRIPTION
`SVSJOIN` is broken on InspIRCd 1.2 and 2.0 for keyed channels (see https://github.com/inspircd/inspircd/pull/892). This is a workaround by issuing an `INVITE` first if necessary. It's still *slightly* confusing to users, but at least they'll actually get joined to the channel.

This commit also makes sure the key parameter is always passed properly to `SendSVSJoin()`.