### PR TITLE
Fix the handling of kick messages with InspIRCd v3.

### DIFF
--- a/modules/protocol/inspircd3.cpp
+++ b/modules/protocol/inspircd3.cpp
@@ -1250,11 +1250,13 @@ struct IRCDMessageKick : IRCDMessage
 
 	void Run(MessageSource &source, const std::vector<Anope::string> &params) anope_override
 	{
+		// Received: :715AAAAAA KICK #chan 715AAAAAD :reason
+		// Received: :715AAAAAA KICK #chan 628AAAAAA 4 :reason
 		Channel *c = Channel::Find(params[0]);
-		if (c)
+		if (!c)
 			return;
 
-		const Anope::string &reason = params.size() > 3 ? params[3] : "";
+		const Anope::string &reason = params.size() > 3 ? params[3] : params[2];
 		c->KickInternal(source, params[1], reason);
 	}
 };


### PR DESCRIPTION
* Fix an inverted if statement.
* Fix setting of the reason, it will always be included in the message from what I can find (minimum parameters is 3); just might be the 3rd or the 4th parameter depending on if the target's membership ID is included or not.

This currently causes weird desyncs since the user isn't removed internally. Credit to @Techman for spotting this as rejoining after a kick resulted in not receiving the expected status modes.
I have tested this on my testnet, both with a local and a remote user; works as expected.