### PR TITLE
HostServ: Remove vhost when a nick is dropped

### DIFF
--- a/modules/pseudoclients/hostserv.cpp
+++ b/modules/pseudoclients/hostserv.cpp
@@ -66,6 +66,15 @@ class HostServCore : public Module
 		}
 	}
 
+	void OnNickDrop(CommandSource &source, NickAlias *na) anope_override
+	{
+		if (na->HasVhost())
+		{
+			FOREACH_MOD(OnDeleteVhost, (na));
+			na->RemoveVhost();
+		}
+	}
+
 	void OnNickUpdate(User *u) anope_override
 	{
 		this->OnUserLogin(u);


### PR DESCRIPTION
I decided to file this in the spirit of #259. I agree with @genius3000's statement that this should be handled in HostServCore.

This implementation is fairly simple. If a nick being dropped has a vhost, it is removed.

I've tested:
- Dropping a nickname from the user's perspective
- Dropping a nickname from a network admin's perspective

The end result is the vhost is unset, and the user's cloaked or real host is restored, depending on whether the IRCd being used supports host cloaking.