### PR TITLE
Fix for translations being ignored in cs_seen.cpp

### DIFF
--- a/modules/commands/cs_seen.cpp
+++ b/modules/commands/cs_seen.cpp
@@ -300,7 +300,7 @@ class CommandSeen : public Command
 		if (u2)
 			onlinestatus = ".";
 		else
-			onlinestatus = Anope::printf(_(" but %s mysteriously dematerialized."), target.c_str());
+			onlinestatus = Anope::printf(Language::Translate(source.nc, _(" but %s mysteriously dematerialized.")), target.c_str());
 
 		Anope::string timebuf = Anope::Duration(Anope::CurTime - info->last, source.nc);
 		Anope::string timebuf2 = Anope::strftime(info->last, source.nc, true);
@@ -314,9 +314,9 @@ class CommandSeen : public Command
 		{
 			u2 = User::Find(info->nick2, true);
 			if (u2)
-				onlinestatus = Anope::printf( _(". %s is still online."), u2->nick.c_str());
+				onlinestatus = Anope::printf(Language::Translate(source.nc, _(". %s is still online.")), u2->nick.c_str());
 			else
-				onlinestatus = Anope::printf(_(", but %s mysteriously dematerialized."), info->nick2.c_str());
+				onlinestatus = Anope::printf(Language::Translate(source.nc, _(", but %s mysteriously dematerialized.")), info->nick2.c_str());
 
 			source.Reply(_("%s (%s) was last seen changing nick to %s %s ago%s"),
 				target.c_str(), info->vhost.c_str(), info->nick2.c_str(), timebuf.c_str(), onlinestatus.c_str());


### PR DESCRIPTION
These strings: " but %s mysteriously dematerialized.", ". %s is still online." and ", but %s mysteriously dematerialized." weren't translated by the method Anope::printf().