### PR TITLE
Reflect OpenLDAP 2.5 upstream change from libldap_r to libldap

### DIFF
--- a/modules/extra/m_ldap.cpp
+++ b/modules/extra/m_ldap.cpp
@@ -9,8 +9,8 @@
  * Based on the original code of Services by Andy Church.
  */
 
-/* RequiredLibraries: ldap_r,lber */
-/* RequiredWindowsLibraries: libldap_r,liblber */
+/* RequiredLibraries: ldap_r|ldap,lber */
+/* RequiredWindowsLibraries: libldap_r|libldap,liblber */
 
 #include "module.h"
 #include "modules/ldap.h"


### PR DESCRIPTION
Starting with OpenLDAP 2.5 upstream decided to merge the non-threaded libldap_r library into the threaded libldap library. And starting with OpenLDAP 2.6 common Linux distributions such as Fedora do not ship the compatibility symbolic link anymore (which leads to a build failure), thus the linking should prefer libldap rather than libldap_r.

See also:
 - https://lists.openldap.org/hyperkitty/list/openldap-announce@openldap.org/thread/BH3VDPG6IYYF5L5U6LZGHHKMJY5HFA3L/
 - https://bugzilla.redhat.com/show_bug.cgi?id=2032707