### PR TITLE
Update chanserv.example.conf

### DIFF
--- a/data/chanserv.example.conf
+++ b/data/chanserv.example.conf
@@ -94,7 +94,7 @@ module
 	 * This directive is optional, if left blank, the options will default to keeptopic, peace,
 	 * securefounder, and signkick. If you really want no defaults, use "none" by itself as the option.
 	 */
-	defaults = "keeptopic peace securefounder signkick"
+	defaults = "keeptopic peace cs_private securefounder signkick"
 
 	/*
 	 * The maximum number of channels which may be registered to a single nickname.


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary
Add `cs_private` to ChanServ defaults.

<!--
Briefly describe what this pull request changes.
-->

## Rationale
This adds the `cs_private` option to ChanServ, which hides channels from the `/CS LIST` command output for non-privileged users, since some channels may be +s (secret).
<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 3.11 -->Ubuntu 22.04.4 LTS
**Compiler name and version:** <!-- e.g. GCC 4.2.0 -->gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
