### PR TITLE
Allow post-handshake SASL in UnrealIRCd 4.2.2 and up.

### DIFF
--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -381,7 +381,9 @@ class UnrealIRCdProto : public IRCDProto
 			if (!s)
 				return;
 			distmask = s->GetName();
-		} else {
+		}
+		else
+		{
 			distmask = message.target.substr(0, p);
 		}
 

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -399,7 +399,9 @@ class UnrealIRCdProto : public IRCDProto
 			if (!s)
 				return;
 			distmask = s->GetName();
-		} else {
+		}
+		else
+		{
 			distmask = uid.substr(0, p);
 		}
 		UplinkSocket::Message(Me) << "SVSLOGIN " << distmask << " " << uid << " " << acc;

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -373,18 +373,36 @@ class UnrealIRCdProto : public IRCDProto
 	void SendSASLMessage(const SASL::Message &message) anope_override
 	{
 		size_t p = message.target.find('!');
-		if (p == Anope::string::npos)
-			return;
+		Anope::string distmask;
 
-		UplinkSocket::Message(BotInfo::Find(message.source)) << "SASL " << message.target.substr(0, p) << " " << message.target << " " << message.type << " " << message.data << (message.ext.empty() ? "" : " " + message.ext);
+		if (p == Anope::string::npos)
+		{
+			Server *s = Server::Find(message.target.substr(0, 3));
+			if (!s)
+				return;
+			distmask = s->GetName();
+		} else {
+			distmask = message.target.substr(0, p);
+		}
+
+		UplinkSocket::Message(BotInfo::Find(message.source)) << "SASL " << distmask << " " << message.target << " " << message.type << " " << message.data << (message.ext.empty() ? "" : " " + message.ext);
 	}
 
 	void SendSVSLogin(const Anope::string &uid, const Anope::string &acc, const Anope::string &vident, const Anope::string &vhost) anope_override
 	{
 		size_t p = uid.find('!');
+		Anope::string distmask;
+
 		if (p == Anope::string::npos)
-			return;
-		UplinkSocket::Message(Me) << "SVSLOGIN " << uid.substr(0, p) << " " << uid << " " << acc;
+		{
+			Server *s = Server::Find(uid.substr(0, 3));
+			if (!s)
+				return;
+			distmask = s->GetName();
+		} else {
+			distmask = uid.substr(0, p);
+		}
+		UplinkSocket::Message(Me) << "SVSLOGIN " << distmask << " " << uid << " " << acc;
 	}
 
 	bool IsIdentValid(const Anope::string &ident) anope_override
@@ -1005,8 +1023,7 @@ struct IRCDMessageSASL : IRCDMessage
 
 	void Run(MessageSource &source, const std::vector<Anope::string> &params) anope_override
 	{
-		size_t p = params[1].find('!');
-		if (!SASL::sasl || p == Anope::string::npos)
+		if (!SASL::sasl)
 			return;
 
 		SASL::Message m;


### PR DESCRIPTION
This updates the unreal4 protocol module to work with both pseudo-id's
and real UID's. Something that will also be necessary once UnrealIRCd
gets rid of pseudo-id's altogether.