### PR TITLE
Update anope.example.conf

### DIFF
--- a/data/example.conf
+++ b/data/example.conf
@@ -953,7 +953,7 @@ mail
 	 * If set, this option enables the mail commands in Services. You may choose
 	 * to disable it if you have no Sendmail-compatible mailer installed. Whilst
 	 * this directive (and entire block) is optional, it is required if
-	 * nickserv:registration is set to yes.
+	 * nickserv:registration is set to mail.
 	 */
 	usemail = yes
 


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary
<!--
Briefly describe what this pull request changes.
-->
Corrected typo on erroneous option value name. `nickserv:registration` only has as options: none, admin, mail. I assume that `mail` is the word that should replace `yes`

## Rationale
<!--
Describe why you have made this change.
-->
There's no `yes` option on `nickserv:registration`