### PR TITLE
Webcpanel: Add ability to CONFIRM accounts via NickServ tab

### DIFF
--- a/modules/webcpanel/pages/nickserv/confirm.cpp
+++ b/modules/webcpanel/pages/nickserv/confirm.cpp
@@ -1,0 +1,26 @@
+/*
+ * (C) 2003-2022 Anope Team
+ * Contact us at team@anope.org
+ *
+ * Please read COPYING and README for further details.
+ */
+
+#include "../../webcpanel.h"
+
+WebCPanel::NickServ::Confirm::Confirm(const Anope::string &cat, const Anope::string &u) : WebPanelProtectedPage(cat, u)
+{
+}
+
+bool WebCPanel::NickServ::Confirm::OnRequest(HTTPProvider *server, const Anope::string &page_name, HTTPClient *client, HTTPMessage &message, HTTPReply &reply, NickAlias *na, TemplateFileServer::Replacements &replacements)
+{
+
+		std::vector<Anope::string> params;
+		params.push_back(message.post_data["code"]);
+
+		WebPanel::RunCommand(client, na->nc->display, na->nc, "NickServ", "nickserv/confirm", params, replacements);
+
+	TemplateFileServer page("nickserv/confirm.html");
+
+	page.Serve(server, page_name, client, message, reply, replacements);
+	return true;
+}

