### PR TITLE
Disable `os_session` by default

### DIFF
--- a/data/operserv.example.conf
+++ b/data/operserv.example.conf
@@ -548,8 +548,10 @@ command { service = "OperServ"; name = "RELOAD"; command = "operserv/reload"; pe
  * be killed. Exceptions to the default session limit can be defined via the exception list.
  *
  * Used to manage the session limit exception list, and view currently active sessions.
+ * 
+ * Most of the IRCds nowadays (UnrealIRCd, InspIRCd, Hybrid IRCd, Solanum IRCd) can do this on their own.
  */
-module
+#module
 {
 	name = "os_session"
 
@@ -618,8 +620,8 @@ module
 	session_ipv4_cidr = 32
 	session_ipv6_cidr = 128
 }
-command { service = "OperServ"; name = "EXCEPTION"; command = "operserv/exception"; permission = "operserv/exception"; }
-command { service = "OperServ"; name = "SESSION"; command = "operserv/session"; permission = "operserv/session"; }
+#command { service = "OperServ"; name = "EXCEPTION"; command = "operserv/exception"; permission = "operserv/exception"; }
+#command { service = "OperServ"; name = "SESSION"; command = "operserv/session"; permission = "operserv/session"; }
 
 /*
  * os_set


### PR DESCRIPTION
**This idea is open to discussion**

Nowadays, IRCds such as UnrealIRCd, InspIRCd, Hybrid IRCd, Solanum, etc, have the ability to define the nnumber of local and global users that can be connected to the network from the same IP as the same time.

IMHO, this module should be disabled by default, since actually we would need to edit 2 configuration files (the ircd and operserv) to allow higher number of users connected from the same IP.

Any ideas/thoghts are welcome.