### PR TITLE
Update nickserv.example.conf

### DIFF
--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -766,6 +766,7 @@ log
  *  nickserv/confirm              - Can confirm other users nicknames
  *  nickserv/drop                 - Can drop other users nicks
  *  nickserv/drop/override        - Allows dropping nicks without using a confirmation code
+ *  nickserv/list                 - Can view all registered nickames
  *  nickserv/recover              - Can recover other users nicks
  *  operserv/config               - Can modify services's configuration
  *  operserv/oper/modify          - Can add and remove operators with at most the same privileges

--- a/data/nickserv.example.conf
+++ b/data/nickserv.example.conf
@@ -396,7 +396,7 @@ module
 	 */
 	listmax = 50
 }
-command { service = "NickServ"; name = "LIST"; command = "nickserv/list"; }
+command { service = "NickServ"; name = "LIST"; command = "nickserv/list"; permission = "nickserv/list"; }
 
 command { service = "NickServ"; name = "SET PRIVATE"; command = "nickserv/set/private"; }
 command { service = "NickServ"; name = "SASET PRIVATE"; command = "nickserv/saset/private"; permission = "nickserv/saset/private"; }


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary
Change the permission of the `∕NS LIST` command usage so normal users can't see the registered nicknames.

<!--
Briefly describe what this pull request changes.
-->

## Rationale
Limit the `∕NS LIST` command to those that have the `nickserv/list` permission, which are usually opers.

<!--
Describe why you have made this change.
-->
IMHO, allowing regular users to see all the registered nicks with the `/NS LIST *` command is a security/privacy issue.

This PR fixes that by restricting the command to those that have the `nickserv/list` permission (usually opers).
## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 3.11 --> Ubuntu 22.04 LTS
**Compiler name and version:** <!-- e.g. GCC 4.2.0 --> gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
