### PR TITLE
Fix mail sending for reliability.

### DIFF
--- a/src/tools/anopesmtp.cpp
+++ b/src/tools/anopesmtp.cpp
@@ -411,12 +411,40 @@ int smtp_send_email()
 		return 0;
 	}
 
+	if (!smtp_read(buf, 1024))
+	{
+		alog("SMTP: error reading buffer");
+		return 0;
+	}
+
+	code = smtp_get_code(buf);
+	if (code != 250)
+	{
+		alog("SMTP: error expected code 250 got %d",code);
+		return 0;
+	}
+
 	return 1;
 }
 
 void smtp_disconnect()
 {
-	smtp_send("QUIT\r\n");
+	if (!smtp_send("QUIT\r\n"))
+	{
+		alog("SMTP: error writing to socket");
+	}
+
+	if (!smtp_read(buf, 1024))
+	{
+		alog("SMTP: error reading buffer");
+	}
+
+	code = smtp_get_code(buf);
+	if (code != 221)
+	{
+		alog("SMTP: error expected code 221 got %d",code);
+	}
+
 	ano_sockclose(smail.sock);
 }
 


### PR DESCRIPTION
After sending the "\r\n.\r\n" after the mail payload, smtp_send_email was not waiting for the mail server to complete post-processing and respond with "250", but was sending "QUIT\r\n" immediately and dropping the connection.  Mail server may kill the transaction if it can't send the "250" (socket closed).  The changes proposed completes the mail transaction by reading for the 250 and in smtp_disconnect steps through a proper quit sequence by waiting for the 221 server response.

I discovered this by including the --debug option in services.conf sendmailpath, which invoked logging in smtp_send and that slowed it down enough for the mail server to return the 250 and complete the transaction.