### PR TITLE
Multiple updates for unreal4 protocol

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1100,6 +1100,13 @@ class CoreExport Module : public Extensible
 	 * @return EVENT_STOP to force the user off of the nick
 	 */
 	virtual EventReturn OnNickValidate(User *u, NickAlias *na) { throw NotImplementedException(); }
+
+	/** Called when a certain user has to be unbanned on a certain channel.
+	 * May be used to send protocol-specific messages.
+	 * @param u The user to be unbanned
+	 * @param c The channel that user has to be unbanned on
+	 */
+	virtual void OnChannelUnban(User *u, Channel *c) { throw NotImplementedException(); }
 };
 
 enum Implementation
@@ -1125,7 +1132,7 @@ enum Implementation
 	I_OnPrivmsg, I_OnLog, I_OnLogMessage, I_OnDnsRequest, I_OnCheckModes, I_OnChannelSync, I_OnSetCorrectModes,
 	I_OnSerializeCheck, I_OnSerializableConstruct, I_OnSerializableDestruct, I_OnSerializableUpdate,
 	I_OnSerializeTypeCreate, I_OnSetChannelOption, I_OnSetNickOption, I_OnMessage, I_OnCanSet, I_OnCheckDelete,
-	I_OnExpireTick, I_OnNickValidate,
+	I_OnExpireTick, I_OnNickValidate, I_OnChannelUnban,
 	I_SIZE
 };
 

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -73,6 +73,8 @@ class CoreExport IRCDProto : public Service
 	unsigned MaxModes;
 	/* The maximum number of bytes a line may have */
 	unsigned MaxLine;
+	/* Extban list */
+	std::vector<Anope::string> extbanNames;
 
 	/* Retrieves the next free UID or SID */
 	virtual Anope::string UID_Retrieve();
@@ -237,6 +239,9 @@ class CoreExport IRCDProto : public Service
 	virtual bool IsIdentValid(const Anope::string &);
 	virtual bool IsHostValid(const Anope::string &);
 	virtual bool IsExtbanValid(const Anope::string &) { return false; }
+	virtual bool IsExtban(const Anope::string &, const Anope::string &);
+
+	virtual void AddExtban(const Anope::string &);
 
 	/** Retrieve the maximum number of list modes settable on this channel
 	 * Defaults to Config->ListSize

--- a/modules/commands/cs_unban.cpp
+++ b/modules/commands/cs_unban.cpp
@@ -44,6 +44,8 @@ class CommandCSUnban : public Command
 
 				if (!ci->c || !source.AccessFor(ci).HasPriv("UNBAN"))
 					continue;
+				
+				FOREACH_MOD(OnChannelUnban, (source.GetUser(), ci->c));
 
 				for (unsigned j = 0; j < modes.size(); ++j)
 					if (ci->c->Unban(source.GetUser(), modes[j]->name, true))
@@ -87,6 +89,8 @@ class CommandCSUnban : public Command
 
 		bool override = !source.AccessFor(ci).HasPriv("UNBAN") && source.HasPriv("chanserv/kick");
 		Log(override ? LOG_OVERRIDE : LOG_COMMAND, source, this, ci) << "to unban " << u2->nick;
+
+		FOREACH_MOD(OnChannelUnban, (u2, ci->c));
 
 		for (unsigned i = 0; i < modes.size(); ++i)
 			ci->c->Unban(u2, modes[i]->name, source.GetUser() == u2);

--- a/modules/protocol/inspircd12.cpp
+++ b/modules/protocol/inspircd12.cpp
@@ -480,10 +480,13 @@ class InspIRCd12Proto : public IRCDProto
 class InspIRCdExtBan : public ChannelModeList
 {
  public:
-	InspIRCdExtBan(const Anope::string &mname, char modeChar) : ChannelModeList(mname, modeChar) { }
+	InspIRCdExtBan(const Anope::string &mname, char modeChar) : ChannelModeList(mname, modeChar)
+	{
+		IRCD->AddExtban(mname);
+	}
 
 	bool Matches(User *u, const Entry *e) anope_override
-	{
+	{ /* FIXME these matches will never work, as e->GetMask will return only "unwrapped" mask! */
 		const Anope::string &mask = e->GetMask();
 
 		if (mask.find("m:") == 0 || mask.find("N:") == 0)

