### PR TITLE
Added deny_dropping_display option in ns_drop module

### DIFF
--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -330,7 +330,16 @@ command { service = "NickServ"; name = "CERT"; command = "nickserv/cert"; }
  *
  * Used for unregistering names.
  */
-module { name = "ns_drop" }
+module { 
+	name = "ns_drop"
+
+	/*
+	 * If set users will have to drop all aliases before can drop their display nick.
+	 * Recommended, if you don't allow your users to change their account name and you have disabled NS SET DISPLAY
+	 * and NS UNGROUP commands.
+	 */	
+	deny_dropping_display = no
+}
 command { service = "NickServ"; name = "DROP"; command = "nickserv/drop"; }
 
 /*

--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -330,7 +330,8 @@ command { service = "NickServ"; name = "CERT"; command = "nickserv/cert"; }
  *
  * Used for unregistering names.
  */
-module { 
+module
+{ 
 	name = "ns_drop"
 
 	/*

--- a/modules/commands/ns_drop.cpp
+++ b/modules/commands/ns_drop.cpp
@@ -71,6 +71,9 @@ public:
 				"is dropped you may lose all of your access and channels that\n"
 				"you may own. Any other user will be able to gain control of\n"
 				"this nick."));
+		if (Config->GetModule("ns_drop")->Get<bool>("deny_dropping_display"))
+			source.Reply(_("You must drop all aliases in the group\n"
+				before you can drop your display nick."));
 		if (!source.HasPriv("nickserv/drop"))
 			source.Reply(_("You may drop any nick within your group."));
 		else

--- a/modules/commands/ns_drop.cpp
+++ b/modules/commands/ns_drop.cpp
@@ -37,7 +37,16 @@ public:
 			return;
 		}
 
+		const NickCore *nc;
+		nc = source.GetAccount();
+
 		bool is_mine = source.GetAccount() == na->nc;
+
+		if (Config->GetModule("ns_drop")->Get<bool>("deny_dropping_display") && is_mine && (nc->aliases->size() > 1) && (na->nc->display == nick))
+		{
+			source.Reply(_("You must drop all aliases in the group before proceeding to delete your account."));
+			return;
+		}
 
 		if (!is_mine && !source.HasPriv("nickserv/drop"))
 			source.Reply(ACCESS_DENIED);

--- a/modules/commands/ns_drop.cpp
+++ b/modules/commands/ns_drop.cpp
@@ -37,8 +37,7 @@ public:
 			return;
 		}
 
-		const NickCore *nc;
-		nc = source.GetAccount();
+		const NickCore *nc = source.GetAccount();
 
 		bool is_mine = source.GetAccount() == na->nc;
 
@@ -50,7 +49,7 @@ public:
 
 		if (!is_mine && !source.HasPriv("nickserv/drop"))
 			source.Reply(ACCESS_DENIED);
-		else if (Config->GetModule("nickserv")->Get<bool>("secureadmins", "yes") && !is_mine && na->nc->IsServicesOper())
+		else if (Config->GetModule(this->module)->Get<bool>("secureadmins", "yes") && !is_mine && na->nc->IsServicesOper())
 			source.Reply(_("You may not drop other Services Operators' nicknames."));
 		else
 		{
@@ -71,7 +70,7 @@ public:
 				"is dropped you may lose all of your access and channels that\n"
 				"you may own. Any other user will be able to gain control of\n"
 				"this nick."));
-		if (Config->GetModule("ns_drop")->Get<bool>("deny_dropping_display"))
+		if (Config->GetModule(this->module)->Get<bool>("deny_dropping_display"))
 			source.Reply(_("You must drop all aliases in the group\n"
 				before you can drop your display nick."));
 		if (!source.HasPriv("nickserv/drop"))

--- a/modules/commands/ns_drop.cpp
+++ b/modules/commands/ns_drop.cpp
@@ -72,7 +72,7 @@ public:
 				"this nick."));
 		if (Config->GetModule(this->module)->Get<bool>("deny_dropping_display"))
 			source.Reply(_("You must drop all aliases in the group\n"
-				before you can drop your display nick."));
+				"before you can drop your display nick."));
 		if (!source.HasPriv("nickserv/drop"))
 			source.Reply(_("You may drop any nick within your group."));
 		else


### PR DESCRIPTION
## Summary
This option prevents users from deleting their display nick as long as they have aliases in the group.


## Rationale

If you want to deny account name change just disabling  NS SET DISPLAY and NS UNGROUP in not enough, as anyone can drop his display nick ad the next alias available will become the new display nick


## Todo
- Translations
- A modify to OnExpireTick() on nickserv.cpp to let display nick expire only if there's no aliases when this option is enabled
