### PR TITLE
Improve wording of the resetpass:confirm log message.

### DIFF
--- a/modules/commands/ns_resetpass.cpp
+++ b/modules/commands/ns_resetpass.cpp
@@ -100,7 +100,7 @@ class NSResetPass : public Module
 					reset.Unset(nc);
 					nc->Shrink<bool>("UNCONFIRMED");
 
-					Log(LOG_COMMAND, source, &commandnsresetpass) << "confirmed RESETPASS to forcefully identify as " << na->nick;
+					Log(LOG_COMMAND, source, &commandnsresetpass) << "to confirm RESETPASS and forcefully identify as " << na->nick;
 
 					if (source.GetUser())
 					{


### PR DESCRIPTION
The current wording doesn't work with the `used <command>` added in the log function.

Current log message: `COMMAND: test!g3k@g3k.solutions used CONFIRM confirmed RESETPASS to forcefully identify as test`

New log message: `COMMAND: test!g3k@g3k.solutions used CONFIRM to confirm RESETPASS and forcefully identify as test`