--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -109,6 +109,7 @@ class InspIRCdExtBan : public ChannelModeVirtual<ChannelModeList>
 	InspIRCdExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -139,9 +140,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -154,9 +154,7 @@ namespace InspIRCdExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -191,9 +189,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
 
-			return u->IsIdentified() && real_mask.equals_ci(u->Account()->display);
+			return u->IsIdentified() && mask.equals_ci(u->Account()->display);
 		}
 	};
 
@@ -207,8 +204,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -222,8 +218,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->server->GetName(), real_mask);
+			return Anope::Match(u->server->GetName(), mask);
 		}
 	};
 
@@ -237,8 +232,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
+			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, mask);
 		}
 	};
 
@@ -252,8 +246,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->Account() && Entry("BAN", real_mask).Matches(u);
+			return !u->Account() && Entry("BAN", mask).Matches(u);
 		}
 	};
 }

--- a/modules/protocol/inspircd3.cpp
+++ b/modules/protocol/inspircd3.cpp
@@ -534,6 +534,7 @@ class InspIRCdExtBan : public ChannelModeVirtual<ChannelModeList>
 	InspIRCdExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -564,9 +565,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -579,9 +579,7 @@ namespace InspIRCdExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -616,9 +614,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
 
-			return u->IsIdentified() && real_mask.equals_ci(u->Account()->display);
+			return u->IsIdentified() && mask.equals_ci(u->Account()->display);
 		}
 	};
 
@@ -632,8 +629,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -647,8 +643,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->server->GetName(), real_mask);
+			return Anope::Match(u->server->GetName(), mask);
 		}
 	};
 
@@ -662,8 +657,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
+			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, mask);
 		}
 	};
 
@@ -677,8 +671,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->Account() && Entry("BAN", real_mask).Matches(u);
+			return !u->Account() && Entry("BAN", mask).Matches(u);
 		}
 	};
 }

--- a/modules/protocol/unreal.cpp
+++ b/modules/protocol/unreal.cpp
@@ -424,6 +424,7 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 	UnrealExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -453,8 +454,7 @@ namespace UnrealExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -489,9 +489,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -505,9 +504,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -535,9 +533,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return u->Account() && Anope::Match(u->Account()->display, real_mask);
+			return u->Account() && Anope::Match(u->Account()->display, mask);
 		}
 	};
 }

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -226,7 +226,7 @@ class UnrealIRCdProto : public IRCDProto
 		   SID    = SID/UID mode
 		*/
 		UplinkSocket::Message() << "PASS :" << Config->Uplinks[Anope::CurrentUplink].password;
