### PR TITLE
Fix -Wclass-memaccess warning:

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -739,7 +739,7 @@ Anope::string Anope::Resolve(const Anope::string &host, int type)
 	if (getaddrinfo(host.c_str(), NULL, &hints, &addrresult) == 0)
 	{
 		sockaddrs addr;
-		memcpy(&addr, addrresult->ai_addr, addrresult->ai_addrlen);
+		memcpy(static_cast<void*>(&addr), addrresult->ai_addr, addrresult->ai_addrlen);
 		result = addr.addr();
 		Log(LOG_DEBUG_2) << "Resolver: " << host << " -> " << result;
 


### PR DESCRIPTION
/anope/src/misc.cpp: In function ‘Anope::string Anope::Resolve(const Anope::string&, int)’:
/anope/src/misc.cpp:742:60: warning: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘union sockaddrs’ from an array of ‘struct sockaddr’ [-Wclass-memaccess]
   memcpy(&addr, addrresult->ai_addr, addrresult->ai_addrlen);
                                                            ^
In file included from /anope/include/users.h:21,
                 from /anope/include/bots.h:12,
                 from /anope/include/regchannel.h:18,
                 from /anope/include/config.h:16,
                 from /anope/src/misc.cpp:16:
/anope/include/sockets.h:27:18: note: ‘union sockaddrs’ declared here
 union CoreExport sockaddrs
                  ^~~~~~~~~