### PR TITLE
fix build on some musl systems

### DIFF
--- a/include/services.h
+++ b/include/services.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 #include <algorithm>
 #include <bitset>


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary

Adds `#include <cstring>` to include/services.h as quite a few musl libc systems fail to build without it. It was needed in many places so figured a single add to services.h is best.

## Rationale

To allow musl distros (voidlinux and others) to package without having to patch it

## Testing Environment

locally and on a small network of 50ish users

I have tested this pull request on:

**Operating system name and version: void linux kernel 6.10
**Compiler name and version: gcc 13.2
