### PR TITLE
Remove overleft of module with m_ prefix

### DIFF
--- a/data/modules.example.conf
+++ b/data/modules.example.conf
@@ -783,7 +783,7 @@ module { name = "sasl" }
  * xmlrpc
  *
  * Allows remote applications (websites) to execute queries in real time to retrieve data from Anope.
- * By itself this module does nothing, but allows other modules (m_xmlrpc_main) to receive and send XMLRPC queries.
+ * By itself this module does nothing, but allows other modules (xmlrpc_main) to receive and send XMLRPC queries.
  */
 #module
 {


### PR DESCRIPTION
Minor change to remove overleft of module with `m_` prefix, because at least in my build, it's `xmlrpc_main.so` now.
