### PR TITLE
Fix NickServ INFO and GLIST showing an incorrect unconfirmed expiry.

### DIFF
--- a/modules/commands/ns_group.cpp
+++ b/modules/commands/ns_group.cpp
@@ -326,7 +326,7 @@ class CommandNSGList : public Command
 		ListFormatter list(source.GetAccount());
 		list.AddColumn(_("Nick")).AddColumn(_("Expires"));
 		time_t nickserv_expire = Config->GetModule("nickserv")->Get<time_t>("expire", "21d"),
-		       unconfirmed_expire = Config->GetModule("nickserv")->Get<time_t>("unconfirmedexpire", "1d");
+		       unconfirmed_expire = Config->GetModule("ns_register")->Get<time_t>("unconfirmedexpire", "1d");
 		for (unsigned i = 0; i < nc->aliases->size(); ++i)
 		{
 			const NickAlias *na2 = nc->aliases->at(i);

--- a/modules/pseudoclients/nickserv.cpp
+++ b/modules/pseudoclients/nickserv.cpp
@@ -558,7 +558,7 @@ class NickServCore : public Module, public NickServService
 		}
 		else
 		{
-			time_t unconfirmed_expire = Config->GetModule(this)->Get<time_t>("unconfirmedexpire", "1d");
+			time_t unconfirmed_expire = Config->GetModule("ns_register")->Get<time_t>("unconfirmedexpire", "1d");
 			info[_("Expires")] = Anope::strftime(na->time_registered + unconfirmed_expire, source.GetAccount());
 		}
 	}


### PR DESCRIPTION
The config option `unconfirmedexpire` is under the module `ns_register` not the base `nickserv` module.

Reported by @KoraggKnightWolf via IRC.
Thanks to @Adam- for catching the second spot (ns_group.cpp).