### PR TITLE
Update unreal4.cpp

### DIFF
--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -78,18 +78,7 @@ class UnrealIRCdProto : public IRCDProto
 	void SendVhostDel(User *u) anope_override
 	{
 		BotInfo *HostServ = Config->GetClient("HostServ");
-		/* Should we unset the cloak (umode +x)? If the IRC client has no support to the CHGHOST cap
-		 * then the user real IP is displayed for a fraction of a second which is bad
-		 * For security, we only remove the vhost (umode -t) without touching the cloak
-		 * Line is only commented as it might be useful in a near future
-		 */
-		// u->RemoveMode(HostServ, "CLOAK");
 		u->RemoveMode(HostServ, "VHOST");
-		/* Because the change above this is no longer needed
-		 * Commented as it might be useful in a near future
-		 */
-		// ModeManager::ProcessModes();
-		// u->SetMode(HostServ, "CLOAK");
 	}
 
 	void SendAkill(User *u, XLine *x) anope_override
@@ -215,11 +204,6 @@ class UnrealIRCdProto : public IRCDProto
 			UplinkSocket::Message(Me) << "CHGHOST " << u->GetUID() << " " << vhost;
 		// Internally unreal sets +xt on chghost
 		BotInfo *bi = Config->GetClient("HostServ");
-		/* If user is already uncloaked (umode -x) due to personal choice or IRCd config
-		 * we shouldn't force the cloak in that case. Line commented because it might be useful in a near future
-		 */
-		// u->SetMode(bi, "CLOAK");
-		/* This is where se set the vHost */
 		u->SetMode(bi, "VHOST");
 	}
 

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -78,7 +78,18 @@ class UnrealIRCdProto : public IRCDProto
 	void SendVhostDel(User *u) anope_override
 	{
 		BotInfo *HostServ = Config->GetClient("HostServ");
+		/* Should we unset the cloak (umode +x)? If the IRC client has no support to the CHGHOST cap
+		 * then the user real IP is displayed for a fraction of a second which is bad
+		 * For security, we only remove the vhost (umode -t) without touching the cloak
+		 * Line is only commented as it might be useful in a near future
+		 */
+		// u->RemoveMode(HostServ, "CLOAK");
 		u->RemoveMode(HostServ, "VHOST");
+		/* Because the change above this is no longer needed
+		 * Commented as it might be useful in a near future
+		 */
+		// ModeManager::ProcessModes();
+		// u->SetMode(HostServ, "CLOAK");
 	}
 
 	void SendAkill(User *u, XLine *x) anope_override
@@ -204,9 +215,11 @@ class UnrealIRCdProto : public IRCDProto
 			UplinkSocket::Message(Me) << "CHGHOST " << u->GetUID() << " " << vhost;
 		// Internally unreal sets +xt on chghost
 		BotInfo *bi = Config->GetClient("HostServ");
-		// If the user was previously -x by default (or by admin choice in the IRCd config)
-		// we shouldn't force the cloak on the user. Commented in case we might need it later
+		/* If user is already uncloaked (umode -x) due to personal choice or IRCd config
+		 * we shouldn't force the cloak in that case. Line commented because it might be useful in a near future
+		 */
 		// u->SetMode(bi, "CLOAK");
+		/* This is where se set the vHost */
 		u->SetMode(bi, "VHOST");
 	}
 

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -204,7 +204,9 @@ class UnrealIRCdProto : public IRCDProto
 			UplinkSocket::Message(Me) << "CHGHOST " << u->GetUID() << " " << vhost;
 		// Internally unreal sets +xt on chghost
 		BotInfo *bi = Config->GetClient("HostServ");
-		u->SetMode(bi, "CLOAK");
+		// If the user was previously -x by default (or by admin choice in the IRCd config)
+		// we shouldn't force the cloak on the user. Commented in case we might need it later
+		// u->SetMode(bi, "CLOAK");
 		u->SetMode(bi, "VHOST");
 	}
 

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -79,8 +79,6 @@ class UnrealIRCdProto : public IRCDProto
 	{
 		BotInfo *HostServ = Config->GetClient("HostServ");
 		u->RemoveMode(HostServ, "VHOST");
-		ModeManager::ProcessModes();
-		u->SetMode(HostServ, "CLOAK");
 	}
 
 	void SendAkill(User *u, XLine *x) anope_override

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -78,7 +78,6 @@ class UnrealIRCdProto : public IRCDProto
 	void SendVhostDel(User *u) anope_override
 	{
 		BotInfo *HostServ = Config->GetClient("HostServ");
-		u->RemoveMode(HostServ, "CLOAK");
 		u->RemoveMode(HostServ, "VHOST");
 		ModeManager::ProcessModes();
 		u->SetMode(HostServ, "CLOAK");


### PR DESCRIPTION
While using `/HS OFF`, if the IRC client has no support for CHGHOST capability, the user IP is exposed for a split of a second.
This PR aims to fix that.

## Previous behaviour:
### Using /HS OFF #
* Test (~vitor@PTirc/Users/Test) has left (Changing host)
* Test (~vitor@xx.xxx.xx.xx) has joined
* Test (~vitor@xx.xxx.xx.xx) has left (Changing host)
* Test (~vitor@DAB1F162.F8B482F.58EF52D7.IP) has joined

## Current behaviour with the fix:
### Using /HS OFF #
* Test (~vitor@PTirc/Users/Test) has left (Changing host)
* Test (~vitor@DAB1F162.F8B482F.58EF52D7.IP) has joined

Some input from @syzop would be appreciated.

Cheers