### PR TITLE
Fix a possible crash when deleting a BotServ bot.

### DIFF
--- a/src/bots.cpp
+++ b/src/bots.cpp
@@ -62,9 +62,9 @@ BotInfo::~BotInfo()
 		IRCD->SendSQLineDel(&x);
 	}
 
-	for (std::set<ChannelInfo *>::iterator it = this->channels->begin(), it_end = this->channels->end(); it != it_end; ++it)
+	for (std::set<ChannelInfo *>::iterator it = this->channels->begin(), it_end = this->channels->end(); it != it_end;)
 	{
-		ChannelInfo *ci = *it;
+		ChannelInfo *ci = *it++;
 		this->UnAssign(NULL, ci);
 	}
 


### PR DESCRIPTION
This can only be triggered by services operators with permission
to delete a BotServ bot. If the bot is assigned to any channels
when being deleted, a crash could occur.

```
The call to UnAssign() erases the channel from the set which
invalidates the iterator in this loop. Handle this in the same
manner as the NickCore dtor.
```
