### PR TITLE
anope database: write to temporary file and rename

### DIFF
--- a/modules/database/db_flatfile.cpp
+++ b/modules/database/db_flatfile.cpp
@@ -312,10 +312,7 @@ class DBFlatFile : public Module, public Pipe
 				else
 					db_name = Anope::DataDir + "/" + Config->GetModule(this)->Get<const Anope::string>("database", "anope.db");
 
-				if (Anope::IsFile(db_name))
-					rename(db_name.c_str(), (db_name + ".tmp").c_str());
-
-				std::fstream *fs = databases[s_type->GetOwner()] = new std::fstream(db_name.c_str(), std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+				std::fstream *fs = databases[s_type->GetOwner()] = new std::fstream((db_name + ".tmp").c_str(), std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
 
 				if (!fs->is_open())
 					Log(this) << "Unable to open " << db_name << " for writing";
@@ -349,14 +346,15 @@ class DBFlatFile : public Module, public Pipe
 					this->Write("Unable to write database " + db_name);
 
 					f->close();
-
-					if (Anope::IsFile((db_name + ".tmp").c_str()))
-						rename((db_name + ".tmp").c_str(), db_name.c_str());
 				}
 				else
 				{
 					f->close();
-					unlink((db_name + ".tmp").c_str());
+#ifdef _WIN32
+					/* Windows rename() fails if the file already exists. */
+					remove(db_name.c_str());
+#endif
+					rename((db_name + ".tmp").c_str(), db_name.c_str());
 				}
 
 				delete f;


### PR DESCRIPTION
On a machine that had disk trouble and a couple of unclean shutdowns, I have had to restore the anope database from an older backup, and noticed empty dated files in the backups/ directory. 

This change decreases the likelihood of ending up with a zero-byte (or missing) anope.db by changing the sequence in which the database is written.

Previously, the code would:

1. Move the existing `anope.db` to `anope.db.tmp` (if the server crashes here, you are missing `anope.db` entirely)
2. Write to `anope.db` (if the server crashes here, you might have an empty `anope.db`)
3. Remove `anope.db.tmp` if the write succeeded, or rename `anope.db.tmp` back to `anope.db` if the write failed.

With this PR, the code will:

1. Write to `anope.db.tmp` (if the server crashes here, the old file is still intact)
2. Rename `anope.db.tmp` to `anope.db` if the write succeeded. (if the server crashes here you either have the old database, or the new one, but never a missing/empty one)