### PR TITLE
Update unreal4.cpp

### DIFF
--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -82,7 +82,6 @@ class UnrealIRCdProto : public IRCDProto
 	void SendVhostDel(User *u) anope_override
 	{
 		BotInfo *HostServ = Config->GetClient("HostServ");
-		u->RemoveMode(HostServ, "CLOAK");
 		u->RemoveMode(HostServ, "VHOST");
 		ModeManager::ProcessModes();
 		u->SetMode(HostServ, "CLOAK");

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -84,7 +84,6 @@ class UnrealIRCdProto : public IRCDProto
 		BotInfo *HostServ = Config->GetClient("HostServ");
 		u->RemoveMode(HostServ, "VHOST");
 		ModeManager::ProcessModes();
-		u->SetMode(HostServ, "CLOAK");
 	}
 
 	void SendAkill(User *u, XLine *x) anope_override


### PR DESCRIPTION
This fixes the bug reported on https://bugs.unrealircd.org/view.php?id=6068

As Jobe stated, Anope was sending -xt and then a separate +x, instead of simply sending a -t, this resulted in 2 separate host change events and thus 2 separate part+join resyncs.

Previous behavior on **/hs off**:
```
[08/02/2022 - 00:16:02] * LocalGhost (uid376365@PTirc/Users/James) has left (Changing host)
[08/02/2022 - 00:16:02] * LocalGhost (uid376365@id-376365.uxbridge.irccloud.com) has joined
[08/02/2022 - 00:16:02] * irc3.ptirc.org sets modes [#Portugal +o LocalGhost]
[08/02/2022 - 00:16:02] * LocalGhost (uid376365@id-376365.uxbridge.irccloud.com) has left (Changing host)
[08/02/2022 - 00:16:02] * LocalGhost (uid376365@32E4615F:15F25CF6:80AEFEA0:IP) has joined
[08/02/2022 - 00:16:02] * irc3.ptirc.org sets modes [#Portugal +o LocalGhost]
```

Behavior after the fix:
```
[08/02/2022 - 01:06:30] * LocalGhost (uid376365@PTirc/Users/James) has left (Changing host)
[08/02/2022 - 01:06:30] * LocalGhost (uid376365@32E4615F:15F25CF6:80AEFEA0:IP) has joined
[08/02/2022 - 01:06:30] * irc3.ptirc.org sets modes [#Portugal +o LocalGhost]
```