### PR TITLE
Fix musl build (gettext internals)

### DIFF
--- a/src/language.cpp
+++ b/src/language.cpp
@@ -75,7 +75,7 @@ const char *Language::Translate(const NickCore *nc, const char *string)
 
 #if GETTEXT_FOUND
 
-#ifdef __USE_GNU_GETTEXT
+#if defined(__GLIBC__) && defined(__USE_GNU_GETTEXT)
 extern "C" int _nl_msg_cat_cntr;
 #endif
 
@@ -87,7 +87,7 @@ const char *Language::Translate(const char *lang, const char *string)
 	if (!lang || !*lang)
 		lang = Config->DefLanguage.c_str();
 
-#ifdef __USE_GNU_GETTEXT
+#if defined(__GLIBC__) && defined(__USE_GNU_GETTEXT)
 	++_nl_msg_cat_cntr;
 #endif
 


### PR DESCRIPTION
```
__USE_GNU_GETTEXT is exposed by musl because they provide
a GNU gettext-compatible interface. This doesn't mean they
provide all the internals that glibc does.

Check for __GLIBC__ if using internal _nl_msg_cat_cntr.
```

Signed-off-by: Sam James (sam_c) <sam@cmpct.info>