### PR TITLE
Update ns_drop.cpp

### DIFF
--- a/modules/commands/ns_drop.cpp
+++ b/modules/commands/ns_drop.cpp
@@ -45,10 +45,14 @@ class CommandNSDrop : public Command
 			source.Reply(_("You may not drop other Services Operators' nicknames."));
 		else
 		{
+			User *u = source.GetUser();
 			FOREACH_MOD(OnNickDrop, (source, na));
 
 			Log(!is_mine ? LOG_ADMIN : LOG_COMMAND, source, this) << "to drop nickname " << na->nick << " (group: " << na->nc->display << ") (email: " << (!na->nc->email.empty() ? na->nc->email : "none") << ")";
 			delete na;
+			u->vhost.clear();
+			IRCD->SendVhostDel(u);
+			u->UpdateHost();
 
 			source.Reply(_("Nickname \002%s\002 has been dropped."), nick.c_str());
 		}


### PR DESCRIPTION
Automatically remove the vHost of a user as soon as they drop the nickname.

I don't know how accurate this changes are, but seems to work on my network (UnrealIRCd 5).

Cheers.