### PR TITLE
Update nickserv.example.conf regarding "addaccessonreg" feature

### DIFF
--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -261,7 +261,7 @@ module
 	 * being recognized, unless they manually add an address to the access list of their account.
 	 * This directive is optional.
 	 */
-	addaccessonreg = yes
+	addaccessonreg = no
 }
 command { service = "NickServ"; name = "ACCESS"; command = "nickserv/access"; }
 


### PR DESCRIPTION
When set to `yes` this breaks the `killprotect` functionality, because a user is expected to turn into guest after the specified amount of time.
Also new users that register their nicknames will wonder why they can't join a +R channel but they didn't change their nick to Guest*