### PR TITLE
Mark pseudoclients as bots on InspIRCd if the bot mode exists.

### DIFF
--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -410,6 +410,7 @@ struct IRCDMessageCapab : Message::Capab
 			Servers::Capab.insert("SERVERS");
 			Servers::Capab.insert("TOPICLOCK");
 			IRCD->CanSVSHold = false;
+			IRCD->DefaultPseudoclientModes = "+I";
 		}
 		else if (params[0].equals_cs("CHANMODES") && params.size() > 1)
 		{

--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -562,7 +562,10 @@ struct IRCDMessageCapab : Message::Capab
 				UserMode *um = NULL;
 
 				if (modename.equals_cs("bot"))
+				{
 					um = new UserMode("BOT", modechar[0]);
+					IRCD->DefaultPseudoclientModes += modechar;
+				}
 				else if (modename.equals_cs("callerid"))
 					um = new UserMode("CALLERID", modechar[0]);
 				else if (modename.equals_cs("cloak"))


### PR DESCRIPTION
This will allow their messages to be marked as originating from bots on InspIRCd v3 (ref: https://github.com/inspircd/inspircd/commit/180b8b6ab194fd74cb5c64fc3ec0775eb542451a).