### PR TITLE
unreal4: set vhost/vident during SASL

### DIFF
--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -407,6 +407,11 @@ class UnrealIRCdProto : public IRCDProto
 		{
 			distmask = uid.substr(0, p);
 		}
+
+		if (!vident.empty())
+			UplinkSocket::Message(Me) << "CHGIDENT " << uid << " " << vident;
+		if (!vhost.empty())
+			UplinkSocket::Message(Me) << "CHGHOST " << uid << " " << vhost;
 		UplinkSocket::Message(Me) << "SVSLOGIN " << distmask << " " << uid << " " << acc;
 	}
 


### PR DESCRIPTION
This sends the `CHGIDENT` and `CHGHOST` message right before the `SVSLOGIN` (SASL succeeded) message.
For SASL users this means you get the correct vident/vhost straight from the start, which is great for auto-join/re-joins/etc.
I see other protocol modules have this too (inspircd as a separate command like us, and charybdis and plexus in a single protocol message).

This feature will work with UnrealIRCd git of today (https://github.com/unrealircd/unrealircd/commit/977c4b433a51b1a5c88bd271f85cfde60968fd2d). The feature will also be in 6.0.7 stable, scheduled for April 2023.
It is no problem to send the protocol message to older UnrealIRCd servers (just a harmless no such nick/channel being sent back to the services server), in which case the usual post-registration CHGHOST/CHGIDENT will still be done.