### PR TITLE
Fix for bug 1712

### DIFF
--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -651,7 +651,7 @@ struct IRCDMessageCapab : Message::Capab
 				if (capab.find("CHANMODES") != Anope::string::npos)
 				{
 					Anope::string modes(capab.begin() + 10, capab.end());
-					commasepstream sep(modes);
+					commasepstream sep(modes, true);
 					Anope::string modebuf;
 
 					sep.GetToken(modebuf);
@@ -689,7 +689,7 @@ struct IRCDMessageCapab : Message::Capab
 				else if (capab.find("USERMODES") != Anope::string::npos)
 				{
 					Anope::string modes(capab.begin() + 10, capab.end());
-					commasepstream sep(modes);
+					commasepstream sep(modes, true);
 					Anope::string modebuf;
 
 					sep.GetToken(modebuf);


### PR DESCRIPTION
The not explicitly checked for (chan,user)modes in their inital `CAPAB` string are added to a list to be properly added as a Mode during the `CAPABILITIES` line. The logic for both `CHANMODES` and `USERMODES` needs the `commasepstream` to allow empty values to correctly match up at times.
For example: `USERMODES=,,s,BHIRSWcdghikorwx` had the first token returned as `s` and second token as `BHIRSWcdghikorwx` but the code ignores the first two tokens.
Allowing empty values matches things up properly no matter the modes available on Insp and fixes OS UMODE not working for "extra" modes. Usermode 's' (snomask) was also unable to be set/unset with OS UMODE previously and can be now (though you still can't set the parameters this way, only set/unset the mode).