### PR TITLE
Enable message-tags support for UnrealIRCd

### DIFF
--- a/modules/protocol/unrealircd.cpp
+++ b/modules/protocol/unrealircd.cpp
@@ -444,6 +444,13 @@ private:
 	{
 		Uplink::Send(user, "SVS2MODE", c->name, "-b", u->GetUID());
 	}
+
+	bool IsTagValid(const Anope::string &tname, const Anope::string &tvalue) override
+	{
+		if (Servers::Capab.count("MTAGS"))
+			return true;
+		return false;
+	}
 };
 
 class UnrealExtBan


### PR DESCRIPTION
As (sortof) requested in https://github.com/anope/anope/issues/360, this adds message-tags support for the unrealircd protocol module in anope 2.1. Support for this is auto-detected / enabled conditionally when "MTAGS" is present in "PROTOCTL". This is the case in UnrealIRCd 5.0.0 and later.

The change has been tested with current UnrealIRCd 6.1.5-git by using the CS ENTRYMSG functionality where `+draft/channel-context=` correctly shows up on the client-side. And also tested the other way around, with a (modified) UnrealIRCd which did not have "MTAGS", the message tag does not show up there... as expected.
