### PR TITLE
Update nickserv.example.conf

### DIFF
--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -115,7 +115,7 @@ module
 	 * This directive is optional, if left blank, the options will default to ns_secure, memo_signon, and
 	 * memo_receive. If you really want no defaults, use "none" by itself as the option.
 	 */
-	defaults = "ns_secure ns_private hide_email hide_mask memo_signon memo_receive autoop"
+	defaults = "killprotect ns_secure ns_private hide_email hide_mask memo_signon memo_receive autoop ns_keep_modes"
 
 	/*
 	 * The minimum length of time between consecutive uses of NickServ's REGISTER command. This

--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -115,7 +115,7 @@ module
 	 * This directive is optional, if left blank, the options will default to ns_secure, memo_signon, and
 	 * memo_receive. If you really want no defaults, use "none" by itself as the option.
 	 */
-	defaults = "killprotect ns_secure ns_private hide_email hide_mask memo_signon memo_receive autoop ns_keep_modes"
+	defaults = "killprotect ns_secure ns_private hide_email hide_mask memo_signon memo_receive autoop"
 
 	/*
 	 * The minimum length of time between consecutive uses of NickServ's REGISTER command. This


### PR DESCRIPTION
Since `addaccessonreg` is set to **no**, IMHO, this changes also add more security to newer installations/registered users.

Cheers