### PR TITLE
inspircd protocols: Update IRCDMessageMetadata for channel metadata.

### DIFF
--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -923,7 +923,7 @@ class IRCDMessageMetadata : IRCDMessage
 				}
 				else if ((do_topiclock) && (params[1] == "topiclock"))
 				{
-					bool mystate = c->ci->GetExt<bool>("TOPICLOCK");
+					bool mystate = c->ci->HasExt("TOPICLOCK");
 					bool serverstate = (params[2] == "1");
 					if (mystate != serverstate)
 						UplinkSocket::Message(Me) << "METADATA " << c->name << " topiclock :" << (mystate ? "1" : "");


### PR DESCRIPTION
InspIRCd 3 now includes the channel TS in any channel metadata. This requires two changes to how it's handled in this function **(note: this section is only ran for a bursting server):**
- increase the type and value parameter indexes by one.
- update the messages sent from this function to include the TS (creation time).

While testing this I also noticed a minor issue with the topiclock state lookup, `GetExt<bool>("TOPICLOCK")` is always returning a NULL pointer (due to being a `SerializableExtensibleItem<bool>` which by design does not create an object). When the bursting server says topiclock is enabled, this will cause services to disable it. Note: upon services connecting to an uplink it will be enabled again shortly after during OnChannelSync() which runs OnChanRegistered() and sets any modelocks and/or topiclock. See log snippet:
```
[Nov 14 11:32:57.535253 2019] Debug: Received: :715 METADATA #area51 1573731059 mlock :nt
[Nov 14 11:32:57.535326 2019] Debug: Received: :715 METADATA #area51 1573731059 topiclock :1
[Nov 14 11:32:57.535385 2019] Debug: Sent: :00B METADATA #area51 1573731059 topiclock :
[Nov 14 11:32:57.536358 2019] Debug: Received: :715 ENDBURST
[Nov 14 11:32:57.536396 2019] Debug: Processed ENDBURST for earth.area51.g3ktest.net
[Nov 14 11:32:57.536427 2019] SERVER: earth.area51.g3ktest.net (Earth's Area51 - We cannot say more!) is done syncing
[Nov 14 11:32:57.537399 2019] Debug: Sent: :00B METADATA * saslmechlist :EXTERNAL,PLAIN
[Nov 14 11:32:57.537484 2019] Debug: Sent: :00B METADATA #area51 1573731059 mlock :nt
[Nov 14 11:32:57.537527 2019] Debug: Sent: :00B METADATA #area51 1573731059 topiclock :1
[Nov 14 11:32:57.538528 2019] Debug: Sent: :00B ENDBURST
[Nov 14 11:32:57.538570 2019] SERVER: services.area51 (Network Services) is done syncing
```
Changing `GetExt<bool>` to `HasExt` which is used in OnChanRegistered() returns the accurate boolean and the state is compared properly. See log snippet:
```
[Nov 14 11:35:51.614027 2019] Debug: Received: :715 METADATA #area51 1573731059 mlock :nt
[Nov 14 11:35:51.614102 2019] Debug: Received: :715 METADATA #area51 1573731059 topiclock :1
[Nov 14 11:35:51.614455 2019] Debug: Received: :715 ENDBURST
[Nov 14 11:35:51.614490 2019] Debug: Processed ENDBURST for earth.area51.g3ktest.net
[Nov 14 11:35:51.614518 2019] SERVER: earth.area51.g3ktest.net (Earth's Area51 - We cannot say more!) is done syncing
[Nov 14 11:35:51.614557 2019] Debug: Sent: :00B METADATA * saslmechlist :EXTERNAL,PLAIN
[Nov 14 11:35:51.614611 2019] Debug: Sent: :00B METADATA #area51 1573731059 mlock :nt
[Nov 14 11:35:51.614650 2019] Debug: Sent: :00B METADATA #area51 1573731059 topiclock :1
[Nov 14 11:35:51.614772 2019] Debug: Sent: :00B ENDBURST
[Nov 14 11:35:51.614804 2019] SERVER: services.area51 (Network Services) is done syncing
```
~~It's a very minor issue since OnChannelSync() gets everything set correctly, nevertheless it's incorrectly disabling topiclock momentarily as is. This actually creates the question of whether we need to even receive, compare, and check this information from a bursting server. If OnChannelSync() is always called when we burst to a server, the modelocks and topiclock will always be set correctly. I'll run a few more tests.~~ I was unsure if OnChannelSync() ran for other servers connecting. Ran some tests and reviewed the code, learnt that it doesn't as the channel would already be synced. So this metadata code is required to ensure any other server but the direct uplink has their modelocks/topiclock corrected.
This exposed the same error in the **inspircd20** protocol module. Another commit has been added to correct that.