### PR TITLE
Display banexpire value on botserv/info

### DIFF
--- a/modules/commands/bs_info.cpp
+++ b/modules/commands/bs_info.cpp
@@ -85,6 +85,7 @@ class CommandBSInfo : public Command
 
 			source.Reply(CHAN_INFO_HEADER, ci->name.c_str());
 			info[_("Bot nick")] = ci->bi ? ci->bi->nick : _("not assigned yet");
+			info[_("Ban expiration")] = stringify(ci->banexpire);
 
 			Anope::string enabled = Language::Translate(source.nc, _("Enabled"));
 			Anope::string disabled = Language::Translate(source.nc, _("Disabled"));


### PR DESCRIPTION
This displays the "banexpire" value information due /bs info #chan 
if not set any then it displays 0 
(i wish to know how to add a convert method to minutes in brackets e.g: SECONDS (MINUTES) but anyway)