--- a/modules/webcpanel/pages/nickserv/confirm.cpp
+++ b/modules/webcpanel/pages/nickserv/confirm.cpp
@@ -14,10 +14,10 @@ WebCPanel::NickServ::Confirm::Confirm(const Anope::string &cat, const Anope::str
 bool WebCPanel::NickServ::Confirm::OnRequest(HTTPProvider *server, const Anope::string &page_name, HTTPClient *client, HTTPMessage &message, HTTPReply &reply, NickAlias *na, TemplateFileServer::Replacements &replacements)
 {
 
-		std::vector<Anope::string> params;
-		params.push_back(message.post_data["code"]);
+	std::vector<Anope::string> params;
+	params.push_back(message.post_data["code"]);
 
-		WebPanel::RunCommand(client, na->nc->display, na->nc, "NickServ", "nickserv/confirm", params, replacements);
+	WebPanel::RunCommand(client, na->nc->display, na->nc, "NickServ", "nickserv/confirm", params, replacements);
 
 	TemplateFileServer page("nickserv/confirm.html");
 

--- a/modules/webcpanel/pages/nickserv/confirm.h
+++ b/modules/webcpanel/pages/nickserv/confirm.h
@@ -1,0 +1,24 @@
+/*
+ * (C) 2003-2022 Anope Team
+ * Contact us at team@anope.org
+ *
+ * Please read COPYING and README for further details.
+ */
+
+namespace WebCPanel
+{
+
+namespace NickServ
+{
+
+class Confirm : public WebPanelProtectedPage
+{
+ public:
+	Confirm(const Anope::string &cat, const Anope::string &u);
+
+	bool OnRequest(HTTPProvider *, const Anope::string &, HTTPClient *, HTTPMessage &, HTTPReply &, NickAlias *, TemplateFileServer::Replacements &) anope_override;
+};
+
+}
+
+}

--- a/modules/webcpanel/templates/default/nickserv/confirm.html
+++ b/modules/webcpanel/templates/default/nickserv/confirm.html
@@ -1,0 +1,27 @@
+{INCLUDE header.html}
+		<div class="panel-heading">Confirm your Email</div>
+		<div class="panel-body">
+			<div class="alert alert-info">
+				{M}<br>
+			</div>
+
+			<em>You can <strong>CONFIRM</strong> your registration by entering your confirmation code below.</em>
+
+			<hr>
+
+			<h4>Confirm your account</h4>
+			<form class="form-horizontal" method="post" action="/nickserv/confirm">
+				<div class="form-group">
+					<label class="control-label col-lg-2" for="confirm">Confirmation Code:</label>
+					<div class="col-lg-5">
+						<input class="form-control" type="text" name="code" id="code" placeholder="Code from Email">
+					</div>
+				</div>
+				<div class="form-group">
+					<div class="col-lg-offset-2 col-lg-5">
+						<button type="submit" class="btn btn-primary">Confirm Me!</button>
+					</div>
+				</div>
+			</form>
+		</div>
+{INCLUDE footer.html}

--- a/modules/webcpanel/templates/default/nickserv/confirm.html
+++ b/modules/webcpanel/templates/default/nickserv/confirm.html
@@ -1,9 +1,11 @@
 {INCLUDE header.html}
 		<div class="panel-heading">Confirm your Email</div>
 		<div class="panel-body">
+			{FOR M IN MESSAGES}
 			<div class="alert alert-info">
 				{M}<br>
 			</div>
+			{END FOR}
 
 			<em>You can <strong>CONFIRM</strong> your registration by entering your confirmation code below.</em>
 

--- a/modules/webcpanel/webcpanel.cpp
+++ b/modules/webcpanel/webcpanel.cpp
@@ -28,6 +28,7 @@ class ModuleWebCPanel : public Module
 	WebCPanel::NickServ::Cert nickserv_cert;
 	WebCPanel::NickServ::Access nickserv_access;
 	WebCPanel::NickServ::Alist nickserv_alist;
+	WebCPanel::NickServ::Confirm nickserv_confirm;
 
 	WebCPanel::ChanServ::Info chanserv_info;
 	WebCPanel::ChanServ::Set chanserv_set;
@@ -49,7 +50,7 @@ class ModuleWebCPanel : public Module
 		id(this, "webcpanel_id"), ip(this, "webcpanel_ip"), last_login(this, "webcpanel_last_login"),
 		style_css("style.css", "/static/style.css", "text/css"), logo_png("logo.png", "/static/logo.png", "image/png"), cubes_png("cubes.png", "/static/cubes.png", "image/png"), favicon_ico("favicon.ico", "/favicon.ico", "image/x-icon"),
 		index("/"), logout("/logout"), _register("/register"), confirm("/confirm"),
-		nickserv_info("NickServ", "/nickserv/info"), nickserv_cert("NickServ", "/nickserv/cert"), nickserv_access("NickServ", "/nickserv/access"), nickserv_alist("NickServ", "/nickserv/alist"),
+		nickserv_info("NickServ", "/nickserv/info"), nickserv_cert("NickServ", "/nickserv/cert"), nickserv_access("NickServ", "/nickserv/access"), nickserv_alist("NickServ", "/nickserv/alist"), nickserv_confirm("NickServ", "/nickserv/confirm"),
 		chanserv_info("ChanServ", "/chanserv/info"), chanserv_set("ChanServ", "/chanserv/set"), chanserv_access("ChanServ", "/chanserv/access"), chanserv_akick("ChanServ", "/chanserv/akick"),
 		chanserv_modes("ChanServ", "/chanserv/modes"), chanserv_drop("ChanServ", "/chanserv/drop"), memoserv_memos("MemoServ", "/memoserv/memos"), hostserv_request("HostServ", "/hostserv/request"),
 		operserv_akill("OperServ", "/operserv/akill")
@@ -106,6 +107,11 @@ class ModuleWebCPanel : public Module
 			ss.url = "/nickserv/alist";
 			s.subsections.push_back(ss);
 			provider->RegisterPage(&this->nickserv_alist);
+
+			ss.name = "Confirm";
+			ss.url = "/nickserv/confirm";
+			s.subsections.push_back(ss);
+			provider->RegisterPage(&this->nickserv_confirm);
 
 			panel.sections.push_back(s);
 		}
@@ -214,6 +220,7 @@ class ModuleWebCPanel : public Module
 			provider->UnregisterPage(&this->nickserv_cert);
 			provider->UnregisterPage(&this->nickserv_access);
 			provider->UnregisterPage(&this->nickserv_alist);
+			provider->UnregisterPage(&this->nickserv_confirm);
 
 			provider->UnregisterPage(&this->chanserv_info);
 			provider->UnregisterPage(&this->chanserv_set);

--- a/modules/webcpanel/webcpanel.h
+++ b/modules/webcpanel/webcpanel.h
@@ -166,6 +166,7 @@ namespace WebPanel
 #include "pages/nickserv/cert.h"
 #include "pages/nickserv/access.h"
 #include "pages/nickserv/alist.h"
+#include "pages/nickserv/confirm.h"
 
 #include "pages/chanserv/info.h"
 #include "pages/chanserv/set.h"


### PR DESCRIPTION
This PR allows users who register, using the Anope Webcpanel to login and confirm their email address _(registration)_ with the emailed **CONFIRM code**.