-		UplinkSocket::Message() << "PROTOCTL " << "NICKv2 VHP UMODE2 NICKIP SJOIN SJOIN2 SJ3 NOQUIT TKLEXT MLOCK SID";
+		UplinkSocket::Message() << "PROTOCTL " << "NICKv2 VHP UMODE2 NICKIP SJOIN SJOIN2 SJ3 NOQUIT TKLEXT MLOCK SID MTAGS";
 		UplinkSocket::Message() << "PROTOCTL " << "EAUTH=" << Me->GetName() << ",,,Anope-" << Anope::VersionShort();
 		UplinkSocket::Message() << "PROTOCTL " << "SID=" << Me->GetSID();
 		SendServer(Me);

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -646,7 +646,76 @@ struct IRCDMessageCapab : Message::Capab
 		{
 			Anope::string capab = params[i];
 
-			if (capab.find("CHANMODES") != Anope::string::npos)
+			if (capab.find("USERMODES=") != Anope::string::npos)
+			{
+				Anope::string modebuf(capab.begin() + 10, capab.end());
+				for (size_t t = 0, end = modebuf.length(); t < end; ++t)
+				{
+					switch (modebuf[t])
+					{
+						case 'B':
+							ModeManager::AddUserMode(new UserMode("BOT", 'B'));
+							continue;
+						case 'G':
+							ModeManager::AddUserMode(new UserMode("CENSOR", 'G'));
+							continue;
+						case 'H':
+							ModeManager::AddUserMode(new UserModeOperOnly("HIDEOPER", 'H'));
+							continue;
+						case 'I':
+							ModeManager::AddUserMode(new UserModeOperOnly("HIDEIDLE", 'I'));
+							continue;
+						case 'R':
+							ModeManager::AddUserMode(new UserMode("REGPRIV", 'R'));
+							continue;
+						case 'S':
+							ModeManager::AddUserMode(new UserModeOperOnly("PROTECTED", 'S'));
+							continue;
+						case 'T':
+							ModeManager::AddUserMode(new UserMode("NOCTCP", 'T'));
+							continue;
+						case 'W':
+							ModeManager::AddUserMode(new UserModeOperOnly("WHOIS", 'W'));
+							continue;
+						case 'd':
+							ModeManager::AddUserMode(new UserMode("DEAF", 'd'));
+							continue;
+						case 'i':
+							ModeManager::AddUserMode(new UserMode("INVIS", 'i'));
+							continue;
+						case 'o':
+							ModeManager::AddUserMode(new UserModeOperOnly("OPER", 'o'));
+							continue;
+						case 'p':
+							ModeManager::AddUserMode(new UserMode("PRIV", 'p'));
+							continue;
+						case 'q':
+							ModeManager::AddUserMode(new UserModeOperOnly("GOD", 'q'));
+							continue;
+						case 'r':
+							ModeManager::AddUserMode(new UserModeNoone("REGISTERED", 'r'));
+							continue;
+						case 's':
+							ModeManager::AddUserMode(new UserModeOperOnly("SNOMASK", 's'));
+							continue;
+						case 't':
+							ModeManager::AddUserMode(new UserModeNoone("VHOST", 't'));
+							continue;
+						case 'w':
+							ModeManager::AddUserMode(new UserMode("WALLOPS", 'w'));
+							continue;
+						case 'x':
+							ModeManager::AddUserMode(new UserMode("CLOAK", 'x'));
+							continue;
+						case 'z':
+							ModeManager::AddUserMode(new UserModeNoone("SSL", 'z'));
+							continue;
+						default:
+							ModeManager::AddUserMode(new UserMode("", modebuf[t]));
+					}
+				}
+			}
+			else if (capab.find("CHANMODES=") != Anope::string::npos)
 			{
 				Anope::string modes(capab.begin() + 10, capab.end());
 				commasepstream sep(modes);
@@ -1409,30 +1478,6 @@ class ProtoUnreal : public Module
 
 	bool use_server_side_mlock;
 
-	void AddModes()
-	{
-		/* Add user modes */
-		ModeManager::AddUserMode(new UserMode("BOT", 'B'));
-		ModeManager::AddUserMode(new UserMode("CENSOR", 'G'));
-		ModeManager::AddUserMode(new UserModeOperOnly("HIDEOPER", 'H'));
-		ModeManager::AddUserMode(new UserModeOperOnly("HIDEIDLE", 'I'));
-		ModeManager::AddUserMode(new UserMode("REGPRIV", 'R'));
-		ModeManager::AddUserMode(new UserModeOperOnly("PROTECTED", 'S'));
-		ModeManager::AddUserMode(new UserMode("NOCTCP", 'T'));
-		ModeManager::AddUserMode(new UserModeOperOnly("WHOIS", 'W'));
-		ModeManager::AddUserMode(new UserMode("DEAF", 'd'));
-		ModeManager::AddUserMode(new UserMode("INVIS", 'i'));
-		ModeManager::AddUserMode(new UserModeOperOnly("OPER", 'o'));
-		ModeManager::AddUserMode(new UserMode("PRIV", 'p'));
-		ModeManager::AddUserMode(new UserModeOperOnly("GOD", 'q'));
-		ModeManager::AddUserMode(new UserModeNoone("REGISTERED", 'r'));
-		ModeManager::AddUserMode(new UserModeOperOnly("SNOMASK", 's'));
-		ModeManager::AddUserMode(new UserModeNoone("VHOST", 't'));
-		ModeManager::AddUserMode(new UserMode("WALLOPS", 'w'));
-		ModeManager::AddUserMode(new UserMode("CLOAK", 'x'));
-		ModeManager::AddUserMode(new UserModeNoone("SSL", 'z'));
-	}
-
  public:
 	ProtoUnreal(const Anope::string &modname, const Anope::string &creator) : Module(modname, creator, PROTOCOL | VENDOR),
 		ircd_proto(this),
@@ -1447,7 +1492,6 @@ class ProtoUnreal : public Module
 		message_sid(this), message_sjoin(this), message_topic(this), message_uid(this), message_umode2(this)
 	{
 
-		this->AddModes();
 	}
 
 	void Prioritize() anope_override

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -719,6 +719,9 @@ struct IRCDMessageCapab : Message::Capab
 						case 'd':
 							ModeManager::AddUserMode(new UserMode("DEAF", 'd'));
 							continue;
+						case 'D':
+							ModeManager::AddUserMode(new UserMode("PRIVDEAF", 'D'));
+							continue;
 						case 'i':
 							ModeManager::AddUserMode(new UserMode("INVIS", 'i'));
 							continue;
@@ -748,6 +751,9 @@ struct IRCDMessageCapab : Message::Capab
 							continue;
 						case 'z':
 							ModeManager::AddUserMode(new UserModeNoone("SSL", 'z'));
+							continue;
+						case 'Z':
+							ModeManager::AddUserMode(new UserMode("SSLPRIV", 'Z'));
 							continue;
 						default:
 							ModeManager::AddUserMode(new UserMode("", modebuf[t]));
@@ -889,7 +895,7 @@ struct IRCDMessageCapab : Message::Capab
 							ModeManager::AddChannelMode(new ChannelMode("CENSOR", 'G'));
 							continue;
 						case 'Z':
-							ModeManager::AddChannelMode(new ChannelModeUnrealSSL("", 'Z'));
+							ModeManager::AddChannelMode(new ChannelModeUnrealSSL("ALLSSL", 'Z'));
 							continue;
 						case 'd':
 							// post delayed. means that channel is -D but invisible users still exist.
@@ -898,7 +904,7 @@ struct IRCDMessageCapab : Message::Capab
 							ModeManager::AddChannelMode(new ChannelMode("DELAYEDJOIN", 'D'));
 							continue;
 						case 'P':
-							ModeManager::AddChannelMode(new ChannelMode("PERM", 'P'));
+							ModeManager::AddChannelMode(new ChannelModeOperOnly("PERM", 'P'));
 							continue;
 						default:
 							ModeManager::AddChannelMode(new ChannelMode("", modebuf[t]));

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -1699,6 +1699,13 @@ class ProtoUnreal : public Module
 
 		return EVENT_CONTINUE;
 	}
+
+	void OnChannelUnban(User *u, Channel *c) anope_override
+	{
+		UplinkSocket::Message(Config->GetClient("ChanServ")) << "SVS2MODE " << c->name << " -b " << u->GetUID();
+		/* Unreal will remove all matching bans for us regardless of our internal matching.
+		   Don't use Message(Me) here as certain Unreal versions will always respond with TS-less MODE message. */
+	}
 };
 
 MODULE_INIT(ProtoUnreal)

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -451,10 +451,12 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 	UnrealExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
 	{
+		param = "~" + Anope::string(ext) + ":" + param;
 		return ChannelModeVirtual<ChannelModeList>::Wrap(param);
 	}
 
