### PR TITLE
Memo deletion: add new privilege and some logging

### DIFF
--- a/data/chanserv.example.conf
+++ b/data/chanserv.example.conf
@@ -519,7 +519,7 @@ privilege
 /*
  * MEMO privilege.
  *
- * Used by memoserv/del, memoserv/ignore, memoserv/info, memoserv/list,
+ * Used by memoserv/ignore, memoserv/info, memoserv/list,
  * memoserv/main, memoserv/read and memoserv/set.
  *
  * Users with this permission can manage channel memos.
@@ -528,6 +528,22 @@ privilege
 {
 	name = "MEMO"
 	rank = 280
+	level = 10
+	flag = "m"
+	xop = "SOP"
+}
+
+/*
+ * MEMODEL privilege.
+ *
+ * Used by memoserv/del.
+ *
+ * Users with this permission can delete channel memos.
+ */
+privilege
+{
+	name = "MEMODEL"
+	rank = 290
 	level = 10
 	flag = "m"
 	xop = "SOP"

--- a/language/anope.en_US.po
+++ b/language/anope.en_US.po
@@ -2513,6 +2513,10 @@ msgstr "Allowed to modify the access list"
 msgid "Allowed to read channel memos"
 msgstr "Allowed to read channel memos"
 
+#: src/access.cpp:45
+msgid "Allowed to delete channel memos"
+msgstr "Allowed to delete channel memos"
+
 #: src/access.cpp:54
 msgid "Allowed to set channel settings"
 msgstr "Allowed to set channel settings"

--- a/modules/commands/ms_del.cpp
+++ b/modules/commands/ms_del.cpp
@@ -65,7 +65,7 @@ class CommandMSDel : public Command
 				source.Reply(CHAN_X_NOT_REGISTERED, chan.c_str());
 				return;
 			}
-			else if (!source.AccessFor(ci).HasPriv("MEMO"))
+			else if (!source.AccessFor(ci).HasPriv("MEMODEL"))
 			{
 				source.Reply(ACCESS_DENIED);
 				return;

--- a/modules/commands/ms_del.cpp
+++ b/modules/commands/ms_del.cpp
@@ -14,10 +14,11 @@
 class MemoDelCallback : public NumberList
 {
 	CommandSource &source;
+	Command *cmd;
 	ChannelInfo *ci;
 	MemoInfo *mi;
  public:
-	MemoDelCallback(CommandSource &_source, ChannelInfo *_ci, MemoInfo *_mi, const Anope::string &list) : NumberList(list, true), source(_source), ci(_ci), mi(_mi)
+	MemoDelCallback(CommandSource &_source, Command *c, ChannelInfo *_ci, MemoInfo *_mi, const Anope::string &list) : NumberList(list, true), source(_source), cmd(c), ci(_ci), mi(_mi)
 	{
 	}
 
@@ -30,6 +31,8 @@ class MemoDelCallback : public NumberList
 
 		mi->Del(number - 1);
 		source.Reply(_("Memo %d has been deleted."), number);
+		if(ci)
+			Log(LOG_COMMAND, source, cmd, ci) << "on memo " << number ;
 	}
 };
 
@@ -87,7 +90,7 @@ class CommandMSDel : public Command
 		{
 			if (isdigit(numstr[0]))
 			{
-				MemoDelCallback list(source, ci, mi, numstr);
+				MemoDelCallback list(source, this, ci, mi, numstr);
 				list.Process();
 			}
 			else if (numstr.equals_ci("LAST"))
@@ -96,6 +99,8 @@ class CommandMSDel : public Command
 				FOREACH_MOD(OnMemoDel, (ci ? ci->name : source.nc->display, mi, mi->GetMemo(mi->memos->size() - 1)));
 				mi->Del(mi->memos->size() - 1);
 				source.Reply(_("Memo %d has been deleted."), mi->memos->size() + 1);
+				if(ci)
+					Log(LOG_COMMAND, source, this, ci) << "on LAST memo";
 			}
 			else
 			{
@@ -106,7 +111,10 @@ class CommandMSDel : public Command
 					mi->Del(i - 1);
 				}
 				if (!chan.empty())
+				{
 					source.Reply(_("All memos for channel %s have been deleted."), chan.c_str());
+					Log(LOG_COMMAND, source, this, ci) << "on ALL memos";
+				}
 				else
 					source.Reply(_("All of your memos have been deleted."));
 			}

--- a/src/access.cpp
+++ b/src/access.cpp
@@ -42,6 +42,7 @@ static struct
 	{"INVITE", _("Allowed to use the INVITE command")},
 	{"KICK", _("Allowed to use the KICK command")},
 	{"MEMO", _("Allowed to read channel memos")},
+	{"MEMODEL", _("Allowed to delete channel memos")},
 	{"MODE", _("Allowed to use the MODE command")},
 	{"NOKICK", _("Prevents users being kicked by Services")},
 	{"OP", _("Allowed to (de)op users")},


### PR DESCRIPTION
Any user with the MEMO privilege can delete a channel memo without leaving a trace. These two commits add a MEMODEL privilege and generates logs every time a channel memo is deleted.