### PR TITLE
Fix password overflow error message to mention bytes instead of characters

### DIFF
--- a/include/language.h
+++ b/include/language.h
@@ -73,7 +73,7 @@ namespace Language
 #define MORE_OBSCURE_PASSWORD		_("Please try again with a more obscure password. Passwords should be at least\n" \
 						"five characters long, should not be something easily guessed\n" \
 						"(e.g. your real name or your nick), and cannot contain the space or tab characters.")
-#define PASSWORD_TOO_LONG		_("Your password is too long. It must not exceed %u characters.")
+#define PASSWORD_TOO_LONG		_("Your password is too long. It must not exceed %u bytes.")
 #define NICK_NOT_REGISTERED		_("Your nick isn't registered.")
 #define NICK_X_NOT_REGISTERED		_("Nick \002%s\002 isn't registered.")
 #define NICK_X_NOT_IN_USE		_("Nick \002%s\002 isn't currently in use.")


### PR DESCRIPTION
For example, when using this 20-characters password:

```
C -> S: PRIVMSG NickServ :REGISTER éééééééééééééééééééé foo@example.org
S -> C: :NickServ!services@services.host NOTICE foo :Your password is too long. It must not exceed 32 characters.
```

(Same bug on Atheme: https://github.com/atheme/atheme/pull/798 ^^)