@@ -463,6 +465,7 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 		if (cm->type != MODE_LIST || param.length() < 4 || param[0] != '~' || param[1] != ext || param[2] != ':')
 			return cm;
 
+		param = param.substr(3);
 		return this;
 	}
 };
@@ -478,8 +481,7 @@ namespace UnrealExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -514,9 +516,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -530,9 +531,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -560,12 +560,11 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			if (real_mask == "0" && !u->Account()) /* ~a:0 is special and matches all unauthenticated users */
+			if (mask == "0" && !u->Account()) /* ~a:0 is special and matches all unauthenticated users */
 				return true;
 
-			return u->Account() && Anope::Match(u->Account()->display, real_mask);
+			return u->Account() && Anope::Match(u->Account()->display, mask);
 		}
 	};
 
@@ -579,8 +578,7 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
-			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
+			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, mask);
 		}
 	};
 	
@@ -594,9 +592,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 			ModData *moddata = u->GetExt<ModData>("ClientModData");
-			return moddata != NULL && moddata->find("operclass") != moddata->end() && Anope::Match((*moddata)["operclass"], real_mask);
+			return moddata != NULL && moddata->find("operclass") != moddata->end() && Anope::Match((*moddata)["operclass"], mask);
 		}
 	};
 	
@@ -611,8 +608,7 @@ namespace UnrealExtban
 		{
 			/* strip down the time (~t:1234:) and call other matchers */
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
-			real_mask = real_mask.substr(real_mask.find(":") + 1);
+			Anope::string real_mask = mask.substr(real_mask.find(":") + 1);
 			return Entry("BAN", real_mask).Matches(u);
 		}
 	};
