### PR TITLE
Update ns_register.cpp

### DIFF
--- a/modules/commands/ns_register.cpp
+++ b/modules/commands/ns_register.cpp
@@ -83,7 +83,7 @@ class CommandNSConfirm : public Command
 				source.Reply(_("Invalid passcode."));
 		}
 		else
-			source.Reply(_("Invalid passcode."));
+			source.Reply(NICK_IDENTIFY_REQUIRED);
 
 		return;
 	}


### PR DESCRIPTION
Tell users that they must identify to their account before using CONFIRM.

This only happens when a nickname is registered via webcpanel and said nickname is online.