### PR TITLE
Disable the os_oline module by default.

### DIFF
--- a/data/operserv.example.conf
+++ b/data/operserv.example.conf
@@ -511,11 +511,11 @@ command { service = "OperServ"; name = "NOOP"; command = "operserv/noop"; permis
  *
  * Provides the command operserv/oline.
  *
- * Used to set oper flags on users, and is specific to UnrealIRCd.
+ * Used to set oper flags on users, and is specific to UnrealIRCd 3.2.
  * See /helpop ?svso on your IRCd for more information.
  */
-module { name = "os_oline" }
-command { service = "OperServ"; name = "OLINE"; command = "operserv/oline"; permission = "operserv/oline"; }
+#module { name = "os_oline" }
+#command { service = "OperServ"; name = "OLINE"; command = "operserv/oline"; permission = "operserv/oline"; }
 
 /*
  * os_oper


### PR DESCRIPTION
This only works on UnrealIRCd 3.2 (which has been EOL for over a year now) and regularly confuses users who think that "your IRCd does not support OMODE" is an error they need to fix.