@@ -627,7 +623,6 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 			ModData *moddata = u->GetExt<ModData>("ClientModData");
 			if (moddata == NULL || moddata->find("geoip") == moddata->end())
 				return false;
@@ -637,7 +632,7 @@ namespace UnrealExtban
 			while (sep.GetToken(tokenbuf))
 			{
 				if (tokenbuf.rfind("cc=", 0) == 0)
-					return (tokenbuf.substr(3, 2) == real_mask);
+					return (tokenbuf.substr(3, 2) == mask);
 			}
 			return false;
 		}

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -799,6 +799,42 @@ struct IRCDMessageCapab : Message::Capab
 			{
 				UplinkSID = capab.substr(4);
 			}
+			else if (!capab.find("PREFIX=")) /* PREFIX=(qaohv)~&@%+ */
+			{
+				Anope::string modes(capab.begin() + 7, capab.end());
+				reverse(modes.begin(), modes.end()); /* +%@&!)vhoaq( */
+				std::size_t mode_count = modes.find(')');
+				Anope::string mode_prefixes = modes.substr(0, mode_count);
+				Anope::string mode_chars = modes.substr(mode_count+1, mode_count);
+				
+				for (size_t t = 0, end = mode_chars.length(); t < end; ++t)
+				{
+					Anope::string mode_name;
+					switch (mode_chars[t])
+					{
+
+						case 'v':
+							mode_name = "VOICE";
+							break;
+						case 'h':
+							mode_name = "HALFOP";
+							break;
+						case 'o':
+							mode_name = "OP";
+							break;
+						case 'a':
+							mode_name = "PROTECT";
+							break;
+						case 'q':
+							mode_name = "OWNER";
+							break;
+						default:
+							mode_name = "";
+							break;
+					}
+					ModeManager::AddChannelMode(new ChannelModeStatus(mode_name, mode_chars[t], mode_prefixes[t], t));
+				}
+			}
 		}
 
 		Message::Capab::Run(source, params);
@@ -1373,13 +1409,6 @@ class ProtoUnreal : public Module
 
 	void AddModes()
 	{
-		ModeManager::AddChannelMode(new ChannelModeStatus("VOICE", 'v', '+', 0));
-		ModeManager::AddChannelMode(new ChannelModeStatus("HALFOP", 'h', '%', 1));
-		ModeManager::AddChannelMode(new ChannelModeStatus("OP", 'o', '@', 2));
-		/* Unreal sends +q as * and +a as ~ */
-		ModeManager::AddChannelMode(new ChannelModeStatus("PROTECT", 'a', '~', 3));
-		ModeManager::AddChannelMode(new ChannelModeStatus("OWNER", 'q', '*', 4));
-
 		/* Add user modes */
 		ModeManager::AddUserMode(new UserMode("BOT", 'B'));
 		ModeManager::AddUserMode(new UserMode("CENSOR", 'G'));

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -623,6 +623,45 @@ class ChannelModeFlood : public ChannelModeParam
 	}
 };
 
