### PR TITLE
Correction of #526

### DIFF
--- a/modules/extra/stats/irc2sql/irc2sql.cpp
+++ b/modules/extra/stats/irc2sql/irc2sql.cpp
@@ -198,7 +198,7 @@ void IRC2SQL::OnSetDisplayedHost(User *u)
 void IRC2SQL::OnChannelCreate(Channel *c)
 {
 	query = "INSERT INTO `" + prefix + "chan` (channel, topic, topicauthor, topictime, modes) "
-		"VALUES (@channel@,@topic@,@topicauthor@,@topictime@,@modes@) "
+		"VALUES (@channel@,@topic@,@topicauthor@,FROM_UNIXTIME(@topictime@),@modes@) "
 		"ON DUPLICATE KEY UPDATE channel=VALUES(channel), topic=VALUES(topic),"
 			"topicauthor=VALUES(topicauthor), topictime=VALUES(topictime), modes=VALUES(modes)";
 	query.SetValue("channel", c->name);


### PR DESCRIPTION
Related to #526 : MySQL doesn't accept the timestamp in topictime, must use FROM_UNIXTIME() like it's done in OnTopicUpdated

## Summary

When re-enabling irc2mysql, the table is not filled when chans had a topic: 
`Incorrect datetime value: '1755679391' for column `zeolia_anope`.`chan`.`topictime` at row 1`

## Rationale

This makes the table empty

## Testing Environment

Debian 12, anope 2.0.16

## Checks

Compiled, shutdown anope, restart, disable and re-enable irc2sql

No more errors in log, database filled.

I have ensured that:

- [x] The code I am submitting is my own work and/or I have permission from the author to share it.
- [x] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [x] I have documented any features added by this pull request.
- [x] This pull request does not introduce any incompatible API changes (stable branches only, delete if not applicable).
