### PR TITLE
Fix OS SQLINE expiry with UnrealIRCd

### DIFF
--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -196,7 +196,7 @@ class UnrealIRCdProto : public IRCDProto
 	*/
 	void SendSQLine(User *, const XLine *x) anope_override
 	{
-		UplinkSocket::Message() << "SQLINE " << x->mask << " :" << x->GetReason();
+		UplinkSocket::Message() << "TKL + Q * " << x->mask << " " << x->by << " " << x->expires << " " << x->created << " :" << x->GetReason();
 	}
 
 	/* Functions that use serval cmd functions */


### PR DESCRIPTION
Backport of https://github.com/anope/anope/pull/378 to anope 2.0.x. Original text below (also did retest with 2.0.x git).

This fixes https://github.com/anope/anope/issues/374 in the sense that we no longer use the `SQLINE` command in server to server traffic to UnrealIRCd when setting a SQLINE, we now use the `TKL` command. This way the expiry time that anope wants can be communicated to UnrealIRCd. Commands like `OS SQLINE ADD +1m ...` work properly now and for `OS FORBID` it will obey the 15 seconds that anope uses (or whatever 'inhabit' is set to by the admin).

This has been tested on UnrealIRCd 6.1.5-git. The `TKL` command syntax should be fine for any UnrealIRCd in the past 20 years or so, so we should be good :D.