### PR TITLE
Show NickServ SET MESSAGE in help when 'useprivmsg' is enabled

### DIFF
--- a/modules/commands/ns_set.cpp
+++ b/modules/commands/ns_set.cpp
@@ -963,7 +963,7 @@ class CommandNSSetMessage : public Command
 
 	void OnServHelp(CommandSource &source) anope_override
 	{
-		if (!Config->GetBlock("options")->Get<bool>("useprivmsg"))
+		if (Config->GetBlock("options")->Get<bool>("useprivmsg"))
 			Command::OnServHelp(source);
 	}
 };


### PR DESCRIPTION
The current if statement is backwards, hiding the command when it can be set and displaying it when it cannot be set.