### PR TITLE
Allow multiple IP addresses in extforward_ip separated by spaces

### DIFF
--- a/data/modules.example.conf
+++ b/data/modules.example.conf
@@ -223,8 +223,9 @@ module { name = "help" }
 		 * extforward_headers set below, set this to its IP.
 		 * This allows services to obtain the real IP of users by
 		 * reading the forwarded-for HTTP header.
+		 * Multiple IP addresses can be specified separated by a space character.
 		 */
-		#extforward_ip = "192.168.0.255"
+		#extforward_ip = "192.168.0.255 192.168.1.255"
 
 		/* The header to look for. These probably work as is. */
 		extforward_header = "X-Forwarded-For Forwarded-For"

--- a/include/modules/httpd.h
+++ b/include/modules/httpd.h
@@ -141,7 +141,7 @@ class HTTPProvider : public ListenSocket, public Service
 	unsigned short port;
 	bool ssl;
  public:
-	Anope::string ext_ip;
+	std::vector<Anope::string> ext_ips;
 	std::vector<Anope::string> ext_headers;
 
 	HTTPProvider(Module *c, const Anope::string &n, const Anope::string &i, const unsigned short p, bool s) : ListenSocket(i, p, i.find(':') != Anope::string::npos), Service(c, "HTTPProvider", n), ip(i), port(p), ssl(s) { }

--- a/modules/m_httpd.cpp
+++ b/modules/m_httpd.cpp
@@ -67,7 +67,7 @@ class MyHTTPClient : public HTTPClient
 			return;
 		}
 
-		if (this->ip == this->provider->ext_ip)
+		if (std::find(this->provider->ext_ips.begin(), this->provider->ext_ips.end(), this->ip) != this->provider->ext_ips.end())
 		{
 			for (unsigned i = 0; i < this->provider->ext_headers.size(); ++i)
 			{
@@ -435,7 +435,7 @@ class HTTPD : public Module
 			}
 
 
-			p->ext_ip = ext_ip;
+			spacesepstream(ext_ip).GetTokens(p->ext_ips);
 			spacesepstream(ext_header).GetTokens(p->ext_headers);
 		}
 


### PR DESCRIPTION
This mimics the behavior of `extforward_header` to allow multiple IPs in the `extforward_ip` config option. This is especially useful as most reverse proxies will either use multiple IPs (eg. v4 and v6) or a user may have multiple reverse proxies.