+class ChannelModeHistory : public ChannelModeParam /* stolen from inspircd3's ColonDelimitedParamMode */
+{
+ public:
+	ChannelModeHistory(char modeChar) : ChannelModeParam("HISTORY", modeChar, true) { }
+
+	bool IsValid(Anope::string &value) const anope_override
+	{
+		if (value.empty())
+			return false; // empty param is never valid
+
+		Anope::string::size_type pos = value.find(':');
+		if ((pos == Anope::string::npos) || (pos == 0))
+			return false; // no ':' or it's the first char, both are invalid
+
+		Anope::string rest;
+		try
+		{
+			if (convertTo<int>(value, rest, false) <= 0)
+				return false; // negative numbers and zero are invalid
+
+			rest = rest.substr(1);
+			int n;
+			// The part after the ':' is a duration and it
+			// can be in the user friendly "1d3h20m" format, make sure we accept that
+			n = Anope::DoTime(rest);
+
+			if (n <= 0)
+				return false;
+		}
+		catch (const ConvertException &e)
+		{
+			// conversion error, invalid
+			return false;
+		}
+
+		return true;
+	}
+};
+
 class ChannelModeUnrealSSL : public ChannelMode
 {
  public:

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -708,6 +708,8 @@ struct IRCDMessageCapab : Message::Capab
 						case 'l':
 							ModeManager::AddChannelMode(new ChannelModeParam("LIMIT", 'l', true));
 							continue;
+						case 'H':
+							ModeManager::AddChannelMode(new ChannelModeHistory('H'));
 						default:
 							ModeManager::AddChannelMode(new ChannelModeParam("", modebuf[t], true));
 					}
@@ -1417,11 +1419,8 @@ class ProtoUnreal : public Module
 		ModeManager::AddUserMode(new UserMode("REGPRIV", 'R'));
 		ModeManager::AddUserMode(new UserModeOperOnly("PROTECTED", 'S'));
 		ModeManager::AddUserMode(new UserMode("NOCTCP", 'T'));
-		ModeManager::AddUserMode(new UserMode("WEBTV", 'V'));
 		ModeManager::AddUserMode(new UserModeOperOnly("WHOIS", 'W'));
 		ModeManager::AddUserMode(new UserMode("DEAF", 'd'));
-		ModeManager::AddUserMode(new UserModeOperOnly("GLOBOPS", 'g'));
-		ModeManager::AddUserMode(new UserModeOperOnly("HELPOP", 'h'));
 		ModeManager::AddUserMode(new UserMode("INVIS", 'i'));
 		ModeManager::AddUserMode(new UserModeOperOnly("OPER", 'o'));
 		ModeManager::AddUserMode(new UserMode("PRIV", 'p'));

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -554,6 +554,9 @@ namespace UnrealExtban
 			const Anope::string &mask = e->GetMask();
 			Anope::string real_mask = mask.substr(3);
 
+			if (real_mask == "0" && !u->Account()) /* ~a:0 is special and matches all unauthenticated users */
+				return true;
+
 			return u->Account() && Anope::Match(u->Account()->display, real_mask);
 		}
 	};

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -1278,6 +1278,19 @@ struct IRCDMessageSID : IRCDMessage
 	}
 };
 
+static char UnrealSjoinPrefixToModeChar(char sjoin_prefix)
+{
+	switch(sjoin_prefix)
+	{
+		case '*':
+			return ModeManager::GetStatusChar('~');
+		case '~':
+			return ModeManager::GetStatusChar('&');
+		default:
+			return ModeManager::GetStatusChar(sjoin_prefix); /* remaining are regular */
+	}
+}
+
 struct IRCDMessageSJoin : IRCDMessage
 {
 	IRCDMessageSJoin(Module *creator) : IRCDMessage(creator, "SJOIN", 3) { SetFlag(IRCDMESSAGE_REQUIRE_SERVER); SetFlag(IRCDMESSAGE_SOFT_LIMIT); }
@@ -1321,7 +1334,7 @@ struct IRCDMessageSJoin : IRCDMessage
 				Message::Join::SJoinUser sju;
 
 				/* Get prefixes from the nick */
-				for (char ch; (ch = ModeManager::GetStatusChar(buf[0]));)
+				for (char ch; (ch = UnrealSjoinPrefixToModeChar(buf[0]));)
 				{
 					sju.first.AddMode(ch);
 					buf.erase(buf.begin());

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -570,6 +570,23 @@ namespace UnrealExtban
 			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
 		}
 	};
