### PR TITLE
modules/dns: NotifySocket takes a bool parameter, not int address family

### DIFF
--- a/modules/dns.cpp
+++ b/modules/dns.cpp
@@ -976,7 +976,7 @@ class MyManager : public Manager, public Timer
 
 			packet->questions.push_back(Question(zone, QUERY_SOA));
 
-			new NotifySocket(ip.find(':') != Anope::string::npos ? AF_INET6 : AF_INET, packet);
+			new NotifySocket(ip.find(':') != Anope::string::npos, packet);
 		}
 	}
 


### PR DESCRIPTION
gcc warning: ?: using integer constants in boolean context, the expression will always evaluate to ‘true’ [-Wint-in-bool-context]