### PR TITLE
Send the casemap as part of CAPAB CAPABILITIES on InspIRCd.

### DIFF
--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -37,7 +37,7 @@ class InspIRCd20Proto : public IRCDProto
 	void SendConnect() anope_override
 	{
 		UplinkSocket::Message() << "CAPAB START 1202";
-		UplinkSocket::Message() << "CAPAB CAPABILITIES :PROTOCOL=1202";
+		UplinkSocket::Message() << "CAPAB CAPABILITIES :PROTOCOL=1202 CASEMAPPING=" << Config->GetBlock("options")->Get<const Anope::string>("casemap", "ascii");
 		UplinkSocket::Message() << "CAPAB END";
 		insp12->SendConnect();
 	}


### PR DESCRIPTION
This is technically part of the 1205 protocol but it is entirely backwards compatible so older versions will not be negatively affected by this.