### PR TITLE
Add missing whitespace in multi-line comment

### DIFF
--- a/data/modules.example.conf
+++ b/data/modules.example.conf
@@ -420,7 +420,7 @@ module { name = "help" }
  *
  * Provides the regex engine regex/stdlib, which uses the regular expression library that is part of
  * the C++ standard library.
-*/
+ */
 module
 {
 	name = "m_regex_stdlib"


### PR DESCRIPTION
Cosmetic change to match the multi-line comment style of the rest of the file.