### PR TITLE
Check for 'hide' flag in commands in (bs,cs,ns)_set HELP

### DIFF
--- a/modules/commands/bs_set.cpp
+++ b/modules/commands/bs_set.cpp
@@ -41,6 +41,9 @@ class CommandBSSet : public Command
 			const CommandInfo &info = it->second;
 			if (c_name.find_ci(this_name + " ") == 0)
 			{
+				if (info.hide)
+					continue;
+
 				ServiceReference<Command> command("Command", info.name);
 				if (command)
 				{

--- a/modules/commands/cs_set.cpp
+++ b/modules/commands/cs_set.cpp
@@ -43,6 +43,9 @@ class CommandCSSet : public Command
 			const CommandInfo &info = it->second;
 			if (c_name.find_ci(this_name + " ") == 0)
 			{
+				if (info.hide)
+					continue;
+
 				ServiceReference<Command> c("Command", info.name);
 
 				// XXX dup

--- a/modules/commands/ns_set.cpp
+++ b/modules/commands/ns_set.cpp
@@ -42,6 +42,9 @@ class CommandNSSet : public Command
 
 			if (c_name.find_ci(this_name + " ") == 0)
 			{
+				if (info.hide)
+					continue;
+
 				ServiceReference<Command> c("Command", info.name);
 				// XXX dup
 				if (!c)


### PR DESCRIPTION
This code is duplicated from help.cpp to (bs,cs,ns)_set.cpp for listing
the available SET commands. The check for the 'hide' flag was missed
and this incorrectly listed commands that were configured as hidden.

This was reported by DeviL on IRC about a month ago. 