+	
+	class TimedBanMatcher : public UnrealExtBan
+	{
+	 public:
+	 	TimedBanMatcher(const Anope::string &mname, const Anope::string &mbase, char c) : UnrealExtBan(mname, mbase, c)
+		{
+		}
+		
+		bool Matches(User *u, const Entry *e) anope_override
+		{
+			/* strip down the time (~t:1234:) and call other matchers */
+			const Anope::string &mask = e->GetMask();
+			Anope::string real_mask = mask.substr(3);
+			real_mask = real_mask.substr(real_mask.find(":") + 1);
+			return Entry("BAN", real_mask).Matches(u);
+		}
+	};
 }
 
 class ChannelModeFlood : public ChannelModeParam
@@ -782,6 +799,7 @@ struct IRCDMessageCapab : Message::Capab
 							ModeManager::AddChannelMode(new UnrealExtban::RegisteredMatcher("REGISTEREDBAN", "BAN", 'R'));
 							ModeManager::AddChannelMode(new UnrealExtban::AccountMatcher("ACCOUNTBAN", "BAN", 'a'));
 							ModeManager::AddChannelMode(new UnrealExtban::FingerprintMatcher("SSLBAN", "BAN", 'S'));
+							ModeManager::AddChannelMode(new UnrealExtban::TimedBanMatcher("TIMEDBAN", "BAN", 't'));
 							// also has O for opertype extban, but it doesn't send us users opertypes
 							continue;
 						case 'e':

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -32,7 +32,7 @@ class UnrealIRCdProto : public IRCDProto
 
 	UnrealIRCdProto(Module *creator) : IRCDProto(creator, "UnrealIRCd 4+"), ClientModData(creator, "ClientModData"), ChannelModData(creator, "ChannelModData")
 	{
-		DefaultPseudoclientModes = "+Soiq";
+		DefaultPseudoclientModes = "+SoiqB";
 		CanSVSNick = true;
 		CanSVSJoin = true;
 		CanSetVHost = true;

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -443,7 +443,6 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
 	{
-		param = "~" + Anope::string(ext) + ":" + param;
 		return ChannelModeVirtual<ChannelModeList>::Wrap(param);
 	}
 
@@ -452,7 +451,6 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 		if (cm->type != MODE_LIST || param.length() < 4 || param[0] != '~' || param[1] != ext || param[2] != ':')
 			return cm;
 
-		param = param.substr(3);
 		return this;
 	}
 };

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -824,6 +824,7 @@ struct IRCDMessageCapab : Message::Capab
 							continue;
 						case 'H':
 							ModeManager::AddChannelMode(new ChannelModeHistory('H'));
+							continue;
 						default:
 							ModeManager::AddChannelMode(new ChannelModeParam("", modebuf[t], true));
 					}

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -849,14 +849,13 @@ const Anope::string Entry::GetNUHMask() const
 bool Entry::Matches(User *u, bool full) const
 {
 	/* First check if this mode has defined any matches (usually for extbans). */
-	if (IRCD->IsExtbanValid(this->mask))
+	if (IRCD->IsExtban(this->name, this->mask))
 	{
 		ChannelMode *cm = ModeManager::FindChannelModeByName(this->name);
 		if (cm != NULL && cm->type == MODE_LIST)
 		{
 			ChannelModeList *cml = anope_dynamic_static_cast<ChannelModeList *>(cm);
-			if (cml->Matches(u, this))
-				return true;
+			return (cml->Matches(u, this));
 		}
 	}
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -450,6 +450,16 @@ Anope::string IRCDProto::NormalizeMask(const Anope::string &mask)
 	return Entry("", mask).GetNUHMask();
 }
 
+bool IRCDProto::IsExtban(const Anope::string &mname, const Anope::string &mmask)
+{
+	return std::find(extbanNames.begin(), extbanNames.end(), mname) != extbanNames.end();
+}
+
+void IRCDProto::AddExtban(const Anope::string &mname)
+{
+	extbanNames.push_back(mname);
+}
+
 MessageSource::MessageSource(const Anope::string &src) : source(src), u(NULL), s(NULL)
 {
 	/* no source for incoming message is our uplink */


### PR DESCRIPTION
- added new modes and removed unused ones
- added and fixed several extban matchers
- handling of ircd-provided usermode list and channel prefix list
- fix handling of +q channel mode prefix by SJOIN
This also changes:
- extban handling (was not working as expected, probably for all ircds), this required api changes
- added capability of calling ircd's internal user unbanning procedure