### PR TITLE
data/global.example.conf: Correction

### DIFF
--- a/data/global.example.conf
+++ b/data/global.example.conf
@@ -71,7 +71,7 @@ module
 	 *
 	 * This directive is optional.
 	 */
-	#globaloncycledown = "Services are restarting, they will be back shortly - please be good while we're gone"
+	#globaloncycledown = "Services are restarting, they will be back shortly - please be good while they're gone"
 
 	/*
 	 * This is the global message that will be sent when Services (re)join the


### PR DESCRIPTION
The previous default example (which is in use on many Anope networks) refers to Services in 2nd person, then 1st person - in the same sentence.