### PR TITLE
Add unix socket support to mysql module

### DIFF
--- a/data/modules.example.conf
+++ b/data/modules.example.conf
@@ -372,6 +372,7 @@ module { name = "help" }
 		username = "anope"
 		password = "mypassword"
 		port = 3306
+		socket = ""
 	}
 }
 

--- a/modules/extra/mysql.cpp
+++ b/modules/extra/mysql.cpp
@@ -249,7 +249,7 @@ public:
 				const Anope::string &user = block->Get<const Anope::string>("username", "anope");
 				const Anope::string &password = block->Get<const Anope::string>("password");
 				unsigned int port = block->Get<unsigned int>("port", "3306");
-				const Anope::string &socket = block->Get<const Anope::string>("socket", "");
+				const Anope::string &socket = block->Get<const Anope::string>("socket");
 
 				try
 				{
@@ -499,7 +499,7 @@ void MySQLService::Connect()
 	const unsigned int timeout = 1;
 	mysql_options(this->sql, MYSQL_OPT_CONNECT_TIMEOUT, reinterpret_cast<const char *>(&timeout));
 
-	bool connect = mysql_real_connect(this->sql, this->server.c_str(), this->user.c_str(), this->password.c_str(), this->database.c_str(), this->port, this->socket.empty() ? NULL : this->socket.c_str(), CLIENT_MULTI_RESULTS);
+	bool connect = mysql_real_connect(this->sql, this->server.c_str(), this->user.c_str(), this->password.c_str(), this->database.c_str(), this->port, this->socket.empty() ? nullptr : this->socket.c_str(), CLIENT_MULTI_RESULTS);
 
 	if (!connect)
 		throw SQL::Exception("Unable to connect to MySQL service " + this->name + ": " + mysql_error(this->sql));

--- a/modules/extra/mysql.cpp
+++ b/modules/extra/mysql.cpp
@@ -121,6 +121,7 @@ class MySQLService final
 	Anope::string user;
 	Anope::string password;
 	unsigned int port;
+	Anope::string socket;
 
 	MYSQL *sql = nullptr;
 
@@ -136,7 +137,7 @@ public:
 	 */
 	std::mutex Lock;
 
-	MySQLService(Module *o, const Anope::string &n, const Anope::string &d, const Anope::string &s, const Anope::string &u, const Anope::string &p, unsigned int po);
+	MySQLService(Module *o, const Anope::string &n, const Anope::string &d, const Anope::string &s, const Anope::string &u, const Anope::string &p, unsigned int po, const Anope::string &so);
 
 	~MySQLService();
 
@@ -248,13 +249,14 @@ public:
 				const Anope::string &user = block->Get<const Anope::string>("username", "anope");
 				const Anope::string &password = block->Get<const Anope::string>("password");
 				unsigned int port = block->Get<unsigned int>("port", "3306");
+				const Anope::string &socket = block->Get<const Anope::string>("socket", "");
 
 				try
 				{
-					auto *ss = new MySQLService(this, connname, database, server, user, password, port);
+					auto *ss = new MySQLService(this, connname, database, server, user, password, port, socket);
 					this->MySQLServices.emplace(connname, ss);
 
-					Log(LOG_NORMAL, "mysql") << "MySQL: Successfully connected to server " << connname << " (" << server << ")";
+					Log(LOG_NORMAL, "mysql") << "MySQL: Successfully connected to server " << connname << " (" << (socket.empty() ? server + ":" + port : socket) << ")";
 				}
 				catch (const SQL::Exception &ex)
 				{
@@ -309,13 +311,14 @@ public:
 	}
 };
 
-MySQLService::MySQLService(Module *o, const Anope::string &n, const Anope::string &d, const Anope::string &s, const Anope::string &u, const Anope::string &p, unsigned int po)
+MySQLService::MySQLService(Module *o, const Anope::string &n, const Anope::string &d, const Anope::string &s, const Anope::string &u, const Anope::string &p, unsigned int po, const Anope::string &so)
 	: Provider(o, n)
 	, database(d)
 	, server(s)
 	, user(u)
 	, password(p)
 	, port(po)
+	, socket(so)
 {
 	Connect();
 }
@@ -496,12 +499,15 @@ void MySQLService::Connect()
 	const unsigned int timeout = 1;
 	mysql_options(this->sql, MYSQL_OPT_CONNECT_TIMEOUT, reinterpret_cast<const char *>(&timeout));
 
-	bool connect = mysql_real_connect(this->sql, this->server.c_str(), this->user.c_str(), this->password.c_str(), this->database.c_str(), this->port, NULL, CLIENT_MULTI_RESULTS);
+	bool connect = mysql_real_connect(this->sql, this->server.c_str(), this->user.c_str(), this->password.c_str(), this->database.c_str(), this->port, this->socket.empty() ? NULL : this->socket.c_str(), CLIENT_MULTI_RESULTS);
 
 	if (!connect)
 		throw SQL::Exception("Unable to connect to MySQL service " + this->name + ": " + mysql_error(this->sql));
 
-	Log(LOG_DEBUG) << "Successfully connected to MySQL service " << this->name << " at " << this->server << ":" << this->port;
+	if (this->socket.empty())
+		Log(LOG_DEBUG) << "Successfully connected to MySQL service " << this->name << " at " << this->server << ":" << this->port;
+	else
+		Log(LOG_DEBUG) << "Successfully connected to MySQL service " << this->name << " at " << this->socket;
 }
 
 


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

This pull-request adds the ability to use unix sockets with the mysql module

## Rationale

<!--
Describe why you have made this change.
-->

Unix sockets have less overhead than tcp

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:
**Operating system name and version:** ArchLinux 6.9.7-arch1-1 x86_64
**Compiler name and version:** gcc (GCC) 14.1.1 20240522

mariadb 11.4.2-1, mariadb-libs 11.4.2-1 (libmariadbclient)
