### PR TITLE
Update anope.example.conf

### DIFF
--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -134,22 +134,31 @@ define
  *     <uline server="services.localhost.net" silent="yes">
  *     <bind address="127.0.0.1" port="7000" type="servers">
  *
- * An example configuration for UnrealIRCd that is compatible with the below uplink
+ * An example configuration for UnrealIRCd 4.x (3.2 series are deprecated) that is compatible with the below uplink
  * and serverinfo configuration would look like:
+ *
+ *	listen {
+ *	     ip 127.0.0.1;
+ *	     port 7000;
+ *	     options {
+ *		serversonly;
+ *	     };
+ *	};
  *
  *     link services.localhost.net
  *     {
- *          username *;
- *          hostname *;
- *          bind-ip "127.0.0.1";
- *          port 7000;
- *          hub *;
- *          password-connect "mypassword";
- *          password-receive "mypassword";
+ *          incoming {
+ *          	mask *@127.0.0.1;
+ *          };
+ *         outgoing { 
+ *          	bind-ip 127.0.0.1;
+ *          	hostname 127.0.0.1;
+ *          	port 7000;
+ *          };
+ *          password "mypassword";
  *          class servers;
- *     };
+ *      };
  *     ulines { services.localhost.net; };
- *     listen 127.0.0.1:7000;
  */
 uplink
 {

--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -134,31 +134,31 @@ define
  *     <uline server="services.localhost.net" silent="yes">
  *     <bind address="127.0.0.1" port="7000" type="servers">
  *
- * An example configuration for UnrealIRCd 4.x (3.2 series are deprecated) that is compatible with the below uplink
+ * An example configuration for UnrealIRCd 4.x that is compatible with the below uplink
  * and serverinfo configuration would look like:
  *
- *	listen {
- *	     ip 127.0.0.1;
- *	     port 7000;
- *	     options {
- *		serversonly;
- *	     };
- *	};
+ * listen {
+ *   ip 127.0.0.1;
+ *   port 7000;
+ *    options {
+ *     serversonly;
+ *    };
+ * };
  *
- *     link services.localhost.net
- *     {
- *          incoming {
- *          	mask *@127.0.0.1;
- *          };
- *         outgoing { 
- *          	bind-ip 127.0.0.1;
- *          	hostname 127.0.0.1;
- *          	port 7000;
- *          };
- *          password "mypassword";
- *          class servers;
- *      };
- *     ulines { services.localhost.net; };
+ * link services.localhost.net
+ * {
+ *   incoming {
+ *    mask *@127.0.0.1;
+ *   };
+ *   outgoing { 
+ *    bind-ip 127.0.0.1;
+ *    hostname 127.0.0.1;
+ *    port 7000;
+ *   };
+ *   password "mypassword";
+ *   class servers;
+ * };
+ * ulines { services.localhost.net; };
  */
 uplink
 {

--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -145,15 +145,9 @@ define
  *    };
  * };
  *
- * link services.localhost.net
- * {
+ * link services.localhost.net {
  *   incoming {
  *    mask *@127.0.0.1;
- *   };
- *   outgoing { 
- *    bind-ip 127.0.0.1;
- *    hostname 127.0.0.1;
- *    port 7000;
  *   };
  *   password "mypassword";
  *   class servers;


### PR DESCRIPTION
Updated the configuration example to match the new syntax of listen and link blocks of UnrealIRCd 4.x, since 3.2 is deprecated and no longer supported by UnrealIRCd team.