### PR TITLE
Adding Romanian Language

### DIFF
--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -509,7 +509,7 @@ options
 	 *
 	 * Removing .UTF-8 will instead use the default encoding for the language, e.g. iso-8859-1 for western European languages.
 	 */
-	languages = "de_DE.UTF-8 el_GR.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 nl_NL.UTF-8 pl_PL.UTF-8 pt_PT.UTF-8 tr_TR.UTF-8"
+	languages = "de_DE.UTF-8 el_GR.UTF-8 es_ES.UTF-8 fr_FR.UTF-8 it_IT.UTF-8 nl_NL.UTF-8 pl_PL.UTF-8 pt_PT.UTF-8 ro_RO.UTF-8 tr_TR.UTF-8"
 
 	/*
 	 * Default language that non- and newly-registered nicks will receive messages in.

--- a/language/anope.ro_RO.po
+++ b/language/anope.ro_RO.po
@@ -6340,7 +6340,7 @@ msgstr "Utilizatori (pseudonim): %lu intrări, %lu compartimente, cel mai lung l
 
 #, c-format
 msgid "Users (uid): %lu entries, %lu buckets, longest chain is %zu"
-msgstr ""
+msgstr "Utilizatori (uid): %lu intrări, %lu compartimente, cel mai lung lanț este %zu"
 
 msgid "Users list:"
 msgstr "Listă de utilizatori este după cum urmează:"

--- a/language/anope.ro_RO.po
+++ b/language/anope.ro_RO.po
@@ -1,0 +1,7168 @@
+# Anope IRC Services language file
+# Copyright (C) 2025
+# This file is distributed under the same license as the Anope IRC Services package.
+# Cristian Anghel <kidprotect-cristian@yahoo.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Anope\n"
+"Report-Msgid-Bugs-To: #anope.ro at TeraNova IRC Network\n"
+"POT-Creation-Date: 2025-08-08 01:05+0100\n"
+"PO-Revision-Date: 2025-10-08 16:50+0100\n"
+"Last-Translator: Cristian Anghel <kidprotect-cristian@yahoo.com>\n"
+"Language-Team: Romanian\n"
+"Language: ro_RO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#, c-format
+msgid "%d channel(s) cleared, and %d channel(s) dropped."
+msgstr "%d canal(e) golite(e) și %d canal(e) radiat(e)."
+
+#, c-format
+msgid "%d nickname dropped."
+msgid_plural "%d nicknames dropped."
+msgstr[0] "%d pseudonim radiat."
+msgstr[1] "%d pseudonime radiate."
+
+#, c-format
+msgid "%s added to %s %s list."
+msgstr "%1$s a fost adăugat(ă) în lista de %3$s aparținând %2$s."
+
+#, c-format
+msgid "%s added to %s access list at level %d."
+msgstr "%s a fost adăugat(ă) în lista de accese aparținând %s cu nivelul %d."
+
+#, c-format
+msgid "%s added to %s access list at privilege %s (level %d)"
+msgstr "%s a fost adăugat(ă) în lista de accese aparținând %s cu privilegiul %s (nivelul %d)"
+
+#, c-format
+msgid "%s added to %s autokick list."
+msgstr "%s a fost adăugat(ă) în lista de izgoniri automate aparținănd %s."
+
+#, c-format
+msgid "%s added to %s bad words list."
+msgstr "%s a fost adăugat(ă) în lista de cuvinte nepotrivite aparținând %s."
+
+#, c-format
+msgid "%s added to %s's certificate list."
+msgstr "%s a fost adăugat(ă) în lista de certificate aparținând %s."
+
+#, c-format
+msgid "%s added to ignore list."
+msgstr "%s a fost adăugat(ă) în lista de ignorări."
+
+#, c-format
+msgid "%s added to the %s list."
+msgstr "%s a fost adăugat(ă) în lista de %s."
+
+#, c-format
+msgid "%s added to the AKILL list."
+msgstr "%s a fost adăugat(ă) în lista de AKILL."
+
+#, c-format
+msgid "%s allows you to execute \"fantasy\" commands in the channel. Fantasy commands are commands that can be executed from messaging a channel, and provide a more convenient way to execute commands. Commands that require a channel as a parameter will automatically have that parameter given."
+msgstr "%s vă permite să executați comenzile fanteziste ( \"fantasy\") în canal. Comenzile fanteziste sunt comenzi care pot fi executate prin trimiterea de mesaje într-un canal și oferă astfel o modalitate mai convenabilă de a executa comenzi. Comenzile care necesită un canal ca parametru vor avea automat acel parametru atribuit."
+
+#, c-format
+msgid "%s allows you to have a bot on your own channel. It has been created for users that can't host or configure a bot, or for use on networks that don't allow user bots. Available commands are listed below; to use them, type %scommand. For more information on a specific command, type %scommand."
+msgstr "%s vă permite să aveți un bot în propriul canal. Acesta a fost creat pentru utilizatorii care nu pot găzdui ori configura un bot, sau pentru utilizarea în rețelele care nu permit boți ai utilizatorilor. Comenzile disponibile sunt listate mai jos; pentru a le folosi tastați %scomanda. Pentru informații suplimentare privind o anumită comandă, tastați %scomanda."
+
+#, c-format
+msgid "%s allows you to register a nickname and prevent others from using it. The following commands allow for registration and maintenance of nicknames; to use them, type %scommand. For more information on a specific command, type %scommand."
+msgstr "%s vă permite să înregistrați un pseudonim și să impedicați alte persoane în a-l folosi. Următoarele comenzi permit înregistrarea și întreținerea pseudonimelor; pentru a le folosi tastați %scomanda. Pentru informații suplimentare privind o anumită comandă, tastați %scomanda."
+
+#, c-format
+msgid "%s allows you to register an account. The following commands allow for registration and maintenance of accounts; to use them, type %scommand. For more information on a specific command, type %scommand."
+msgstr "%s vă permite să înregistrați un cont. Următoarele comenzi permit înregistrarea și întreținerea conturilor; pentru a le folosi tastați %scomanda. Pentru informații suplimentare privind o anumită comandă, tastați %scomanda."
+
+#, c-format
+msgid "%s allows you to register and control various aspects of channels. %s can often prevent malicious users from \"taking over\" channels by limiting who is allowed channel operator privileges. Available commands are listed below; to use them, type %scommand. For more information on a specific command, type %scommand."
+msgstr "%s vă permite să înregistrați și să controlați diverse aspecte ale canalelor. %s poate adesea împiedica utilizatorii rău intenționați să \"preia controlul\" asupra canalelor prin limitarea privilegiilor de operator în canal. Comenzile disponibile sunt listate mai jos; pentru a le folosi, tastați %scomanda. Pentru informații suplimentare privind o anumită comandă, tastați %scomanda."
+
+#, c-format
+msgid "%s already exists in %s bad words list."
+msgstr "%s există deja în lista de cuvinte nepotrivite aparținând %s."
+
+#, c-format
+msgid "%s already exists on %s autokick list."
+msgstr "%s există deja în lista de izgoniri automate aparținând %s."
+
+#, c-format
+msgid "%s already exists on the EXCEPTION list."
+msgstr "%s există deja în lista de excepții."
+
+#, c-format
+msgid "%s cannot be taken as times to ban."
+msgstr "%s nu pot fi considerate ca momente de blocare."
+
+#, c-format
+msgid "%s changed your usermodes to %s."
+msgstr "%s v-a schimbat modurile de utilizator în %s."
+
+#, c-format
+msgid "%s channel list:"
+msgstr "Lista de canale aparținând %s este după cum urmează:"
+
+#, c-format
+msgid "%s deleted from %s %s list."
+msgstr "%1$s a fost înlăturat(ă) din lista de %3$s aparținând %2$s."
+
+#, c-format
+msgid "%s deleted from %s access list."
+msgstr "%s a fost înlăturat(ă) din lista de accese aparținând %s."
+
+#, c-format
+msgid "%s deleted from %s autokick list."
+msgstr "%s a fost înlăturat(ă) din lista de izgoniri automate aparținând %s."
+
+#, c-format
+msgid "%s deleted from %s bad words list."
+msgstr "%s a fost înlăturat(ă) din lista de cuvinte nepotrivite aparținând %s."
+
+#, c-format
+msgid "%s deleted from %s's certificate list."
+msgstr "%s a fost înlăturat(ă) din lista de certificate aparținând %s."
+
+#, c-format
+msgid "%s deleted from session-limit exception list."
+msgstr "%s a fost înlăturat(ă) din lista de excepții privind limita de sesiuni."
+
+#, c-format
+msgid "%s deleted from the %s list."
+msgstr "%s a fost înlăturat(ă) din lista de %s."
+
+#, c-format
+msgid "%s deleted from the AKILL list."
+msgstr "%s a fost înlăturat(ă) din lista de AKILL."
+
+#, c-format
+msgid "%s disabled on channel %s."
+msgstr "%s a fost dezactivat(ă) în canalul %s."
+
+#, c-format
+msgid "%s does not wish to be added to channel access lists."
+msgstr "%s nu dorește să fie adăugat(ă) în listele de accese ale canalelor."
+
+#, c-format
+msgid "%s has been invited to %s."
+msgstr "%s a fost invitat(ă) în %s."
+
+#, c-format
+msgid "%s has been joined to %s."
+msgstr "%s a fost alăturat(ă) în %s."
+
+#, c-format
+msgid "%s has been parted from %s."
+msgstr "%s a fost îndepărtat(ă) din %s."
+
+#, c-format
+msgid "%s has been unbanned from %s."
+msgstr "%s a fost deblocat(ă) în %s."
+
+#, c-format
+msgid "%s has no access in any channels."
+msgstr "%s nu are acces în niciun canal."
+
+#, c-format
+msgid "%s has no access on %s."
+msgstr "%s nu are acces în %s."
+
+#, c-format
+msgid "%s has too many channels registered."
+msgstr "%s are prea multe canale înregistrate."
+
+#, c-format
+msgid "%s is a super administrator."
+msgstr "%s este un super-administrator."
+
+#, c-format
+msgid ""
+"%s is a utility allowing IRC users to send short messages to other IRC users, whether they are online at the time or not, or to channels(*). Both the sender's nickname and the target nickname or channel must be registered in order to send a memo.\n"
+"\n"
+"%s's commands include:"
+msgstr ""
+"%s este un instrument care permite utilizatorilor IRC să expedieze mesaje scurte către alți utilizatori IRC indiferent dacă sunt online în acel moment sau nu, ori către canale(*). Atât pseudonimul expeditorului, cât și pseudonimul ori canalul destinatarului trebuie să fie înregistrate pentru a expedia o misivă.\n"
+"\n"
+"Comenzile %s includ următoarele:"
+
+#, c-format
+msgid "%s is already in %s!"
+msgstr "%s se află deja în %s!"
+
+#, c-format
+msgid "%s is already in %s."
+msgstr "%s se află deja în %s."
+
+#, c-format
+msgid "%s is already on the ignore list."
+msgstr "%s se află deja în lista de ignorări."
+
+#, c-format
+msgid "%s is already suspended."
+msgstr "%s este deja suspendat(ă)s."
+
+#, c-format
+msgid "%s is not a registered unforbidden nick or channel."
+msgstr "%s nu este un pseudonim, ori un canal, înregistrat și neinterzis."
+
+#, c-format
+msgid "%s is not a valid ban type."
+msgstr "%s nu este un tip de blocare valid."
+
+#, c-format
+msgid "%s is not a valid bot or registered channel."
+msgstr "%s nu este un bot valid sau un canal înregistrat."
+
+#, c-format
+msgid "%s is not a valid email address."
+msgstr "%s nu este o adresă de email validă."
+
+#, c-format
+msgid "%s is not currently on channel %s."
+msgstr "%s nu se află momentan în canalul %s."
+
+#, c-format
+msgid "%s is not in %s."
+msgstr "%s nu se află în %s."
+
+#, c-format
+msgid "%s is not on the ignore list."
+msgstr "%s nu se află în lista de ignorări."
+
+#, c-format
+msgid "%s is on the auto kick list of %s (%s)."
+msgstr "%s se află în lista de izgoniri automate aparținând %s (%s)."
+
+#, c-format
+msgid "%s is the founder of %s."
+msgstr "%s este fondator al %s."
+
+#, c-format
+msgid "%s matches access entry %s (from entry %s), which has privilege %s."
+msgstr "%s corespunde intrării de acces %s (de la intrarea %s), care are privilegiul %s."
+
+#, c-format
+msgid "%s matches access entry %s, which has privilege %s."
+msgstr "%s corespunde intrării de acces %s, care are privilegiul %s."
+
+#, c-format
+msgid "%s matches an except on %s and cannot be banned until the except has been removed."
+msgstr "%s corespunde unei excepții în %s și nu poate fi blocat(ă) până când excepția nu a fost înlăturată."
+
+#, c-format
+msgid "%s matches auto kick entry %s on %s (%s)."
+msgstr "%s corespunde intrării de izgonire automată %s în %s (%s)"
+
+#, c-format
+msgid "%s not found on %s %s list."
+msgstr "%1$s este de negăsit în lista de %3$s aparținând %2$s."
+
+#, c-format
+msgid "%s not found on %s access list."
+msgstr "%s este de negăsit în lista de accese aparținând %s."
+
+#, c-format
+msgid "%s not found on %s autokick list."
+msgstr "%s este de negăsit în lista de izgoniri automate aparținând %s."
+
+#, c-format
+msgid "%s not found on %s bad words list."
+msgstr "%s este de negăsit în lista de cuvinte nepotrivite aparținând %s."
+
+#, c-format
+msgid "%s not found on %s's certificate list."
+msgstr "%s este de negăsit în lista de certificate aparținând %s."
+
+#, c-format
+msgid "%s not found on ignore list."
+msgstr "%s este de negăsit în lista de ignorări."
+
+#, c-format
+msgid "%s not found on session list, but has a limit of %d because it matches entry: %s."
+msgstr "%s este de negăsit în lista de sesiuni, dar are o limită de %d deoarece corespunde intrării: %s."
+
+#, c-format
+msgid "%s not found on session-limit exception list."
+msgstr "%s este de negăsit în lista de excepții privind limitările de sesiune."
+
+#, c-format
+msgid "%s not found on the %s list."
+msgstr "%s este de negăsit în lista de %s."
+
+#, c-format
+msgid "%s not found on the AKILL list."
+msgstr "%s este de negăsit în lista de AKILL."
+
+#, c-format
+msgid "%s removed from the %s access list."
+msgstr "%s a fost înlăturat(ă) din lista de accese aparținând %s."
+
+#, c-format
+msgid "%s removed from the ignore list."
+msgstr "%s a fost înlăturat(ă) din lista de ignorări."
+
+#, c-format
+msgid "%s users list:"
+msgstr "Lista de utilizatori aparținând %s este după cum urmează:"
+
+#, c-format
+msgid "%s will no longer be ignored."
+msgstr "%s nu va mai fi ignorat(ă)."
+
+#, c-format
+msgid "%s will now be ignored for %s."
+msgstr "%s va fi de acum ignorat(ă) pentru %s."
+
+#, c-format
+msgid "%s will now permanently be ignored."
+msgstr "%s va fi de acum ignorat(ă) mereu."
+
+msgid "ADD nick user host real"
+msgstr "ADD pseudonim utilizator gazdă nume-real"
+
+msgid "CHANGE oldnick newnick [user [host [real]]]"
+msgstr "CHANGE pseudonim-vechi pseudonim-nou [utilizator [gazdă [nume-real]]]"
+
+msgid "DEL nick"
+msgstr "DEL pseudonim"
+
+msgid "ON is essentially LOGON and NEW combined."
+msgstr "ON is o combinație între LOGON și NEW."
+
+msgid "SET kills all operators from the given server and prevents operators from opering up on the given server. REVOKE removes this restriction."
+msgstr "SET deconectează toți Operatorii dintr-un server precizat și împiedică Operatorii să acționeze din acel server. REVOKE înlătură această restricție."
+
+#, c-format
+msgid "User access levels can be seen by using the %s command; type %sLEVELS for information."
+msgstr "Nivelurile de acces ale utilizatorilor pot fi văzute folosind comanda %s; tastați %sLEVELS pentru informații."
+
+#, c-format
+msgid "[auto-memo] The memo you sent to %s has been viewed."
+msgstr "[confirmare] Misiva pe care ați expediat-o către %s a fost vizualizată."
+
+msgid "{host}: {session} sessions"
+msgstr "{host}: {session} sesiuni"
+
+msgid "{mask}"
+msgstr "{mask}"
+
+msgid "{mask} -- created by {creator}; {expires}"
+msgstr "{mask} -- creat(ă) de {creator}; {expires}"
+
+msgid "{mask} -- created by {creator}; {expires} ({reason})"
+msgstr "{mask} -- creat(ă) de {creator}; {expires} ({reason})"
+
+msgid "{mask} on {type} -- created by {creator}; expires in {expires}"
+msgstr "{mask} pe {type} -- creat(ă) de {creator}; expiră în {expires}"
+
+msgid "{mask} on {type} -- created by {creator}; expires in {expires} ({reason})"
+msgstr "{mask} pe {type} -- creat(ă) de {creator}; expiră în {expires} ({reason})"
+
+msgid "{name}"
+msgstr "{name}"
+
+msgid "{name} ({description})"
+msgstr "{name} ({description})"
+
+msgid "{name} ({mask}) [{realname}]"
+msgstr "{name} ({mask}) [{realname}]"
+
+msgid "{name} -- {users} user(s); +{modes}"
+msgstr "{name} -- {users} utilizator/i; +{modes}"
+
+msgid "{name} -- {users} user(s); +{modes} ({topic})"
+msgstr "{name} -- {users} utilizator/i; +{modes} ({topic})"
+
+msgid "{name} = {level}"
+msgstr "{name} = {level}"
+
+msgid "{name} = {value}"
+msgstr "{name} = {value}"
+
+msgid "{name}: {description}"
+msgstr "{name}: {description}"
+
+msgid "{nick}"
+msgstr "{nick}"
+
+msgid "{nick} (last mask: {last_mask})"
+msgstr "{nick} (ultima mască: {last_mask})"
+
+msgid "{nick} ({mask}) [{real_name}]"
+msgstr "{nick} ({mask}) [{real_name}]"
+
+msgid "{nick}: registered on {registered}"
+msgstr "{nick}: înregistrat(ă) pe {registered}"
+
+msgid "{nick}: registered on {registered}; expires in {expires}"
+msgstr "{nick}: înregistrat(ă) pe {registered}; expiră în {expires}"
+
+msgid "{}{module_name}}:{name} = {value}"
+msgstr "{}{module_name}}:{name} = {value}"
+
+msgid "[target] [password]"
+msgstr "[destinație] [parolă]"
+
+msgid "address"
+msgstr "adresă"
+
+msgid "botname {ON|OFF}"
+msgstr "nume-bot {ON|OFF}"
+
+msgid "channel"
+msgstr "canal"
+
+msgid "channel bantype"
+msgstr "canal tip-blocare"
+
+msgid "channel command method [status]"
+msgstr "canal commandă metodă [statut]"
+
+msgid "channel mask [reason]"
+msgstr "canal mască [motiv]"
+
+msgid "channel modes"
+msgstr "canal moduri"
+
+msgid "channel nick"
+msgstr "canal pseudonim"
+
+msgid "channel nick [reason]"
+msgstr "canal pseudonim [motiv]"
+
+msgid "channel target [what]"
+msgstr "canal destinație [ce]"
+
+msgid "channel text"
+msgstr "canal text"
+
+msgid "channel time"
+msgstr "canal timp"
+
+msgid "channel user reason"
+msgstr "canal utilizator motiv"
+
+msgid "channel what"
+msgstr "canal ce"
+
+msgid "channel ADD mask level [description]"
+msgstr "canal ADD mască nivel [descriere]"
+
+msgid "channel ADD mask [description]"
+msgstr "canal ADD mască [descriere]"
+
+msgid "channel ADD message"
+msgstr "canal ADD mesaj"
+
+msgid "channel ADD word [SINGLE | START | END]"
+msgstr "canal ADD cuvânt [SINGLE | START | END]"
+
+msgid "channel ADD {nick | mask} [reason]"
+msgstr "canal ADD {pseudonim | mască} [motiv]"
+
+msgid "channel APPEND topic"
+msgstr "canal APPEND subiect"
+
+msgid "channel CLEAR"
+msgstr "canal CLEAR"
+
+msgid "channel CLEAR [what]"
+msgstr "canal CLEAR [ce]"
+
+msgid "channel CLEAR [ALL]"
+msgstr "canal CLEAR [ALL]"
+
+msgid "channel DEL num"
+msgstr "canal DEL număr"
+
+msgid "channel DEL {mask | entry-num | list}"
+msgstr "canal DEL {mască | număr-intrare | listă}"
+
+msgid "channel DEL {nick | mask | entry-num | list}"
+msgstr "canal DEL {pseudonim | mască | număr-intrare | listă}"
+
+msgid "channel DEL {word | entry-num | list}"
+msgstr "canal DEL {cuvânt | număr-intrare | listă}"
+
+msgid "channel ENFORCE"
+msgstr "canal ENFORCE"
+
+msgid "channel LIST"
+msgstr "canal LIST"
+
+msgid "channel LIST [mask | entry-num | list]"
+msgstr "canal LIST [mască | număr-intrare | listă]"
+
+msgid "channel LIST [mask | list]"
+msgstr "canal LIST [mască | listă]"
+
+msgid "channel LIST [mask | +flags]"
+msgstr "canal LIST [mască | +stegulețe]"
+
+msgid "channel LOCK {ADD|DEL|SET|LIST} [what]"
+msgstr "canal LOCK {ADD|DEL|SET|LIST} [ce]"
+
+msgid "channel PREPEND topic"
+msgstr "canal PREPEND subiect"
+
+msgid "channel RESET"
+msgstr "canal RESET"
+
+msgid "channel SET modes"
+msgstr "canal SET moduri"
+
+msgid "channel SET type level"
+msgstr "canal SET tip nivel"
+
+msgid "channel VIEW [mask | entry-num | list]"
+msgstr "canal VIEW [mască | număr-intrare | listă]"
+
+msgid "channel VIEW [mask | list]"
+msgstr "canal VIEW [mască | listă]"
+
+msgid "channel [code]"
+msgstr "canal [cod]"
+
+msgid "channel [description]"
+msgstr "canal [descriere]"
+
+msgid "channel [nick]"
+msgstr "canal [pseudonim]"
+
+msgid "channel [parameters]"
+msgstr "canal [parametri]"
+
+msgid "channel [user]"
+msgstr "canal [utilizator]"
+
+msgid "channel [user]+"
+msgstr "canal [utilizator]+"
+
+msgid "channel [+expiry] [reason]"
+msgstr "canal [+expirare] [motiv]"
+
+msgid "channel [+expiry] {nick | mask} [reason]"
+msgstr "canal [+expirare] {pseudonim | mască} [motiv]"
+
+msgid "channel [MODIFY] mask changes [description]"
+msgstr "canal [MODIFY] mască schimbări [descriere]"
+
+msgid "channel [SET] [topic]"
+msgstr "canal [SET] [subiect]"
+
+msgid "channel [UNLOCK|LOCK]"
+msgstr "canal [UNLOCK|LOCK]"
+
+msgid "channel {ON|OFF}"
+msgstr "canal {ON|OFF}"
+
+msgid "channel {ON|OFF} [ttb [ln [secs]]]"
+msgstr "canal {ON|OFF} [ttb [linii [secunde]]]"
+
+msgid "channel {ON|OFF} [ttb [min [percent]]]"
+msgstr "canal {ON|OFF} [ttb [minim [procentaj]]]"
+
+msgid "channel {ON|OFF} [ttb [num]]"
+msgstr "canal {ON|OFF} [ttb [număr]]"
+
+msgid "channel {ON|OFF} [ttb]"
+msgstr "canal {ON|OFF} [ttb]"
+
+msgid "channel {DIS | DISABLE} type"
+msgstr "channel {DIS | DISABLE} tip"
+
+msgid "channel {ON | LEVEL | OFF}"
+msgstr "canal {ON | LEVEL | OFF}"
+
+msgid "channel {ON | OFF}"
+msgstr "canal {ON | OFF}"
+
+msgid "code"
+msgstr "cod"
+
+msgid "email"
+msgstr "email"
+
+msgid "language"
+msgstr "limbă"
+
+msgid "memo-text"
+msgstr "text-misivă"
+
+msgid "message"
+msgstr "mesaj"
+
+msgid "modname"
+msgstr "nume-modul"
+
+msgid "network-name"
+msgstr "nume-rețea"
+
+msgid "new-display"
+msgstr "afișaj-nou"
+
+msgid "new-password"
+msgstr "parolă-nouă"
+
+msgid "nick"
+msgstr "pseudonim"
+
+msgid "nick channel"
+msgstr "pseudonim canal"
+
+msgid "nick channel [reason]"
+msgstr "pseudonim canal [motiv]"
+
+msgid "nick hostmask"
+msgstr "pseudonim masca-gazdei"
+
+msgid "nick newnick"
+msgstr "pseudonim pseudonim-nou"
+
+msgid "nick [reason]"
+msgstr "pseudonim [motiv]"
+
+msgid "nickname"
+msgstr "pseudonim"
+
+msgid "nickname address"
+msgstr "pseudonim adresă"
+
+msgid "nickname email"
+msgstr "pseudonim email"
+
+msgid "nickname language"
+msgstr "pseudonim limbă"
+
+msgid "nickname message"
+msgstr "pseudonim mesaj"
+
+msgid "nickname new-display"
+msgstr "pseudonim afișaj-nou"
+
+msgid "nickname new-password"
+msgstr "pseudonim parolă-nouă"
+
+msgid "nickname timezone"
+msgstr "pseudonim fus-orar"
+
+msgid "nickname [code]"
+msgstr "pseudonim [cod]"
+
+msgid "nickname [parameter]"
+msgstr "pseudonim [parametru]"
+
+msgid "nickname [password]"
+msgstr "pseudonim [parolă]"
+
+msgid "nickname [+expiry] [reason]"
+msgstr "pseudonim [+expirare] [motiv]"
+
+msgid "nickname {EMAIL | STATUS | MASK | QUIT} {ON | OFF}"
+msgstr "pseudonim {EMAIL | STATUS | MASK | QUIT} {ON | OFF}"
+
+msgid "nickname {FIXED | FLEXIBLE | MONOSPACE}"
+msgstr "pseudonim {FIXED | FLEXIBLE | MONOSPACE}"
+
+msgid "nickname {ON | delay | OFF}"
+msgstr "pseudonim {ON | întârziere | OFF}"
+
+msgid "nickname {ON | OFF}"
+msgstr "pseudonim {ON | OFF}"
+
+msgid "option (channel | bot) settings"
+msgstr "opțiune (canal | bot) setări"
+
+msgid "option channel parameters"
+msgstr "opțiune canal parametri"
+
+msgid "option channel {ON|OFF} [settings]"
+msgstr "opțiune canal {ON|OFF} [setări]"
+
+msgid "option nickname parameters"
+msgstr "opțiune pseudonim parametri"
+
+msgid "option parameters"
+msgstr "opțiune parametri"
+
+msgid "option setting"
+msgstr "opțiune setare"
+
+msgid "password"
+msgstr "parolă"
+
+msgid "password [email]"
+msgstr "parolă [email]"
+
+msgid "password email"
+msgstr "parolă email"
+
+msgid "pattern [SUSPENDED] [NOEXPIRE]"
+msgstr "model [SUSPENDED] [NOEXPIRE]"
+
+msgid "pattern [SUSPENDED] [NOEXPIRE] [UNCONFIRMED]"
+msgstr "model [SUSPENDED] [NOEXPIRE] [UNCONFIRMED]"
+
+msgid "server [message]"
+msgstr "server [mesaj]"
+
+msgid "server [reason]"
+msgstr "server [motiv]"
+
+msgid "timezone"
+msgstr "fus-orar"
+
+msgid "type parameters"
+msgstr "tip parametri"
+
+msgid "user modes"
+msgstr "utilizator moduri"
+
+msgid "user [reason]"
+msgstr "utilizator [motiv]"
+
+#, c-format
+msgid "   %s is online using this oper block."
+msgstr "   %s este online utilizând acest bloc Operator."
+
+#, c-format
+msgid "   Command %s on %s is linked to %s"
+msgstr "   Comanda %s în %s este legată de %s"
+
+#, c-format
+msgid "   Providing service: %s"
+msgstr "   Furnizare serviciu: %s"
+
+msgid "   This oper is configured in the configuration file."
+msgstr "   Acest Operator este configurat în fișierul de configurare."
+
+#, c-format
+msgid " Loaded at: %p"
+msgstr " Încărcat la: %p"
+
+#, c-format
+msgid " but %s mysteriously dematerialized."
+msgstr " dar %s s-a dematerializat într-un mod misterios."
+
+msgid "\"Jupiter\" a server"
+msgstr "\"Jupiter\" un server"
+
+#, c-format
+msgid "%-8s %s"
+msgstr "%-8s %s"
+
+#, c-format
+msgid "%2d %-16s letters: %s, words: %s, lines: %s, smileys: %s, actions: %s"
+msgstr "%2d %-16s litere: %s, cuvinte: %s, linii: %s, zâmbete: %s, acțiuni: %s"
+
+#, c-format
+msgid "%c is an unknown status mode."
+msgstr "%c este un mod de statut necunoscut."
+
+#, c-format
+msgid "%c%c is not locked on %s."
+msgstr "%c%c nu este încuiat în %s."
+
+#, c-format
+msgid "%c%c%s has been unlocked from %s."
+msgstr "%c%c%s a fost descuiat din %s."
+
+#, c-format
+msgid "%d access entries from %s have been cloned to %s."
+msgstr "%d intrările de acces din %s au fost clonate în %s."
+
+#, c-format
+msgid "%d bots available."
+msgstr "%d boți disponibili."
+
+#, c-format
+msgid "%d modules loaded."
+msgstr "%d module încărcate."
+
+#, c-format
+msgid "%lld day"
+msgid_plural "%lld days"
+msgstr[0] "%lld zi"
+msgstr[1] "%lld zile"
+
+#, c-format
+msgid "%lld hour"
+msgid_plural "%lld hours"
+msgstr[0] "%lld oră"
+msgstr[1] "%lld ore"
+
+#, c-format
+msgid "%lld minute"
+msgid_plural "%lld minutes"
+msgstr[0] "%lld minut"
+msgstr[1] "%lld minute"
+
+#, c-format
+msgid "%lld second"
+msgid_plural "%lld seconds"
+msgstr[0] "%lld secundă"
+msgstr[1] "%lld secunde"
+
+#, c-format
+msgid "%lld year"
+msgid_plural "%lld years"
+msgstr[0] "%lld an"
+msgstr[1] "%lld ani"
+
+#, c-format
+msgid "%lu nicks are stored in the database, using %.2Lf kB of memory."
+msgstr "%lu pseudonime sunt stocate în baza de date, folosind %.2Lf KB de memorie."
+
+#, c-format
+msgid "%s %s list is empty."
+msgstr "Lista de %2$s din %1$s este goală."
+
+#, c-format
+msgid "%s (%d kick(s) to ban)"
+msgstr "%s (%d izgoniri de blocat)"
+
+#, c-format
+msgid "%s (%d kick(s) to ban; %d lines in %ds)"
+msgstr "%s (%d izgoniri de blocat; %d linii în %ds)"
+
+#, c-format
+msgid "%s (%d kick(s) to ban; %d times)"
+msgstr "%s (%d izgoniri de blocat; %d repetări)"
+
+#, c-format
+msgid "%s (%d kick(s) to ban; minimum %d/%d%%)"
+msgstr "%s (%d izgoniri de blocat; minim %d/%d%%)"
+
+#, c-format
+msgid "%s (%d lines in %ds)"
+msgstr "%s (%d linii în %ds)"
+
+#, c-format
+msgid "%s (%d times)"
+msgstr "%s (%d repetări)"
+
+#, c-format
+msgid "%s (%s ago)"
+msgstr "%s (acum %s)"
+
+#, c-format
+msgid "%s (%s from now)"
+msgstr "%s (%s de acum)"
+
+#, c-format
+msgid "%s (%s) was kicked from %s (\"%s\") %s ago%s"
+msgstr "%s (%s) a fost izgonit(ă) din %s (\"%s\") acum %s%s"
+
+#, c-format
+msgid "%s (%s) was kicked from a secret channel %s ago%s"
+msgstr "%s (%s) a fost izgonit(ă) dintr-un canal secret acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen changing nick from %s to %s %s ago%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată schimbându-și pseudonimul din %s în %s acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen changing nick to %s %s ago%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată schimbându-și pseudonimul în %s acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen connecting %s ago (%s)%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată conectându-se acum %s (%s)%s"
+
+#, c-format
+msgid "%s (%s) was last seen joining %s %s ago%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată alăturându-se în %s acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen joining a secret channel %s ago%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată alăturându-se unui canal secret acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen parting %s %s ago%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată îndepărtându-se din %s acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen parting a secret channel %s ago%s"
+msgstr "%s (%s) a fost văzut(ă) ultima dată îndepărtându-se dintr-un canal secret acum %s%s"
+
+#, c-format
+msgid "%s (%s) was last seen quitting (%s) %s ago (%s)."
+msgstr "%s (%s) a fost văzut(ă) ultima dată plecând din rețea (%s) acum %s (%s)."
+
+#, c-format
+msgid "%s (minimum %d/%d%%)"
+msgstr "%s (minim %d/%d%%)"
+
+#, c-format
+msgid "%s (now)"
+msgstr "%s (acum)"
+
+#, c-format
+msgid "%s access list is empty."
+msgstr "Lista de accese aparținând %s este goală."
+
+#, c-format
+msgid "%s added to %s's auto join list."
+msgstr "%s a fost adăugat(ă) în lista de alăturări automate aparținând %s."
+
+#, c-format
+msgid "%s already exists."
+msgstr "%s există deja."
+
+#, c-format
+msgid "%s autokick list is empty."
+msgstr "Lista de izgoniri automate aparținând %s este goală."
+
+#, c-format
+msgid "%s bad words list is empty."
+msgstr "Lista de cuvinte nepotrivite aparținând %s este goală."
+
+#, c-format
+msgid "%s can no longer be added to channel access lists."
+msgstr "%s nu mai poate fi adăugat(ă) în listele de acces ale canalelor."
+
+#, c-format
+msgid "%s can now be added to channel access lists."
+msgstr "%s poate fi adăugat(ă) acum în listele de accese ale canalelor."
+
+#, c-format
+msgid "%s cannot be the successor on channel %s as they are the founder."
+msgstr "%s nu poate fi succesor al canalului %s deoarece este fondator."
+
+#, c-format
+msgid "%s commands:"
+msgstr "Comenzile %s sunt după cum urmează:"
+
+#, c-format
+msgid "%s coverage is too wide; Please use a more specific mask."
+msgstr "%s corespunde cu prea mulți utilizatori; vă rugăm specificați o mască mai specifică."
+
+#, c-format
+msgid "%s currently has %zu memos, of which %zu are unread."
+msgstr "%s are momentan %zu misive, din care %zu sunt necitite."
+
+#, c-format
+msgid "%s currently has %zu memos, of which 1 is unread."
+msgstr "%s are momentan %zu misive, din care 1 este necitită."
+
+#, c-format
+msgid "%s currently has %zu memos."
+msgstr "%s are momentan %zu misive."
+
+#, c-format
+msgid "%s currently has %zu memos; all of them are unread."
+msgstr "%s are momentan %zu misive; toate necitite."
+
+#, c-format
+msgid "%s currently has 1 memo, and it has not yet been read."
+msgstr "%s are momentan 1 misivă, iar aceasta nu a fost încă citită."
+
+#, c-format
+msgid "%s currently has 1 memo."
+msgstr "%s are momentan 1 misivă."
+
+#, c-format
+msgid "%s currently has no memos."
+msgstr "%s nu are momentan nicio misivă."
+
+#, c-format
+msgid "%s deleted from the %s forbid list."
+msgstr "%s a fost înlăturat(ă) din lista de interziceri %s."
+
+#, c-format
+msgid "%s for %s set to %s."
+msgstr "%s pentru %s a fost setat la %s."
+
+#, c-format
+msgid "%s for %s unset."
+msgstr "%s pentru %s a fost de-setat."
+
+#, c-format
+msgid "%s had an invalid key specified, and was thus ignored."
+msgstr "%s a avut specificată o cheie invalidă, prin urmare a fost ignorată."
+
+#, c-format
+msgid "%s has no memo limit."
+msgstr "%s nu are limită de misive."
+
+#, c-format
+msgid "%s has no memos."
+msgstr "%s nu are misive."
+
+#, c-format
+msgid "%s has no new memos."
+msgstr "%s nu are misive noi."
+
+#, c-format
+msgid "%s is a Services Operator of type %s."
+msgstr "%s este Operator de Servicii de tip %s."
+
+#, c-format
+msgid "%s is a client on services."
+msgstr "%s este un client de servicii."
+
+#, c-format
+msgid "%s is already covered by %s."
+msgstr "%s este deja acoperit(ă) de %s."
+
+#, c-format
+msgid "%s is already on %s's auto join list."
+msgstr "%s se află deja în lista de alăturări automate aparținând %s."
+
+#, c-format
+msgid "%s is an unconfirmed nickname."
+msgstr "%s este un pseudonim neconfirmat."
+
+#, c-format
+msgid ""
+"%s is another way to modify the channel access list, similar to the XOP and ACCESS methods.\n"
+"\n"
+"The MODIFY command allows you to modify the access list. If the mask is not already on the access list it is added, then the changes are applied. If the mask has no more flags, then the mask is removed from the access list. Additionally, you may use +* or -* to add or remove all flags, respectively. You are only able to modify the access list if you have the proper permission on the channel, and even then you can only give other people access to the equivalent of what your access is.\n"
+"\n"
+"The LIST command allows you to list existing entries on the channel access list. If a mask is given, the mask is wildcard matched against all existing entries on the access list, and only those entries are returned. If a set of flags is given, only those on the access list with the specified flags are returned.\n"
+"\n"
+"The CLEAR command clears the channel access list. This requires channel founder access.\n"
+"\n"
+"The available flags are:"
+msgstr ""
+"%s este o altă modalitate de a modifica lista de accese aparținând canalului, similară cu metodele XOP și ACCESS.\n"
+"\n"
+"Comanda MODIFY vă permite să modificați lista de accese. Dacă masca nu se află deja în lista de accese, aceasta este adăugată, apoi modificările sunt aplicate. Dacă masca nu mai are stegulețe, atunci masca este înlăturată din lista de accese. În plus, puteți utiliza +* sau -* pentru a adăuga, respectiv înlătura toate stegulețele. Puteți modifica lista de accese numai dacă aveți permisiunea corespunzătoare în canal însă chiar și atunci puteți oferi altor persoane acces doar la echivalentul accesului dumneavoastră.\n"
+"\n"
+"Comanda LIST vă permite să listați intrările existente din lista de accese în canal. Dacă este oferită o mască, aceasta este comparată cu toate intrările existente din lista de accese și numai acele intrări sunt returnate. Dacă este oferit un set de stegulețe, sunt returnate doar cele din lista de accese cu stegulețele specificate.\n"
+"\n"
+"Comanda CLEAR golește lista de accese în canal. Această comandă necesită acces de fondator al canalului.\n"
+"\n"
+"Stegulețele disponibile sunt după cum urmează:"
+
+#, c-format
+msgid "%s is currently online."
+msgstr "%s este momentan online."
+
+#, c-format
+msgid "%s is disabled"
+msgstr "%s este dezactivat(ă)"
+
+#, c-format
+msgid "%s is enabled"
+msgstr "%s este activat(ă)"
+
+#, c-format
+msgid "%s is not a valid IP address."
+msgstr "%s nu este o adresă IP validă."
+
+#, c-format
+msgid "%s is not a valid command."
+msgstr "%s nu este o comandă validă."
+
+#, c-format
+msgid "%s is not a valid logging method."
+msgstr "%s nu este o metodă de jurnalizare validă."
+
+#, c-format
+msgid "%s is not notified of new memos."
+msgstr "%s nu este notificat(ă) despre noile misive."
+
+#, c-format
+msgid "%s is notified of new memos at logon and when they arrive."
+msgstr "%s este notificat(ă) despre noile misive atunci când se identifică și atunci când acestea sosesc."
+
+#, c-format
+msgid "%s is notified of new memos at logon."
+msgstr "%s este notificat(ă) despre noile misive atunci când se identifică."
+
+#, c-format
+msgid "%s is notified when new memos arrive."
+msgstr "%s este notificat(ă) despre noile misive atunci când acestea sosesc."
+
+#, c-format
+msgid "%s list for %s"
+msgstr "Lista de %s pentru %s"
+
+#, c-format
+msgid "%s list is empty."
+msgstr "Lista de %s este goală."
+
+#, c-format
+msgid "%s locked on %s."
+msgstr "%s este încuiat pentru %s."
+
+#, c-format
+msgid "%s not found."
+msgstr "%s nu a fost găsit(ă)."
+
+#, c-format
+msgid "%s settings:"
+msgstr "Setările %s sunt după cum urmează:"
+
+#, c-format
+msgid "%s was not found on %s's auto join list."
+msgstr "%s nu a fost găsit(ă) în lista de alăturări automate aparținând %s."
+
+#, c-format
+msgid "%s was removed from %s's auto join list."
+msgstr "%s a fost înlăturat(ă) din lista de alăturări automate aparținând %s."
+
+#, c-format
+msgid "%s will not send you any notification of memos."
+msgstr "%s nu vă va expedia nicio notificare despre misive."
+
+#, c-format
+msgid "%s will now notify you of memos when they are sent to you."
+msgstr "%s vă va notifica despre misive atunci când vă sunt expediate."
+
+#, c-format
+msgid "%s will now notify you of memos when you log on and when they are sent to you."
+msgstr "%s vă va notifica despre misive atunci când vă identificați și atunci când vă sunt expediate."
+
+#, c-format
+msgid "%s will now notify you of memos when you log on or unset /AWAY."
+msgstr "%s vă va notifica despre misive atunci când vă identificați și atunci când vă de-setați /AWAY."
+
+#, c-format
+msgid "%s!%s@%s (%s) added to the bot list."
+msgstr "%s!%s@%s (%s) a fost adăugat la lista de boți."
+
+#, c-format
+msgid "%s's auto join list is empty."
+msgstr "Lista de alăturări automate aparținând %s este goală."
+
+#, c-format
+msgid "%s's auto join list:"
+msgstr "Lista de alăturări automate aparținând %s este după cum urmează:"
+
+#, c-format
+msgid "%s's certificate list is empty."
+msgstr "Lista de certificate aparținând %s este goală."
+
+#, c-format
+msgid "%s's memo limit is %d, and may not be changed."
+msgstr "Limita de misive aparținând %s este %d și nu poate fi schimbată."
+
+#, c-format
+msgid "%s's memo limit is %d."
+msgstr "Limita de misive aparținând %s este %d."
+
+#, c-format
+msgid "%u channel"
+msgid_plural "%u channels"
+msgstr[0] "%u canal"
+msgstr[1] "%u canale"
+
+#, c-format
+msgid "%zu nickname in the account."
+msgid_plural "%zu nicknames in the account."
+msgstr[0] "%zu pseudonim în cont."
+msgstr[1] "%zu pseudonime în cont."
+
+msgid "(Split)"
+msgstr "(Decuplare)"
+
+#, c-format
+msgid "(by %s on %s) %s"
+msgstr "(de %s pe %s) %s"
+
+msgid "(disabled)"
+msgstr "(dezactivat)"
+
+msgid "(founder only)"
+msgstr "(doar fondator)"
+
+msgid "* AKILL any new clients connecting"
+msgstr "* AKILL orice client nou care se conectează"
+
+#, c-format
+msgid "* Force channel modes (%s) to be set on all channels"
+msgstr "* Forțează setarea modurilor de canal (%s) în toate canalele"
+
+msgid "* Ignore non-opers with a message"
+msgstr "* Ignoră non-Operatorii cu un mesaj"
+
+msgid "* Kill any new clients connecting"
+msgstr "* Deconectează orice client nou care încearcă să se conecteze"
+
+msgid "* No mode lock changes"
+msgstr "* Fără schimbarea modurilor încuiate"
+
+msgid "* No new channel registrations"
+msgstr "* Fără noi înregistrări de canal"
+
+msgid "* No new memos sent"
+msgstr "* Fără noi expedieri de misive"
+
+msgid "* No new nick registrations"
+msgstr "* Fără noi înregistrări de pseudonime"
+
+msgid "* Silently ignore non-opers"
+msgstr "* Ignoră în tăcere non-Operatorii"
+
+#, c-format
+msgid "* Use the reduced session limit of %d"
+msgstr "* Utilizează limita redusă de sesiuni de %d"
+
+#, c-format
+msgid ", but %s mysteriously dematerialized."
+msgstr ", dar %s s-a dematerializat în mod misterios."
+
+#, c-format
+msgid ". %s is still online."
+msgstr ". %s este încă online."
+
+msgid "<unknown>"
+msgstr "<necunoscut>"
+
+msgid "@nickname"
+msgstr "@pseudonim"
+
+#, c-format
+msgid "A confirmation email has been sent to %s. Follow the instructions in it to change your email address."
+msgstr "Un mesaj email de confirmare a fost expediat către %s. Urmați instrucțiunile din acesta pentru a vă schimba adresa de email."
+
+msgid "A massmemo has been sent to all registered users."
+msgstr "O misivă în masă a fost expediată tuturor utilizatorilor înregistrați."
+
+msgid "A memo informing the user will also be sent, which includes the reason for the rejection if supplied."
+msgstr "O misivă de informare a utilizatorului de asemenea va fi expediată, care include motivul respingerii dacă acesta este furnizat."
+
+msgid "A memo informing the user will also be sent."
+msgstr "O misivă de informare a utilizatorului de asemenea va fi expediată."
+
+#, c-format
+msgid "A notification memo has been sent to %s informing them you have read their memo."
+msgstr "O misivă de notificare a fost expediată către %s, ca o informmare că ați citit mesajul lor."
+
+msgid "A vhost must be in the format of a valid hostname."
+msgstr "O gazdă virtuală trebuie să fie în formatul unui nume de gazdă valid."
+
+msgid "A vident must be in the format of a valid ident."
+msgstr "O identitate virtuală trebuie să fie în formatul unei identități valide."
+
+msgid "ADD expiry {nick|mask} [reason]"
+msgstr "ADD expirare {pseudonim|mască} [motiv]"
+
+msgid "ADD message"
+msgstr "ADD mesaj"
+
+msgid "ADD oper type"
+msgstr "ADD Operator tip"
+
+msgid "ADD target info"
+msgstr "ADD destinație informație"
+
+msgid "ADD text"
+msgstr "ADD text"
+
+msgid "ADD [+expiry] mask limit reason"
+msgstr "ADD [+expirare] mască limită motiv"
+
+msgid "ADD [nickname] channel [key]"
+msgstr "ADD [pseudonim] canal [cheie]"
+
+msgid "ADD [nickname] [fingerprint]"
+msgstr "ADD [pseudonim] [amprentă-digitală]"
+
+msgid "ADD [+expiry] mask reason"
+msgstr "ADD [+expirare] mască motiv"
+
+msgid "ADD [+expiry] mask:reason"
+msgstr "ADD [+expirare] mască:motiv"
+
+msgid "ADD {NICK|CHAN|EMAIL|REGISTER} [+expiry] entry reason"
+msgstr "ADD {NICK|CHAN|EMAIL|REGISTER} [+expirare] intrare motiv"
+
+msgid "ADDIP server.name ip"
+msgstr "ADDIP nume.server ip"
+
+msgid "ADDSERVER server.name [zone.name]"
+msgstr "ADDSERVER nume.server [nume.zonă]"
+
+msgid "ADDZONE zone.name"
+msgstr "ADDZONE nume.zonă"
+
+#, c-format
+msgid "AKICK ENFORCE for %s complete; %d users were affected."
+msgstr "AKICK ENFORCE pentru %s s-a finalizat; %d utilizatori au fost afectați."
+
+msgid "AKILL all users on a specific channel"
+msgstr "AKILL toți utilizatorii dintr-un canal anume"
+
+msgid "AKILL list is empty."
+msgstr "Lista de AKILL este goală."
+
+msgid "AMSG kicker"
+msgstr "Izgonire la AMSG"
+
+msgid "Access"
+msgstr "Acces"
+
+msgid "Access denied."
+msgstr "Acces refuzat."
+
+#, c-format
+msgid "Access for %s on %s:"
+msgstr "Accesul pentru %s în %s este după cum urmează:"
+
+#, c-format
+msgid "Access level must be between %d and %d inclusive."
+msgstr "Nivelul de acces trebuie să fie între %d și %d inclusiv."
+
+msgid "Access level must be non-zero."
+msgstr "Nivelul de acces trebuie să fie diferit de zero."
+
+#, c-format
+msgid "Access level settings for channel %s:"
+msgstr "Setările nivelului de acces pentru canalul %s sunt după cum urmează:"
+
+#, c-format
+msgid "Access levels for %s reset to defaults."
+msgstr "Nivelele de acces pentru %s au fost resetate la valorile implicite."
+
+#, c-format
+msgid "Access list for %s:"
+msgstr "Lista de accese pentru %s este după cum urmează:"
+
+#, c-format
+msgid "Access to this command requires the permission %s to be present in your opertype."
+msgstr "Accesul la această comandă necesită ca permisiunea %s să fie prezentă în tipul de Operator al dumneavoastră."
+
+msgid "Account"
+msgstr "Cont"
+
+#, c-format
+msgid "Account %s has already reached the maximum number of simultaneous logins (%u)."
+msgstr "Contul %s a atins deja numărul maxim de identificări simultane (%u)."
+
+msgid "Account registered"
+msgstr "Cont înregistrat"
+
+msgid "Accounts can not be registered right now. Please try again later."
+msgstr "Nu pot fi înregistrate conturi în acest moment. Vă rugăm încercați mai târziu."
+
+#, c-format
+msgid "Accounts that are not used anymore are subject to the automatic expiration, i.e. they will be deleted after %s if not used."
+msgstr "Conturile care nu mai sunt utilizate expiră automat, adică vor fi radiate după %s dacă nu sunt folosite."
+
+msgid "Activate or deactivate debug mode"
+msgstr "Activează sau dezactivează modul de depanare"
+
+msgid "Activate or deactivate no expire mode"
+msgstr "Activează sau dezactivează modul fără expirare"
+
+msgid "Activate or deactivate super admin mode"
+msgstr "Activează sau dezactivează modul super-administrator"
+
+msgid "Activate the requested vhost for the given nick."
+msgstr "Activează gazda virtuală solicitată pentru pseudonimul precizat."
+
+msgid "Activates the vhost currently assigned to the nick in use. When you use this command any user who performs a /whois on you will see the vhost instead of your real host/IP address."
+msgstr "Activează gazda virtuală care v-a fost atribuită pentru pseudoniumul folosit acum. Când utilizați această comandă, orice utilizator care efectuează un /whois asupra pseudonimului dumneavoastră, va vedea gazda virtuală atribuită în loc de gazda ori adresa IP reală."
+
+msgid "Activates your assigned vhost"
+msgstr "Activează gazda virtuală atribuită dumneavoastră"
+
+msgid "Add a nick to an account"
+msgstr "Adaugă un pseudonim la un cont"
+
+msgid "Add or delete oper information for a given nick or channel. This will show to opers in the respective info command for the nick or channel."
+msgstr "Adaugă sau șterge informații de operator pentru un anumit pseudonim ori canal. Acestea vor fi afișate operatorilor în comanda info privind pseudonimul ori canalul cercetat."
+
+#, c-format
+msgid "Added IP %s to %s."
+msgstr "A fost adăugată adresa IP %s la %s."
+
+#, c-format
+msgid "Added a forbid on %s of type %s to expire on %s."
+msgstr "S-a adăugat o interzicere pentru %s de tipul %s care să expire în %s."
+
+#, c-format
+msgid "Added info to %s."
+msgstr "S-a adăugat informația la %s."
+
+msgid "Added new logon news item."
+msgstr "A fost adăugată o nouă știre la identificare."
+
+msgid "Added new oper news item."
+msgstr "A fost adăugată o nouă știre la Operare."
+
+msgid "Added new random news item."
+msgstr "A fost adăugată o nouă știre aleatorie."
+
+#, c-format
+msgid "Added server %s."
+msgstr "Serverul %s a fost adăugat."
+
+#, c-format
+msgid "Added zone %s."
+msgstr "Zona %s a fost adăugată."
+
+msgid "Additionally, Services Operators with the chanserv/drop/override permission can replace code with OVERRIDE to drop without a confirmation code."
+msgstr "În plus, Operatorii de Servicii cu permisiunea chanserv/drop/override pot înlocui codul cu OVERRIDE pentru a radia fără un cod de confirmare."
+
+msgid "Additionally, Services Operators with the nickserv/confirm/email permission can specify @nickname instead of code to force confirm another user's change of email address."
+msgstr "În plus, Operatorii de Servicii cu permisiunea nickserv/confirm/email pot specifica @pseudonimul în loc de cod pentru a forța confirmarea schimbării adresei de email a unui alt utilizator."
+
+msgid "Additionally, Services Operators with the nickserv/confirm/register permission can specify @nickname instead of code to force confirm another user's account registration."
+msgstr "În plus, Operatorii de Servicii cu permisiunea nickserv/confirm/register pot specifica @pseudonimul în loc de cod pentru a forța confirmarea înregistrării contului unui alt utilizator."
+
+msgid "Additionally, Services Operators with the nickserv/drop/override permission can replace code with OVERRIDE to drop without a confirmation code."
+msgstr "În plus, Operatorii de Servicii cu permisiunea nickserv/drop/override pot înlocui codul cu OVERRIDE pentru a radia fără un cod de confirmare."
+
+msgid "Additionally, Services Operators with the nickserv/resend permission can specify a nickname to resend a confirmation email for another account."
+msgstr "În plus, Operatorii de Servicii cu permisiunea nickserv/resend pot specifica un pseudonim pentru a retrimite un mesaj email de confirmare pentru un alt cont."
+
+#, c-format
+msgid "Additionally, if fantasy is enabled fantasy commands can be executed by prefixing the command name with one of the following characters: %s"
+msgstr "În plus, dacă este activată fantezia, comenzile fanteziste pot fi executate prin prefixarea numelui comenzii cu unul dintre următoarele caractere: %s"
+
+#, c-format
+msgid "All O:lines of %s have been reset."
+msgstr "Toate liniile O:line aparținând %s au fost resetate."
+
+#, c-format
+msgid "All akick entries from %s have been cloned to %s."
+msgstr "Toate intrările AKICK din %s au fost clonate în %s."
+
+#, c-format
+msgid "All available commands for %s:"
+msgstr "Toate comenzile disponibile pentru %s sunt după cum urmează:"
+
+#, c-format
+msgid "All badword entries from %s have been cloned to %s."
+msgstr "Toate intrările de cuvinte nepotrivite din %s au fost clonate în %s."
+
+#, c-format
+msgid "All level entries from %s have been cloned into %s."
+msgstr "Toate intrările de nivel din %s au fost clonate în %s."
+
+msgid "All logon news items deleted."
+msgstr "Toate știrile la conectare au fost șterse."
+
+#, c-format
+msgid "All memos for channel %s have been deleted."
+msgstr "Toate misivele pentru canalul %s au fost șterse."
+
+#, c-format
+msgid "All modes cleared on %s."
+msgstr "Toate modurile au fost golite în canalul %s."
+
+msgid "All new accounts must be validated by an administrator. Please wait for your registration to be confirmed."
+msgstr "Toate conturile noi trebuie să fie validate manual de un administrator. Vă rugăm așteptați confirmarea înregistrării dumneavoastră."
+
+msgid "All of your memos have been deleted."
+msgstr "Toate misivele dumneavoastră au fost șterse."
+
+msgid "All oper news items deleted."
+msgstr "Toate știrile la Operare au fost șterse."
+
+#, c-format
+msgid "All operators from %s have been removed."
+msgstr "Toți operatorii din %s au fost înlăturați."
+
+msgid "All random news items deleted."
+msgstr "Toate știrile aleatorii au fost șterse."
+
+#, c-format
+msgid "All settings from %s have been cloned to %s."
+msgstr "Toate setările din %s au fost clonate în %s."
+
+#, c-format
+msgid "All user modes on %s have been synced."
+msgstr "Toate modurile de utilizator din %s au fost sincronizate."
+
+#, c-format
+msgid "All vhosts for the account %s have been set to %s."
+msgstr "Toate gazdele virtuale pentru contul %s au fost setate la %s."
+
+msgid "Allowed to (de)halfop themself"
+msgstr "Permite a da și lua modul de semi-operator sieși"
+
+msgid "Allowed to (de)halfop users"
+msgstr "Permite a da și lua modul de semi-operator altora"
+
+msgid "Allowed to (de)op themself"
+msgstr "Permite a da și lua modul de operator sieși"
+
+msgid "Allowed to (de)op users"
+msgstr "Permite a da și lua modul de operator altora"
+
+msgid "Allowed to (de)owner themself"
+msgstr "Permite a da și lua modul de proprietar sieși"
+
+msgid "Allowed to (de)owner users"
+msgstr "Permite a da și lua modul de proprietar altora"
+
+msgid "Allowed to (de)protect themself"
+msgstr "Permite a da și lua modul de protecție sieși"
+
+msgid "Allowed to (de)protect users"
+msgstr "Permite a da și lua modul de protecție altora"
+
+msgid "Allowed to (de)voice themself"
+msgstr "Permite a da și lua modul de voce sieși"
+
+msgid "Allowed to (de)voice users"
+msgstr "Permite a da și lua modul de voce altora"
+
+msgid "Allowed to assign/unassign a bot"
+msgstr "Permite a asocia și disocia un bot"
+
+msgid "Allowed to ban users"
+msgstr "Permite a bloca utilizatori"
+
+msgid "Allowed to change channel topics"
+msgstr "Permite a schimba subiectul de canal"
+
+msgid "Allowed to get full INFO output"
+msgstr "Permite a obține toate informațiile cu INFO"
+
+msgid "Allowed to issue commands restricted to channel founders"
+msgstr "Permite a executa comenzi limitate la fondatorii canalului"
+
+msgid "Allowed to modify channel badwords list"
+msgstr "Permite a modifica lista de cuvinte nepotrivite aparținând canalului"
+
+msgid "Allowed to modify channel settings"
+msgstr "Permite a modifica setările canalului"
+
+msgid "Allowed to modify the access list"
+msgstr "Permite a modifica lista de accese"
+
+msgid "Allowed to read channel memos"
+msgstr "Permite a citi misivele canalului"
+
+msgid "Allowed to unban themself"
+msgstr "Permite a se debloca"
+
+msgid "Allowed to unban users"
+msgstr "Permite a debloca utilizatori"
+
+msgid "Allowed to use GETKEY command"
+msgstr "Permite a folosi comanda GETKEY"
+
+msgid "Allowed to use SAY and ACT commands"
+msgstr "Permite a folosi comenzile SAY și ACT"
+
+msgid "Allowed to use fantasy commands"
+msgstr "Permite a folosi comenzile fanteziste"
+
+msgid "Allowed to use the AKICK command"
+msgstr "Permite a folosi comanda AKICK"
+
+msgid "Allowed to use the INVITE command"
+msgstr "Permite a folosi comanda INVITE"
+
+msgid "Allowed to use the KICK command"
+msgstr "Permite a folosi comanda KICK"
+
+msgid "Allowed to use the MODE command"
+msgstr "Permite a folosi comanda MODE"
+
+msgid "Allowed to view the access list"
+msgstr "Permite a vizualiza lista de accese"
+
+msgid "Allows Services Operators to change modes for any channel. Parameters are the same as for the standard /MODE command. Alternatively, CLEAR may be given to clear all modes on the channel. If CLEARALL is given then all modes, including user status, is removed."
+msgstr "Permite Operatorilor de Servicii să schimbe moduri pentru orice canal. Parametrii sunt aceiași ca și pentru comanda standard /MODE. Alternativ, se poate da CLEAR pentru a goli toate modurile din canal. Dacă se dă CLEARALL, atunci toate modurile, inclusiv statutul utilizatorului, sunt înlăturate."
+
+msgid "Allows Services Operators to change modes for any user. Parameters are the same as for the standard /MODE command."
+msgstr "Permite Operatorilor de Servicii să schimbe moduri pentru orice utilizator. Parametrii sunt aceiași ca și pentru comanda standard /MODE."
+
+#, c-format
+msgid ""
+"Allows Services Operators to create, modify, and delete bots that users will be able to use on their own channels.\n"
+"\n"
+"%sADD adds a bot with the given nickname, username, hostname and realname. Since no integrity checks are done for these settings, be really careful.\n"
+"\n"
+"%sCHANGE allows you to change the nickname, username, hostname or realname of a bot without deleting it (and all the data associated with it).\n"
+"\n"
+"%sDEL removes the given bot from the bot list.\n"
+"\n"
+"Note: You cannot create a bot with a nick that is currently registered. If an unregistered user is currently using the nick, they will be killed."
+msgstr ""
+"Permite Operatorilor de Servicii să creeze, să modifice și să înlăture boți pe care utilizatorii îi vor putea folosi în propriile canale.\n"
+"\n"
+"%sADD adaugă un bot cu datele specificate: pseudonimul, numele de utilizator, numele de gazdă și numele real. Întrucât nu se efectuează verificări ale integrității acestor setări, vă rugăm să fiți cu atenție.\n"
+"\n"
+"%sCHANGE vă permite să schimbați pseudonimul, numele utilizator, numele de gazdă și numele real ale unui bot fără a-l înlătura (dimpreună cu toate datele asociate acestuia).\n"
+"\n"
+"%sDEL înlătură botul specificat din lista de boți.\n"
+"\n"
+"Notă: Nu puteți crea un bot cu un pseudonim deja înregistrat. Dacă o persoană neînregistrată folosește pseudonimul respectiv aceasta va fi deconectată."
+
+msgid ""
+"Allows Services Operators to make services ignore a nick or mask for a certain time or until the next restart. The default time format is seconds. You can specify it by using units. Valid units are: s for seconds, m for minutes, h for hours and d for days. Combinations of these units are not permitted. To make services permanently ignore the user, type 0 as time. When adding a mask, it should be in the format nick!user@host, everything else will be considered a nick. Wildcards are permitted.\n"
+"\n"
+"Ignores will not be enforced on IRC Operators."
+msgstr ""
+"Permite Operatorilor de Servicii să facă serviciile să ignore un pseudonim ori o mască pentru o anumită perioadă de timp sau până la următoarea repornire. Formatul implicit de timp este în secunde. Puteți să-l specificați utilizând unități. Unitățile valide sunt: s pentru secunde, m pentru minute, h pentru ore, și d pentru zile. Combinațiile acestor unități nu sunt permise. Pentru a face serviciile să ignore permanent utilizatorul, folosiți 0 ca timp. Când adăugați o mască, aceasta ar trebui să fie în formatul pseudonim!utilizator@gazdă, orice altceva va fi considerat drept pseudonim. Caracterele wildcard sunt permise.\n"
+"\n"
+"Ignorările nu vor fi impuse Operatorilor IRC."
+
+#, c-format
+msgid ""
+"Allows Services Operators to manipulate the AKILL list. If a user matching an AKILL mask attempts to connect, services will issue a KILL for that user and, on supported server types, will instruct all servers to add a ban for the mask which the user matched.\n"
+"\n"
+"%sADD adds the given mask to the AKILL list for the given reason, which must be given. Mask should be in the format of nick!user@host#realname, though all that is required is user@host. If a real name is specified, the reason must be prepended with a :. expiry is specified as an integer followed by one of d (days), h (hours), or m (minutes). Combinations (such as 1h30m) are not permitted. If a unit specifier is not included, the default is days (so +30 by itself means 30 days). To add an AKILL which does not expire, use +0. If the mask to be added starts with a +, an expiry time must be given, even if it is the same as the default. The current AKILL default expiry time can be found with the STATSAKILL command."
+msgstr ""
+"Permite Operatorilor de Servicii să manipuleze lista AKILL. Dacă un utilizator corespunzând unei măști AKILL încearcă să se conecteze, serviciile vor emite o comandă KILL pentru acel utilizator și, pe tipurile de server acceptate, vor instrui toate serverele să adauge o blocare pentru masca corespunzătoare utilizatorului.\n"
+"\n"
+"%sADD adaugă masca specificată la lista AKILL pentru motivul menționat, care trebuie precizat. Masca ar trebui să aibă formatul pseudonim!utilizator@gazdă#numereal, deși tot ce este necesar este utilizator@gazdă. Dacă se specifică un nume real, motivul trebuie să fie precedat de un caracter :. Expirarea este specificată ca un număr întreg urmat de una dintre următoarele: d (zile), h (ore), sau m (minute). Combinațiile (precum 1h30m) nu sunt permise. Dacă nu este specificată o unitate, valoarea implicită este în zile (prin urmare +30 înseamnă 30 zile). Pentru a adăuga un AKILL care nu expiră, utilizați +0. Dacă masca ce urmează să fie adăugată începe cu un +, trebuie specificat un timp de expirare, chiar dacă este același cu cel implicit. Timpul de expirare implicit pentru AKILL poate fi găsit prin comanda STATSAKILL."
+
+msgid ""
+"Allows Services Operators to manipulate the SNLINE list. If a user with a realname matching an SNLINE mask attempts to connect, services will not allow them to pursue their IRC session.\n"
+"\n"
+"SNLINEADD adds the given realname mask to the SNLINE list for the given reason (which must be given). expiry is specified as an integer followed by one of d (days), h (hours), or m (minutes). Combinations (such as 1h30m) are not permitted. If a unit specifier is not included, the default is days (so +30 by itself means 30 days). To add an SNLINE which does not expire, use +0. If the realname mask to be added starts with a +, an expiry time must be given, even if it is the same as the default. The current SNLINE default expiry time can be found with the STATSAKILL command. \n"
+"\n"
+"Note: because the realname mask may contain spaces, the separator between it and the reason is a colon."
+msgstr ""
+"Permite Operatorilor de Servicii să manipuleze lista SNLINE. Dacă un utilizator cu un nume real corespunzând unei măști SNLINE încearcă să se conecteze, serviciile nu îi vor permite să continue sesiunea IRC.\n"
+"\n"
+"SNLINEADD adaugă masca numelui real specificată, la lista SNLINE pentru motivul menționat (care trebuie precizat). Expirarea este specificată ca un număr întreg urmat de una dintre următoarele: d (zile), h (ore), sau m (minute). Combinațiile (precum 1h30m) nu sunt permise. Dacă nu este inclus un specificator de unitate, valoarea implicită este în zile (prin urmare +30 înseamnă 30 zile). Pentru a adăuga un SNLINE care nu expiră, utilizați +0. Dacă masca numelui real ce urmează să fie adăugată începe cu un +, trebuie specificat un timp de expirare, chiar dacă este același cu cel implicit. Timpul de expirare implicit pentru SNLINE poate fi găsit prin comanda STATSAKILL.\n"
+"\n"
+"Notă: deoarece masca numelui real poate conține spații, separatorul între aceasta și motiv este două puncte."
+
+msgid ""
+"Allows Services Operators to manipulate the SQLINE list. If a user with a nick matching an SQLINE mask attempts to connect, services will not allow them to pursue their IRC session. If the first character of the mask is #, services will prevent the use of matching channels. If the mask is a regular expression, the expression will be matched against channels too.\n"
+"\n"
+"SQLINEADD adds the given (nick/channel) mask to the SQLINE list for the given reason (which must be given). expiry is specified as an integer followed by one of d (days), h (hours), or m (minutes). Combinations (such as 1h30m) are not permitted. If a unit specifier is not included, the default is days (so +30 by itself means 30 days). To add an SQLINE which does not expire, use +0. If the mask to be added starts with a +, an expiry time must be given, even if it is the same as the default. The current SQLINE default expiry time can be found with the STATSAKILL command."
+msgstr ""
+"Permite Operatorilor de Servicii să manipuleze lista SQLINE. Dacă un utilizator cu un pseudonim corespunzând unei măști SQLINE încearcă să se conecteze, serviciile nu îi vor permite să continue sesiunea IRC. Dacă primul caracter al măștii este #, serviciile vor împiedica utilizarea canalelor corespunzătoare. Dacă masca este o expresie regulată, atunci expresia va corespunde și canalelor.\n"
+"\n"
+"SQLINEADD adaugă masca (pseudonim/canal) la lista SQLINE pentru motivul menționat (care trebuie precizat). Expirarea este specificată ca un număr întreg urmat de una dintre următoarele: d (zile), h (ore), sau m (minute). Combinațiile (precum 1h30m) nu sunt permise. Dacă nu este inclus un specificator de unitate, valoarea implicită este în zile (prin urmare +30 înseamnă 30 zile). Pentru a adăuga un SQLINE care nu expiră, utilizați +0. Dacă masca ce urmează să fie adăugată începe cu un +, trebuie specificat un timp de expirare, chiar dacă este același cu cel implicit. Timpul de expirare implicit pentru SQLINE poate fi găsit prin comanda STATSAKILL."
+
+#, c-format
+msgid ""
+"Allows Services Operators to manipulate the list of hosts that have specific session limits - allowing certain machines, such as shell servers, to carry more than the default number of clients at a time. Once a host reaches its session limit, all clients attempting to connect from that host will be killed. Before the user is killed, they are notified, of a source of help regarding session limiting. The content of this notice is a config setting.\n"
+"\n"
+"%sADD adds the given host mask to the exception list. Note that nick!user@host and user@host masks are invalid! Only real host masks, such as box.host.dom and *.host.dom, are allowed because sessions limiting does not take nick or user names into account. limit must be a number greater than or equal to zero. This determines how many sessions this host may carry at a time. A value of zero means the host has an unlimited session limit. See the AKILL help for details about the format of the optional expiry parameter. \n"
+"\n"
+"%sDEL removes the given mask from the exception list.\n"
+"\n"
+"%sLIST and %sVIEW show all current sessions if the optional mask is given, the list is limited to those sessions matching the mask. The difference is that %sVIEW is more verbose, displaying the name of the person who added the exception, its session limit, reason, host mask and the expiry date and time. \n"
+"\n"
+"Note that a connecting client will \"use\" the first exception their host matches."
+msgstr ""
+"Permite Operatorilor de Servicii să manipuleze lista de gazde cu limite specifice de sesiune - permițând anumitor mașini, cum ar fi serverele shell, să țină simultan mai mulți clienți decât numărul implicit. Odată ce o gazdă atinge limita de sesiuni, toți clienții care încearcă să se conecteze de pe acea gazdă vor fi deconectați. Înainte ca utilizatorul să fie deconectat, acesta este notificat despre o sursă de ajutor privind limitarea sesiunilor. Conținutul acestei notificări este o setare în configurare.\n"
+"\n"
+"%sADD adaugă masca gazdă precizată la lista de excepții. Rețineți că măștile pseudonim!utilizator@gazdă și utilizator@gazdă sunt invalide! Sunt permise doar măști de gazdă reale, cum ar fi subdomeniu.domeniu.tld și *.domeniu.tld, deoarece limitarea de sesiuni nu ia în considerare pseudonimul și numele de utilizator. limita trebuie să fie un număr mai mare sau egal cu zero. Aceasta determină câte sesiuni poate gestiona simultan această gazdă. O valoare zero înseamnă că gazda are o limită nelimitată de sesiuni. Consultați ajutorul AKILL pentru detalii despre formatul parametrului de expirare opțional.\n"
+"\n"
+"%sDEL înlătură masca precizată din lista de excepții.\n"
+"\n"
+"%sLIST și %sVIEW afișează toate sesiunile curente dacă masca opțională este specificată, lista este limitată la sesiunile ce corespund măștii. Diferența este că %sVIEW este mai detaliat, afișând numele persoanei care a adăugat excepția, limita sa de sesiune, motivul, masca gazdei și data și ora de expirare.\n"
+"\n"
+"Rețineți că un client care se conectează va \"utiliza\" prima excepție ce corespunde gazdei lor."
+
+#, c-format
+msgid ""
+"Allows Services Operators to view the session list.\n"
+"\n"
+"%sLIST lists hosts with at least threshold sessions. The threshold must be a number greater than 1. This is to prevent accidental listing of the large number of single session hosts.\n"
+"\n"
+"%sVIEW displays detailed information about a specific host - including the current session count and session limit. The host value may not include wildcards. \n"
+"\n"
+"See the EXCEPTION help for more information about session limiting and how to set session limits specific to certain hosts and groups thereof."
+msgstr ""
+"Permite Operatorilor de Servicii să vizualizeze lista de sesiuni.\n"
+"\n"
+"%sLIST listează gazdele cu cel puțin sesiuni de prag. Pragul trebuie să fie un număr mai mare decât 1. Acest aspect este pentru a preveni listarea accidentală a numărului mare de gazde cu o singură sesiune.\n"
+"\n"
+"%sVIEW afișează informații detaliate despre o anumită gazdă - inclusiv numărul curent de sesiuni și limita de sesiuni. Valoarea gazdei nu poate conține caractere wildcard.\n"
+"\n"
+"Consultați ajutorul EXCEPTION pentru mai multe informații despre limitarea sesiunilor și despre cum să setați limite de sesiune specifice anumitor gazde și grupuri ale acestora."
+
+msgid ""
+"Allows manipulating the topic of the specified channel. The SET command changes the topic of the channel to the given topic or unsets the topic if no topic is given. The APPEND command appends the given topic to the existing topic. \n"
+"\n"
+"LOCK and UNLOCK may be used to enable and disable topic lock. When topic lock is set, the channel topic will be unchangeable by users who do not have the TOPIC privilege."
+msgstr ""
+"Permite manipularea subiectului canalului specificat. Comanda SET schimbă subiectul canalului la subiectul precizat sau de-setează subiectul dacă nu este specificat niciun subiect. Comanda APPEND adaugă subiectul precizat la subiectul existent.\n"
+"\n"
+"LOCK și UNLOCK poate fi folosit pentru a activa și dezactiva încuierea subiectului. Când încuierea subiectului este setată, subiectul canalului nu va putea fi schimbat de utilizatorii care nu au privilegiul TOPIC."
+
+#, c-format
+msgid ""
+"Allows queueing messages to send to users on the network.\n"
+"\n"
+"The %sADD command adds the given message to the message queue.\n"
+"\n"
+"The %sCLEAR command clears the message queue.\n"
+"\n"
+"The %sDEL command removes the specified message from the message queue. The message number can be obtained from the output of the %sLIST command.\n"
+"\n"
+"The %sLIST command lists all messages that are currently in the message queue."
+msgstr ""
+"Permite punerea mesajelor la coadă pentru a fi trimise către utilizatorii din rețea.\n"
+"\n"
+"Comanda %sADD adaugă mesajul precizat în coada de mesaje.\n"
+"\n"
+"Comanda %sCLEAR golește coada de mesaje.\n"
+"\n"
+"Comanda %sDEL înlătură mesajul specificat din coada de mesaje. Numărul mesajului poate fi obținut prin comanda %sLIST.\n"
+"\n"
+"Comanda %sLIST listează toate mesajele care se află în prezent în coada de mesaje."
+
+#, c-format
+msgid ""
+"Allows sending messages to all users on a server. The message will be sent from %s.\n"
+"\n"
+"You can either send a message by specifying it as a parameter or provide no parameters to send a previously queued message."
+msgstr ""
+"Permite trimiterea de mesaje către toți utilizatorii dintr-un server. Mesajul va fi trimis din partea %s.\n"
+"\n"
+"Puteți fie să trimiteți un mesaj specificându-l ca parametru, fie să nu specificați niciun parametru pentru a trimite un mesaj pus anterior în coada de mesaje."
+
+#, c-format
+msgid ""
+"Allows sending messages to all users on the network. The message will be sent from %s.\n"
+"\n"
+"You can either send a message by specifying it as a parameter or provide no parameters to send a previously queued message."
+msgstr ""
+"Permite trimiterea de mesaje către toți utilizatorii din rețea. Mesajul va fi trimis din partea %s.\n"
+"\n"
+"Puteți fie să trimiteți un mesaj specificându-l ca parametru, fie să nu specificați niciun parametru pentru a trimite un mesaj pus anterior în coadă."
+
+#, c-format
+msgid ""
+"Allows staff to kick a user from any channel. Parameters are the same as for the standard /KICK command. The kick message will have the nickname of the IRCop sending the KICK command prepended; for example:\n"
+"\n"
+"*** SpamMan has been kicked off channel #my_channel by %s (Alcan (Flood))"
+msgstr ""
+"Permite personalului să izgonească un utilizator din orice canal. Parametrii sunt aceiași ca și pentru comanda standard /KICK. Mesajul de izgonire va avea prefixat pseudonimul Operatorului IRC care folosește comanda KICK; spre exemplu:\n"
+"\n"
+"*** OmulSpam a fost izgonit din canalul #canalul_meu de către %s (Nick-Operator (Inundare))"
+
+msgid ""
+"Allows the channel founder to set various channel options and other information.\n"
+"\n"
+"Available options:"
+msgstr ""
+"Permite fondatorului de canal să seteze diverse opțiuni de canal și alte informații.\n"
+"\n"
+"Opțiunile disponibile sunt după cum urmează:"
+
+msgid "Allows you to change and view Services Operators. Note that operators removed by this command but are still set in the configuration file are not permanently affected by this."
+msgstr "Vă permite să schimbați și să vizualizați Operatorii de Servicii. Rețineți că Operatorii înlăturați de această comandă, dar care se află încă setați în fișierul de configurare, nu sunt afectați permanent de aceasta."
+
+msgid ""
+"Allows you to change and view configuration settings. Settings changed by this command are temporary and will not be reflected back into the configuration file, and will be lost if Anope is shut down, restarted, or the configuration is reloaded.\n"
+"\n"
+"Example:\n"
+"     MODIFYnickservregdelay15m"
+msgstr ""
+"Vă permite să modificați și să vizualizați setările de configurare. Setările schimbate prin această comandă sunt temporare și nu se vor reflecta în fișierul de configurare. Aceste modificări vor fi pierdute dacă Anope este oprit, repornit, ori dacă se reîncarcă configurarea.\n"
+"\n"
+"Exemplu:\n"
+"     MODIFYnickservregdelay15m"
+
+msgid "Allows you to choose the way services are communicating with the given user. With MSG set, services will use messages, else they'll use notices."
+msgstr "Vă permite să alegeți metoda prin care serviciile comunică cu utilizatorul precizat. Cu MSG setat, serviciile vor folosi mesaje, altfel vor folosi notificări."
+
+#, c-format
+msgid "Allows you to choose the way services are communicating with you. With %s set, services will use messages, else they'll use notices."
+msgstr "Vă permite să alegeți metoda prin care serviciile comunică cu dumneavoastră. Cu %s setat, serviciile vor utiliza mesaje, altfel vor folosi notificări."
+
+msgid "Allows you to ignore users by nick or host from memoing you or a channel. If someone on the memo ignore list tries to memo you or a channel, they will not be told that you have them ignored."
+msgstr "Vă permite să ignorați utilizatori în funcție de pseudonim sau gazdă, pentru a nu expedia misive către dumneavoastră ori către un canal. Dacă cineva din lista de ignorare a misivelor încearcă să expedieze o misivă către dumneavoastră sau un canal, aceștia nu vor fi informați că-i ignorați."
+
+msgid "Allows you to kill a user from the network. Parameters are the same as for the standard /KILL command."
+msgstr "Vă permite să deconectați un utilizator din rețea. Parametrii sunt aceiași ca și pentru comanda standard /KILL."
+
+#, c-format
+msgid "Allows you to prevent certain pieces of information from being displayed when someone does a %sINFO on the nick. You can hide the email address (EMAIL), last seen user@host mask (MASK), the services access status (STATUS) and last quit message (QUIT). The second parameter specifies whether the information should be displayed (OFF) or hidden (ON)."
+msgstr "Vă permite să împiedicați afișarea anumitor informații atunci când cineva utilizează %sINFO asupra pseudonimului. Puteți ascunde adresa de email (EMAIL), ultima mască utilizator@gazdă văzută (MASK), statutul accesului la servicii (STATUS) și ultimul mesaj de plecare din rețea (QUIT). Al doilea parametru specifică dacă informațiile ar trebui afișate (OFF) sau ascunse (ON)."
+
+#, c-format
+msgid "Allows you to prevent certain pieces of information from being displayed when someone does a %sINFO on your nick. You can hide your email address(EMAIL), last seen user@host mask (MASK), your services access status (STATUS) and last quit message (QUIT). The second parameter specifies whether the information should be displayed (OFF) or hidden (ON)."
+msgstr "Vă permite să împiedicați afișarea anumitor informații atunci când cineva utilizează %sINFO asupra pseudonimului dumneavoastră. Vă puteți ascunde adresa de email (EMAIL), ultima mască utilizator@gazdă văzută (MASK), statutul accesului la servicii (STATUS) și ultimul mesaj de plecare din rețea (QUIT). Al doilea parametru specifică dacă informațiile ar trebui afișate (OFF) sau ascunse (ON)."
+
+#, c-format
+msgid "Allows you to see %s information about a channel or a bot"
+msgstr "Vă permite să vedeți informațiile %s despre un canal sau un bot"
+
+#, c-format
+msgid "Allows you to see %s information about a channel or a bot. If the parameter is a channel, then you'll get information such as enabled kickers. If the parameter is a nick, you'll get information about a bot, such as creation time or number of channels it is on."
+msgstr "Vă permite să vedeți informația %s despre un canal sau un bot. Dacă parametrul este un canal, atunci veți obține informații precum izgonirile active. Dacă parametrul este un pseudonim, atunci veți obține informații despre un bot, cum ar fi timpul său de creație ori canalele în care se află."
+
+msgid "Alternative methods of modifying channel access lists are available."
+msgstr "Există metode alternative de modificare a listelor de accese în canale."
+
+msgid "Approve the requested vhost of a user"
+msgstr "Aprobă gazda virtuală solicitată de un utilizator"
+
+msgid "As a Services Operator, you may drop any nick."
+msgstr "Ca Operator de Servicii, puteți radia orice pseudonim."
+
+msgid "Assigns a bot to a channel"
+msgstr "Asociază un bot unui canal"
+
+msgid "Assigns the specified bot to a channel. You can then configure the bot for the channel so it fits your needs."
+msgstr "Asociază botul specificat unui canal. Puteți apoi configura botul pentru canal, astfel încât să se potrivească nevoilor dumneavoastră."
+
+msgid "Associate a URL with the channel"
+msgstr "Atribuie o pagină web unui canal"
+
+msgid "Associate a URL with this account"
+msgstr "Atribuie o pagină web acestui cont"
+
+msgid "Associate a URL with your account"
+msgstr "Atribuie o pagină web contului dumneavoastră"
+
+msgid "Associate a greet message with your nickname"
+msgstr "Atribuie un mesaj de întâmpinare pseudonimului dumneavoastră"
+
+msgid "Associate an email address with the channel"
+msgstr "Atribuie o adresă de email unui canal"
+
+msgid "Associate an email address with your nickname"
+msgstr "Atribuie o adresă de email pseudonimului dumneavoastră"
+
+msgid "Associate oper info with a nick or channel"
+msgstr "Atribuie informațiile de Operator unui pseudonim sau unui canal"
+
+msgid "Associates the given email address with the nickname."
+msgstr "Atribuie adresa de email precizată unui pseudonim."
+
+msgid "Associates the given email address with your nickname. This address will be displayed whenever someone requests information on the nickname with the INFO command."
+msgstr "Atribuie adresa de email precizată, pseudonimului dumneavoastră. Această adresă de email va fi afișată ori de câte ori cineva solicită informații asupra pseudonimului prin comanda INFO."
+
+msgid "Auto op"
+msgstr "Operare Automată"
+
+#, c-format
+msgid "Autokick list for %s:"
+msgstr "Lista de izgoniri automate pentru %s este după cum urmează:"
+
+msgid "Automatic channel operator status upon join"
+msgstr "Acordă automat modul de operator la alăturare"
+
+msgid "Automatic halfop upon join"
+msgstr "Acordă automat modul de semi-operator la alăturare"
+
+msgid "Automatic owner upon join"
+msgstr "Acordă automat modul de proprietar la alăturare"
+
+msgid "Automatic protect upon join"
+msgstr "Acordă automat modul de protecție la alăturare"
+
+msgid "Automatic voice on join"
+msgstr "Acordă automat modul de voce la alăturare"
+
+msgid "Available commands are:"
+msgstr "Comenzile disponibile sunt după cum urmează:"
+
+#, c-format
+msgid "Available commands for %s:"
+msgstr "Comenzile disponibile pentru %s sunt după cum urmează:"
+
+msgid "Available opertypes:"
+msgstr "Tipurile de Operator disponibile sunt după cum urmează:"
+
+#, c-format
+msgid "Available privileges for %s:"
+msgstr "Privilegiile disponibile pentru %s sunt după cum urmează:"
+
+#, c-format
+msgid "Available timezones in the %s region:"
+msgstr "Fusurile orare disponibile în regiunea %s sunt după cum urmează:"
+
+msgid "BANS enforced by "
+msgstr "BANS impuse de "
+
+msgid "Bad words kicker"
+msgstr "Izgonire la cuvinte nepotrivite"
+
+#, c-format
+msgid "Bad words list for %s:"
+msgstr "Lista de cuvinte nepotrivite pentru %s este după cum urmează:"
+
+msgid "Bad words list is now empty."
+msgstr "Lista de cuvinte nepotrivite este goală acum."
+
+msgid "Ban expiry may not be longer than 1 day."
+msgstr "Expirarea blocării nu poate depăși o zi."
+
+#, c-format
+msgid "Ban on %s expires in %s."
+msgstr "Blocarea pentru %s expiră în %s."
+
+msgid "Ban type"
+msgstr "Tipul de blocare"
+
+#, c-format
+msgid "Ban type for channel %s is now #%d."
+msgstr "Tipul de blocare pentru canalul %s este acum #%d."
+
+msgid "Bans a given nick or mask on a channel"
+msgstr "Blochează un anumit pseudonim sau mască într-un canal"
+
+msgid ""
+"Bans a given nick or mask on a channel. An optional expiry may be given to cause services to remove the ban after a set amount of time.\n"
+"\n"
+"By default, limited to AOPs or those with level 5 access and above on the channel. Channel founders may ban masks."
+msgstr ""
+"Blochează un pseudonim sau o mască într-un canal. Se poate acorda o expirare opțională pentru ca serviciile să înlăture blocajul după o anumită perioadă de timp.\n"
+"\n"
+"Implicit, blocarea este limitată la AOP ori la cei cu acces de nivel 5 sau superior în canal. Fondatorii de canale pot bloca măștile."
+
+#, c-format
+msgid "Bans enforced on %s."
+msgstr "Blocări impuse în %s."
+
+msgid "Bolds kicker"
+msgstr "Izgonire la îngroșări"
+
+#, c-format
+msgid "Bot %s already exists."
+msgstr "Botul %s există deja."
+
+#, c-format
+msgid "Bot %s does not exist."
+msgstr "Bot-ul %s nu există."
+
+#, c-format
+msgid "Bot %s has been assigned to %s."
+msgstr "Botul %s a fost asociat în %s."
+
+#, c-format
+msgid "Bot %s has been changed to %s!%s@%s (%s)."
+msgstr "Botul %s a fost schimbat în %s!%s@%s (%s)."
+
+#, c-format
+msgid "Bot %s has been deleted."
+msgstr "Botul %s a fost înlăturat."
+
+#, c-format
+msgid "Bot %s is already assigned to channel %s."
+msgstr "Botul %s este deja asociat canalului %s."
+
+#, c-format
+msgid "Bot will kick ops on channel %s."
+msgstr "Botul va izgoni operatori din canalul %s."
+
+#, c-format
+msgid "Bot will kick voices on channel %s."
+msgstr "Botul va izgoni membri voce din canalul %s."
+
+#, c-format
+msgid "Bot won't kick ops on channel %s."
+msgstr "Botul nu va izgoni operatori din canalul %s."
+
+#, c-format
+msgid "Bot won't kick voices on channel %s."
+msgstr "Botul nu va izgoni membrii voce din canalul %s."
+
+#, c-format
+msgid "Bot %s is not changeable."
+msgstr "Botul %s nu poate fi schimbat."
+
+#, c-format
+msgid "Bot %s is not deletable."
+msgstr "Botul %s nu poate fi înlăturat."
+
+#, c-format
+msgid "Bot bans will automatically expire after %s."
+msgstr "Blocările de bot vor expira automat după %s."
+
+msgid "Bot bans will no longer automatically expire."
+msgstr "Blocările de bot nu vor mai expira automat."
+
+#, c-format
+msgid "Bot hosts may only be %zu characters long."
+msgstr "Gazdele de bot pot avea doar %zu caractere lungime."
+
+msgid "Bot hosts may only contain valid host characters."
+msgstr "Gazdele de bot pot conține doar caractere valide de gazdă."
+
+#, c-format
+msgid "Bot idents may only be %zu characters long."
+msgstr "Identitățile de bot pot avea doar %zu caractere lungime."
+
+msgid "Bot idents may only contain valid ident characters."
+msgstr "Identitățile de bot pot conține doar caractere valide de intentitate."
+
+#, c-format
+msgid "Bot is not on channel %s."
+msgstr "Botul nu se află în canalul %s."
+
+msgid "Bot list:"
+msgstr "Lista de boți este după cum urmează:"
+
+msgid "Bot nick"
+msgstr "Pseudonim de bot"
+
+#, c-format
+msgid "Bot nicks may only be %zu characters long."
+msgstr "Pseudonimele boților pot avea doar %zu caractere lungime."
+
+msgid "Bot nicks may only contain valid nick characters."
+msgstr "Pseudonimele boților pot conține doar caractere valide de psedudonim."
+
+#, c-format
+msgid "Bot will join a channel whenever there is at least %d user(s) on it."
+msgstr "Botul se va alătura unui canal ori de câte ori există cel puțin %d utilizator/i în acesta."
+
+#, c-format
+msgid "Bot will now kick for %s, and will place a ban after %d kicks for the same user."
+msgstr "Botul va izgoni acum pentru %s și va plasa o blocare după %d izgoniri ale aceluiași utilizator."
+
+#, c-format
+msgid "Bot will now kick for %s."
+msgstr "Botul va izgoni acum pentru %s."
+
+#, c-format
+msgid "Bot will now kick for caps (they must constitute at least %d characters and %d%% of the entire message), and will place a ban after %d kicks for the same user."
+msgstr "Botul va izgoni pentru majuscule (acestea constituie să reprezinte cel puțin %d caractere și %d%% din întregul mesaj), și va plasa o blocare după %d izgoniri ale aceluiași utilizator."
+
+#, c-format
+msgid "Bot will now kick for caps (they must constitute at least %d characters and %d%% of the entire message)."
+msgstr "Botul va izgoni pentru majuscule (acestea trebuie să constituie cel puțin %d caractere și %d%% din întregul mesaj)."
+
+#, c-format
+msgid "Bot will now kick for flood (%d lines in %d seconds and will place a ban after %d kicks for the same user."
+msgstr "Botul va izgoni pentru inundări (%d linii în %d secunde) și va plasa o blocare după %d izgoniri ale aceluiași utilizator."
+
+#, c-format
+msgid "Bot will now kick for flood (%d lines in %d seconds)."
+msgstr "Botul va izgoni pentru inundări (%d linii în %d secunde)."
+
+#, c-format
+msgid "Bot will now kick for repeats (users that repeat the same message %d time), and will place a ban after %d kicks for the same user."
+msgstr "Botul va izgoni pentru repetări (utilizatorii care repetă același mesaj %d ori) și va plasa o blocare după %d izgoniri ale aceluiași utilizator."
+
+#, c-format
+msgid "Bot will now kick for repeats (users that repeat the same message %d time)."
+msgstr "Botul va izgoni pentru repetări (utilizatorii care repetă același mesaj de %d ori)."
+
+#, c-format
+msgid "Bot will now kick for repeats (users that repeat the same message %d times), and will place a ban after %d kicks for the same user."
+msgstr "Botul va izgoni pentru repetări (utilizatorii care repetă același mesaj de %d ori) și va plasa o blocare după %d izgoniri ale aceluiași utilizator."
+
+#, c-format
+msgid "Bot will now kick for repeats (users that repeat the same message %d times)."
+msgstr "Botul va izgoni pentru repetări (utilizatorii care repetă același mesaj de %d ori)."
+
+#, c-format
+msgid "Bot won't kick for %s anymore."
+msgstr "Botul nu va mai izgoni pentru %s."
+
+msgid "Bot won't kick for caps anymore."
+msgstr "Botul nu va mai izgoni pentru majuscule."
+
+msgid "Bot won't kick for flood anymore."
+msgstr "Botul nu va mai izgoni pentru inundări."
+
+msgid "Bot won't kick for repeats anymore."
+msgstr "Botul nu va mai izgoni pentru repetări."
+
+msgid "By"
+msgstr "De"
+
+msgid "CLEAR target"
+msgstr "CLEAR destinație"
+
+msgid "CLEAR time"
+msgstr "CLEAR timp"
+
+msgid "Cancel the last memo you sent"
+msgstr "Anulează ultima misivă pe care ați expediat-o"
+
+msgid "Cancel the registration of a channel"
+msgstr "Radiază înregistrarea unui canal"
+
+msgid "Cancel the registration of a nickname"
+msgstr "Radiază înregistrarea unui pseudonim"
+
+msgid "Cancels the last memo you sent to the given nick or channel, provided it has not been read at the time you use the command."
+msgstr "Anulează ultima misivă pe care ați expediat-o către canalul ori pseudonimul precizat, cu condiția ca acesta să nu fi fost citit la momentul utilizării comenzii."
+
+#, c-format
+msgid "Cannot clone channel %s to itself!"
+msgstr "Nu se poate clona canalul %s către sine însuși!"
+
+msgid "Cannot send mail now; please retry a little later."
+msgstr "Nu se poate trimite un mesaj email momentan; vă rugăm încercați un pic mai târziu."
+
+msgid "Caps kicker"
+msgstr "Izgonire la majuscule"
+
+msgid "Causes services to do an immediate shutdown; databases are not saved. This command should not be used unless damage to the in-memory copies of the databases is feared and they should not be saved."
+msgstr "Determină serviciile să inițieze o oprire imediată: bazele de date nu vor fi salvate. Această comandă nu ar trebui utilizată, decât dacă există o teamă privind deteriorarea bazelor date din memoria activă iar acestea nu trebuie salvate."
+
+msgid "Causes services to reload the configuration file. Note that some directives still need the restart of the services to take effect (such as services' nicknames, activation of the session limitation, etc.)."
+msgstr "Determină serviciile să reîncarce fișierul de configurare. Rețineți că unele directive necesită în continuare repornirea serviciilor pentru a avea efect (cum ar fi pseudonimurile serviciilor, activarea limitei de sesiuni, etc.)."
+
+msgid "Causes services to save all databases and then restart (i.e. exit and immediately re-run the executable)."
+msgstr "Determină serviciile să salveze toate bazele de date iar apoi să se repornească (adică ieșire și rulare imediată a fișierului executabil)."
+
+msgid "Causes services to save all databases and then shut down."
+msgstr "Determină serviciile să salveze toate bazele de date iar apoi să se închidă."
+
+msgid "Causes services to update all database files as soon as you send the command."
+msgstr "Determină serviciile să actualizeze toate fișierele bazelor de date imediat ce utilizați comanda."
+
+#, c-format
+msgid "Certificate list for %s:"
+msgstr "Lista de certificate pentru %s este după cum urmează:"
+
+msgid "ChanServ is required to enable persist on this network."
+msgstr "Chanserv este necesar pentru a activa persistența în această rețea."
+
+msgid "Change channel modes"
+msgstr "Schimbă modurile de canal"
+
+msgid "Change the communication method of services"
+msgstr "Schimbă metoda de comunicare a serviciilor"
+
+msgid "Change user modes"
+msgstr "Schimbă modurile de utilizator"
+
+#, c-format
+msgid "Changed usermodes of %s to %s."
+msgstr "Modurile de utilizator ale %s au fost schimbate în %s."
+
+msgid "Changes the display nickname used to refer to the account. The new displaynickname must already be associated with the account."
+msgstr "Schimbă pseudonimul de afișare folosit pentru a face referire la cont. Noul pseudonim de afișare trebuie să fie deja atribuit contului."
+
+msgid "Changes the display nickname used to refer to your account. The new display nickname must already be associated with your account."
+msgstr "Schimbă pseudonimul de afișare folosit pentru a face refire la contul dumneavoastră. Noul pseudonim de afișare trebuie să fie deja atribuit contului dumneavoastră."
+
+msgid "Changes the founder of a channel. The new nickname must be a registered one."
+msgstr "Schimbă fondatorul unui canal. Noul pseudonim trebuie să fie unul înregistrat."
+
+msgid "Changes the language services uses when sending messages to the given user (for example, when responding to a command they send). language should be chosen from the following list of supported languages:"
+msgstr "Schimbă limba folosită de servicii pentru a trimite mesaje către utilizatorul precizat (spre exemplu, când li se răspunde unei comenzi). Limba ar trebui să fie aleasă din următoarea listă de limbi acceptate, după cum urmează:"
+
+msgid "Changes the language services uses when sending messages to you (for example, when responding to a command you send). language should be chosen from the following list of supported languages:"
+msgstr "Schimbă limba folosită de servicii pentru a vă trimite mesaje dumneavoastră (spre exemplu, când vi se răspunde unei comenzi). Limba ar trebui să fie aleasă din următoarea listă de limbi acceptate, după cum urmează:"
+
+msgid "Changes the password used to identify as the nick's owner."
+msgstr "Schimbă parola folosită pentru identificarea drept proprietar(ă) a pseudonimului."
+
+msgid "Changes the password used to identify you as the nick's owner."
+msgstr "Schimbă parola folosită pentru a vă identifica drept proprietar(ă) a pseudonimului."
+
+msgid "Changes the successor of a channel. If the founder's nickname expires or is dropped while the channel is still registered, the successor will become the new founder of the channel. The successor's nickname must be a registered one. If there's no successor set, then the first nickname on the access list (with the highest access, if applicable) will become the new founder, but if the access list is empty, the channel will be dropped."
+msgstr "Schimbă succesorul unui canal. Dacă pseudonimul fondatorului expiră sau este radiat în timp ce canalul este încă înregistrat, succesorul va deveni noul fondator al canalului. Pseudonimul succesorului trebuie să fie unul înregistrat. Dacă nu este stabilit un succesor, atunci primul pseudonim din lista de accese (cu cel mai mare acces, dacă este cazul) va deveni noul fondator, dar dacă lista de accese este goală, atunci canalul va fi radiat."
+
+msgid "Changes the timezone services uses when sending messages to the given user (for example, when responding to a command they send). timezone should be chosen from an entry in one of the supported timezone regions:"
+msgstr "Schimbă fusul orar pe care îl folosesc serviciile atunci când trimit mesaje către utilizatorul precizat (de exemplu, când se răspunde la o comandă primită). Fusul orar trebuie ales dintr-una dintre regiunile de fus orar acceptate după cum urmează:"
+
+msgid "Changes the timezone services uses when sending messages to you (for example, when responding to a command you send). timezone should be chosen from an entry in one of the supported timezone regions:"
+msgstr "Schimbă fusul orar pe care îl folosesc serviciile atunci când vă trimit mesaje dumneavoastră (de exemplu, când vi se răspunde la o comandă). Fusul orar trebuie ales dintr-una dintre regiunile de fus orar acceptate după cum urmează:"
+
+msgid "Changes when you will be notified about new memos (only for nicknames)"
+msgstr "Schimbă momentele când veți fi notificat(ă) despre noile misive (doar pentru pseudonime)"
+
+#, c-format
+msgid "Changing your usermodes to %s"
+msgstr "Se schimbă modurile de utilizator ale dumneavoastră în %s"
+
+#, c-format
+msgid "Changing your vhost to %s"
+msgstr "Se schimbă gazda virtuală a dumneavoastră în %s"
+
+msgid "Channel"
+msgstr "Canal"
+
+#, c-format
+msgid "Channel %s doesn't exist."
+msgstr "Canalul %s nu există."
+
+#, c-format
+msgid "Channel %s has been dropped."
+msgstr "Canalul %s a fost radiat."
+
+#, c-format
+msgid "Channel %s has no key."
+msgstr "Canalul %s nu are cheie."
+
+#, c-format
+msgid "Channel %s is already registered!"
+msgstr "Canalul %s este deja înregistrat!"
+
+#, c-format
+msgid "Channel %s is forbidden by %s: %s"
+msgstr "Canalul %s este interzis de %s: %s"
+
+#, c-format
+msgid "Channel %s is forbidden."
+msgstr "Canalul %s este interzis."
+
+#, c-format
+msgid "Channel %s is no longer persistent."
+msgstr "Canalul %s nu mai este persistent."
+
+#, c-format
+msgid "Channel %s is now persistent."
+msgstr "Canalul %s este persistent acum."
+
+#, c-format
+msgid "Channel %s is now released."
+msgstr "Canalul %s este eliberat acum."
+
+#, c-format
+msgid "Channel %s is now suspended."
+msgstr "Canalul %s este suspendat acum."
+
+#, c-format
+msgid "Channel %s isn't registered."
+msgstr "Canalul %s nu este înregistrat."
+
+#, c-format
+msgid "Channel %s isn't suspended."
+msgstr "Canalul %s nu este suspendat."
+
+#, c-format
+msgid "Channel %s registered under your account: %s"
+msgstr "Canalul %s a fost înregistrat în contul dumneavoastră: %s"
+
+#, c-format
+msgid "Channel %s will expire."
+msgstr "Canalul %s va expira."
+
+#, c-format
+msgid "Channel %s will not expire."
+msgstr "Canalul %s nu va expira."
+
+#, c-format
+msgid "Channel %s %s list has been cleared."
+msgstr "Lista %2$s a canalului %1$s a fost golită."
+
+#, c-format
+msgid "Channel %s access list has been cleared."
+msgstr "Lista de accese a canalului %s a fost golită."
+
+#, c-format
+msgid "Channel %s akick list has been cleared."
+msgstr "Lista de izgoniri automate a canalului %s a fost golită."
+
+#, c-format
+msgid "Channel %s has no mode locks."
+msgstr "Canalul %s nu are încuieri de moduri."
+
+#, c-format
+msgid "Channel %s is currently suspended."
+msgstr "Canalul %s este momentan suspendat."
+
+#, c-format
+msgid "Channel %s is not a valid channel."
+msgstr "Canalul %s nu este un canal valid."
+
+msgid "Channel list:"
+msgstr "Lista de canale este după cum urmează:"
+
+#, c-format
+msgid "Channel stats for %s on %s:"
+msgstr "Statisticile de canal pentru %s în %s sunt după cum urmează:"
+
+msgid "Channels may not be on access lists."
+msgstr "Canalele nu se pot afla în liste de accese."
+
+#, c-format
+msgid "Channels that %s has access on:"
+msgstr "Canalele în care %s are acces sunt după cum urmează:"
+
+#, c-format
+msgid "Channels: %zu entries, %zu buckets, longest chain is %zu"
+msgstr "Canale: %zu intrări, %zu compartimente, cel mai lung lanț este %zu"
+
+msgid "Chanstats"
+msgstr "Chanstats"
+
+#, c-format
+msgid "Chanstats statistics are now disabled for %s"
+msgstr "Statisticile Chanstats sunt dezactivate acum pentru %s"
+
+msgid "Chanstats statistics are now disabled for this channel."
+msgstr "Statisticile Chanstats sunt dezactivate acum pentru acest canal."
+
+msgid "Chanstats statistics are now disabled for your nick."
+msgstr "Statisticile Chanstats sunt dezactivate acum pentru pseudonimul dumneavoastră."
+
+#, c-format
+msgid "Chanstats statistics are now enabled for %s"
+msgstr "Statisticile Chanstats sunt activate acum pentru %s"
+
+msgid "Chanstats statistics are now enabled for this channel."
+msgstr "Statisticile Chanstats sunt activate acum pentru acest canal."
+
+msgid "Chanstats statistics are now enabled for your nick."
+msgstr "Statisticile Chanstats sunt activate acum pentru pseudonimul dumneavoastră."
+
+msgid "Checks for the last time nick was seen joining, leaving, or changing nick on the network and tells you when and, depending on channel or user settings, where it was."
+msgstr "Verifică ultima dată când pseudonimul a fost văzut alăturându-se, îndepărtându-se, sau schimbându-și pseudonimul în rețea, și vă informează când și unde se afla, în funcție de setările canalului ori ale utilizatorului."
+
+msgid "Checks if last memo to a nick was read"
+msgstr "Verifică dacă ultima misivă către un pseudonim a fost citită"
+
+msgid "Checks whether the _last_ memo you sent to nick has been read or not. Note that this only works with nicks, not with channels."
+msgstr "Verifică dacă _ultima_ misivă expediată pseudonimului a fost citită sau nu. Rețineți că aceasta funcționează numai cu pseudonime, nu și canale."
+
+#, c-format
+msgid "Cleared info from %s."
+msgstr "Informațiile din %s au fost golite."
+
+msgid "Colors kicker"
+msgstr "Izgonire la culori"
+
+msgid "Command"
+msgstr "Comandă"
+
+msgid "Configures AMSG kicker"
+msgstr "Configurează izgonirea la AMSG"
+
+msgid "Configures badwords kicker"
+msgstr "Configurează izgonirea la cuvinte nepotrivite"
+
+msgid "Configures bolds kicker"
+msgstr "Configurează izgonirea la îngroșări"
+
+msgid "Configures bot kickers.  option can be one of:"
+msgstr "Configurează izgonirile botului.  opțiunea poate fi una din următoarele:"
+
+msgid "Configures bot options"
+msgstr "Configurează opțiunile botului"
+
+msgid ""
+"Configures bot options.\n"
+"\n"
+"Available options:"
+msgstr ""
+"Configurează opțiunile botului.\n"
+"\n"
+"Opțiunile disponibile sunt după cum urmează:"
+
+msgid "Configures caps kicker"
+msgstr "Configurează izgonirea la majuscule"
+
+msgid "Configures channel logging settings"
+msgstr "Configurează setările de logare canal"
+
+msgid "Configures color kicker"
+msgstr "Configurează izgonirea la culori"
+
+msgid "Configures flood kicker"
+msgstr "Configurează izgonirea la inundări"
+
+msgid "Configures italics kicker"
+msgstr "Configurează izgonirea la înclinări"
+
+msgid "Configures kickers"
+msgstr "Configurează izgoniri"
+
+msgid "Configures repeat kicker"
+msgstr "Configurează izgonirea la repetări"
+
+msgid "Configures reverses kicker"
+msgstr "Configurează izgonirea la inversări"
+
+msgid ""
+"Configures the layout used by the account for services messages.\n"
+"\n"
+"When the layout is set to FIXED services will use tables and position text such that it looks good in a client that uses a fixed-width font.\n"
+"\n"
+"When the layout is set to FLEXIBLE services will use an alternate format for messages and avoid any positioning that might be broken by a variable-width font.\n"
+"\n"
+"When the layout is set to MONOSPACE services will format messages similar to FIXED but will prefix all messages with a monospace formatting character to force it to display correctly. This requires client support for monospace text formatting."
+msgstr ""
+"Configurează aspectul utilizat de cont pentru mesajele de servicii.\n"
+"\n"
+"Când aspectul este setat la FIXED, serviciile vor folosi tabele și vor poziționa textul în așa fel încât să arate bine într-un client care folosește un font cu lățime fixă.\n"
+"\n"
+"Când aspectul este setat la FLEXIBLE, serviciile vor utiliza un format alternativ pentru mesaje și vor evita orice poziționare care ar putea fi întreruptă de un font cu lățime variabilă.\n"
+"\n"
+"Când aspectul este setat la MONOSPACE, serviciile vor formata mesajele la fel ca FIXED, dar vor prefixa toate mesajele cu un caracter de formatare monospațiu pentru a le forța să se afișeze corect. Acest aspect necesită asistență din partea programelor de client pentru formatarea textului monospațial."
+
+msgid "Configures the layout used for services messages"
+msgstr "Configurează aspectul utilizat pentru mesajele de la servicii"
+
+msgid "Configures the layout used for services messages. When the layout is set to FIXED services will use tables and position text such that it looks good in a client that uses a fixed-width font. When the layout is set to FLEXIBLE services will use an alternate format for messages and avoid any positioning that might be broken by a variable-width font."
+msgstr "Configurează aspectul utilizat pentru mesajele de la servicii. Când aspectul este setat la FIXED, serviciile vor folosi tabele și vor poziționa textul în așa fel încât să arate bine într-un client care folosește un font cu lățime fixă. Când aspectul este setat la FLEXIBLE, serviciile vor utiliza un format alternativ pentru mesaje și vor evita orice poziționare care ar putea fi întreruptă de un font cu lățime variabilă."
+
+msgid ""
+"Configures the layout used for services messages.\n"
+"\n"
+"When the layout is set to FIXED services will use tables and position text such that it looks good in a client that uses a fixed-width font.\n"
+"\n"
+"When the layout is set to FLEXIBLE services will use an alternate format for messages and avoid any positioning that might be broken by a variable-width font.\n"
+"\n"
+"When the layout is set to MONOSPACE services will format messages similar to FIXED but will prefix all messages with a monospace formatting character to force it to display correctly. This requires client support for monospace text formatting."
+msgstr ""
+"Configurează aspectul utilizat pentru mesajele de servicii.\n"
+"\n"
+"Când aspectul este setat la FIXED, serviciile vor folosi tabele și vor poziționa textul în așa fel încât să arate bine într-un client care folosește un font cu lățime fixă.\n"
+"\n"
+"Când aspectul este setat la FLEXIBLE, serviciile vor utiliza un format alternativ pentru mesaje și vor evita orice poziționare care ar putea fi întreruptă de un font cu lățime variabilă.\n"
+"\n"
+"Când aspectul este setat la MONOSPACE, serviciile vor formata mesajele la fel ca FIXED, dar vor prefixa toate mesajele cu un caracter de formatare monospațiu pentru a le forța să se afișeze corect. Acest aspect necesită asistență din partea programelor de client pentru formatarea textului monospațial."
+
+msgid "Configures the time bot bans expire in"
+msgstr "Configurează timpul în care expiră blocările boților"
+
+msgid "Configures underlines kicker"
+msgstr "Configurează izgonirea la sublinieri"
+
+msgid "Confirm a previous account registration"
+msgstr "Confirmă o înregistrare de cont anterioară"
+
+msgid "Confirm a previous action"
+msgstr "Confirmă o acțiune anterioară"
+
+msgid "Confirm a previous change of email address"
+msgstr "Confirmă o schimbare anterioară a adresei de email"
+
+msgid "Confirm a previous password reset"
+msgstr "Confirmă o resetare a parolei anterioare"
+
+#, c-format
+msgid "Confirms a password reset and identifies you to the specified account. You have %s after requesting a reset to do this before your request expires. Once you have done this you can set the password using %s."
+msgstr "Confirmă o resetare a parolei și vă identifică în contul specificat. După ce ați solicitat o resetare, aveți la dispoziție %s pentru a confirma înainte ca solicitarea să expire. După ce ați făcut acest lucru, puteți seta parola folosind %s."
+
+#, c-format
+msgid "Confirms an account registration. You have %s after registration to do this before your registration expires."
+msgstr "Confirmă înregistrarea unui cont. Aveți la dispoziție %s după înregistrare pentru a confirma, înainte ca înregistrarea să expire."
+
+#, c-format
+msgid "Confirms an change of email address. You have %s after requesting an email address change to do this before your request expires."
+msgstr "Confirmă o schimbare a adresei de email. Aveți la dispoziție %s după solicitarea unei schimbări a adresei de email pentru a o confirma înainte ca solicitarea să expire."
+
+msgid "Control modes and mode locks on a channel"
+msgstr "Controlează modurile și încuierile de moduri"
+
+#, c-format
+msgid ""
+"Controls what messages will be sent to users when they join the channel.\n"
+"\n"
+"The %sADD command adds the given message to the list of messages shown to users when they join the channel.\n"
+"\n"
+"The %sDEL command removes the specified message from the list of messages shown to users when they join the channel. You can remove a message by specifying its number which you can get by listing the messages as explained below.\n"
+"\n"
+"The %sLIST command displays a listing of messages shown to users when they join the channel.\n"
+"\n"
+"The %sCLEAR command clears all entries from the list of messages shown to users when they join the channel, effectively disabling entry messages.\n"
+"\n"
+"Adding, deleting, or clearing entry messages requires the SET permission."
+msgstr ""
+"Controlează ce mesaje vor fi trimise utilizatorilor atunci când aceștia se alătură în canal.\n"
+"\n"
+"Comanda %sADD adaugă mesajul precizat la lista de mesaje afișate utilizatorilor atunci când aceștia se alătură în canal.\n"
+"\n"
+"Comanda %sDEL șterge mesajul specificat din lista de mesaje afișate utilizatorilor atunci când aceștia se alătură în canal. Puteți șterge un mesaj specificând numărul acestuia, pe care îl puteți obține listând mesajele după cum este explicat mai jos.\n"
+"\n"
+"Comanda %sLIST afișează o listă de mesaje afișate utilizatorilor atunci când se alătură în canal.\n"
+"\n"
+"Comanda %sCLEAR golește toate intrările din lista de mesaje afișate utilizatorilor atunci când aceștia se alătură în canal, dezactivând efectiv mesajele de intrare.\n"
+"\n"
+"Adăugarea, ștergerea sau golirea mesajelor de intrare necesită permisiunea SET."
+
+msgid "Copies all settings, access, akicks, etc from channel to the target channel. If what is ACCESS, AKICK, BADWORDS, or LEVELS then only the respective settings are cloned. You must be the founder of channel and target."
+msgstr "Copiază toate setările, accesele, izgonirile automate, etc din canalul sursă în canalul destinație. Dacă cerința o reprezintă ACCESS, AKICK, BADWORDS, sau LEVELS atunci doar setările respective sunt clonate. Trebuie să fiți fondatorul canalului sursă cât și destinație."
+
+msgid "Copy all settings from one channel to another"
+msgstr "Copiază toate setările dintr-un canal în altul"
+
+msgid "Created"
+msgstr "Creare"
+
+msgid "Creator"
+msgstr "Creator"
+
+#, c-format
+msgid "Current %s list:"
+msgstr "Lista %s curentă este după cum urmează:"
+
+msgid "Current AKILL list:"
+msgstr "Lista AKILL curentă este după cum urmează:"
+
+msgid "Current Session Limit Exception list:"
+msgstr "Lista de excepții curentă privind limita de sesiuni este după cum urmează:"
+
+msgid "Current module list:"
+msgstr "Lista curentă de module este după cum urmează:"
+
+#, c-format
+msgid "Current number of AKILLs: %zu"
+msgstr "Număr curent de AKILL-uri: %zu"
+
+#, c-format
+msgid "Current number of SNLINEs: %zu"
+msgstr "Număr curent de SNLINE-uri: %zu"
+
+#, c-format
+msgid "Current number of SQLINEs: %zu"
+msgstr "Număr curent de SQLINE-uri: %zu"
+
+#, c-format
+msgid "Current users: %zu (%zu ops)"
+msgstr "Utilizatori curenți: %zu (%zu operatori)"
+
+msgid "DEL entry-num"
+msgstr "DEL număr-intrare"
+
+msgid "DEL oper"
+msgstr "DEL Operator"
+
+msgid "DEL target info"
+msgstr "DEL destinație informație"
+
+msgid "DEL [nickname] channel"
+msgstr "DEL [pseudonim] canal"
+
+msgid "DEL [nickname] fingerprint"
+msgstr "DEL [pseudonim] amprentă-digitală"
+
+msgid "DEL {mask | entry-num | list | id}"
+msgstr "DEL {mască | număr-intrare | listă | id}"
+
+msgid "DEL {mask | entry-num | list}"
+msgstr "DEL {mască | număr-intrare | listă}"
+
+msgid "DEL {nick|mask}"
+msgstr "DEL {pseudonim|mască}"
+
+msgid "DEL {num | ALL}"
+msgstr "DEL {număr | ALL}"
+
+msgid "DEL {NICK|CHAN|EMAIL|REGISTER} entry"
+msgstr "DEL {NICK|CHAN|EMAIL|REGISTER} intrare"
+
+msgid "DELIP server.name ip"
+msgstr "DELIP nume.server ip"
+
+msgid "DELSERVER server.name [zone.name]"
+msgstr "DELSERVER nume.server [nume.zonă]"
+
+msgid "DELZONE zone.name"
+msgstr "DELZONE nume.zonă"
+
+msgid "DEPOOL server.name"
+msgstr "DEPOOL nume.server"
+
+#, c-format
+msgid "Database cleared, removed %lu nicks that were added after %s."
+msgstr "Baza de date a fost golită, au fost înlăturate %lu pseudonime care au fost adăugate după %s."
+
+msgid "Date/Time"
+msgstr "Dată/Timp"
+
+msgid "Deactivates the vhost currently assigned to the nick in use. When you use this command any user who performs a /whois on you will see your real host/IP address."
+msgstr "Dezactivează gazda virtuală atribuită acum pseudonimului în uz. Când utilizați această comandă, orice utilizator care efectuează o verificare /whois asupra dumneavoastră va vedea gazda ori adresa IP reală."
+
+msgid "Deactivates your assigned vhost"
+msgstr "Dezactivează gazda virtuală atribuită dumneavoastră"
+
+#, c-format
+msgid "Default AKILL expiry time: %d days"
+msgstr "Timpul implicit de expirare AKILL este: %d zile"
+
+#, c-format
+msgid "Default AKILL expiry time: %d hours"
+msgstr "Timpul implicit de expirare AKILL este: %d ore"
+
+#, c-format
+msgid "Default AKILL expiry time: %d minutes"
+msgstr "Timpul implicit de expirare AKILL este: %d minute"
+
+msgid "Default AKILL expiry time: 1 day"
+msgstr "Timpul implicit de expirare AKILL este: 1 zi"
+
+msgid "Default AKILL expiry time: 1 hour"
+msgstr "Timpul implicit de expirare AKILL este: 1 oră"
+
+msgid "Default AKILL expiry time: 1 minute"
+msgstr "Timpul implicit de expirare AKILL este: 1 minut"
+
+msgid "Default AKILL expiry time: No expiration"
+msgstr "Timpul implicit de expirare AKILL este: fără expirare"
+
+#, c-format
+msgid "Default SNLINE expiry time: %d days"
+msgstr "Timpul implicit de expirare SNLINE este: %d zile"
+
+#, c-format
+msgid "Default SNLINE expiry time: %d hours"
+msgstr "Timpul implicit de expirare SNLINE este: %d ore"
+
+#, c-format
+msgid "Default SNLINE expiry time: %d minutes"
+msgstr "Timpul implicit de expirare SNLINE este: %d minute"
+
+msgid "Default SNLINE expiry time: 1 day"
+msgstr "Timpul implicit de expirare SNLINE este: 1 zi"
+
+msgid "Default SNLINE expiry time: 1 hour"
+msgstr "Timpul implicit de expirare SNLINE este: 1 oră"
+
+msgid "Default SNLINE expiry time: 1 minute"
+msgstr "Timpul implicit de expirare SNLINE este: 1 minut"
+
+msgid "Default SNLINE expiry time: No expiration"
+msgstr "Timpul implicit de expirare SNLINE este: fără expirare"
+
+#, c-format
+msgid "Default SQLINE expiry time: %d days"
+msgstr "Timpul implicit de expirare SQLINE este: %d zile"
+
+#, c-format
+msgid "Default SQLINE expiry time: %d hours"
+msgstr "Timpul implicit de expirare SQLINE este: %d ore"
+
+#, c-format
+msgid "Default SQLINE expiry time: %d minutes"
+msgstr "Timpul implicit de expirare SQLINE este: %d minute"
+
+msgid "Default SQLINE expiry time: 1 day"
+msgstr "Timpul implicit de expirare SQLINE este: 1 zi"
+
+msgid "Default SQLINE expiry time: 1 hour"
+msgstr "Timpul implicit de expirare SQLINE este: 1 oră"
+
+msgid "Default SQLINE expiry time: 1 minute"
+msgstr "Timpul implicit de expirare SQLINE este: 1 minut"
+
+msgid "Default SQLINE expiry time: No expiration"
+msgstr "Timpul implicit de expirare SQLINE este: fără expirare"
+
+msgid "Define messages to be randomly shown to users at logon"
+msgstr "Definește mesajele care vor fi afișate aleatoriu utilizatorilor la identificare"
+
+msgid "Define messages to be shown to users at logon"
+msgstr "Definește mesajele care vor fi afișate utilizatorilor la identificare"
+
+msgid "Define messages to be shown to users who oper"
+msgstr "Definește mesajele care vor fi afișate utilizatorilor la Operare"
+
+msgid "Delete a memo or memos"
+msgstr "Șterge o misivă sau mai multe"
+
+msgid "Delete the vhost of another user"
+msgstr "Șterge gazda virtuală a altui utilizator"
+
+#, c-format
+msgid "Deleted %d entry from %s %s list."
+msgid_plural "Deleted %d entries from %s %s list."
+msgstr[0] "%d intrare a fost înlăturată din lista %s de %s."
+msgstr[1] "%d intrări au fost înlăturate din lista %s de %s."
+
+#, c-format
+msgid "Deleted %d entry from %s access list."
+msgid_plural "Deleted %d entries from %s access list."
+msgstr[0] "%d intrare a fost înlăturată din lista de accese aparținând %s."
+msgstr[1] "%d intrări au fost înlăturate din lista de accese aparținând %s."
+
+#, c-format
+msgid "Deleted %d entry from %s autokick list."
+msgid_plural "Deleted %d entries from %s autokick list."
+msgstr[0] "%d intrare a fost înlăturată din lista de izgoniri automate aparținând %s."
+msgstr[1] "%d intrări au fost înlăturate din lista de izgoniri automate aparținând %s."
+
+#, c-format
+msgid "Deleted %d entry from %s bad words list."
+msgid_plural "Deleted %d entries from %s bad words list."
+msgstr[0] "%d intrare a fost înlăturată din lista de cuvinte nepotrivite aparținând %s."
+msgstr[1] "%d intrări au fost înlăturate din lista de cuvinte nepotrivite aparținând %s."
+
+#, c-format
+msgid "Deleted %d entry from session-limit exception list."
+msgid_plural "Deleted %d entries from session-limit exception list."
+msgstr[0] "%d intrare a fost înlăturată din lista de excepții privind limita de sesiune."
+msgstr[1] "%d intrări au fost înlăturate din lista de excepții privind limita de sesiune."
+
+#, c-format
+msgid "Deleted %d entry from the %s list."
+msgid_plural "Deleted %d entries from the %s list."
+msgstr[0] "%d intrare a fost înlăturată din lista %s."
+msgstr[1] "%d intrări au fost înlăturate din lista %s."
+
+#, c-format
+msgid "Deleted %d entry from the AKILL list."
+msgid_plural "Deleted %d entries from the AKILL list."
+msgstr[0] "%d intrare a fost înlăturată din lista AKILL."
+msgstr[1] "%d intrări au fost înlăturate din lista AKILL."
+
+#, c-format
+msgid "Deleted %s from %s %s list."
+msgstr "A fost înlăturat(ă) %1$s din lista %3$s aparținând %2$s."
+
+#, c-format
+msgid "Deleted %s from %s access list."
+msgstr "A fost înlăturat(ă) %s din lista de accese aparținând %s."
+
+#, c-format
+msgid "Deleted %s from %s autokick list."
+msgstr "A fost înlăturat(ă) %s din lista de izgoniri automate aparținând %s."
+
+#, c-format
+msgid "Deleted %s from %s bad words list."
+msgstr "A fost înlăturat(ă) %s din lista de cuvinte nepotrivite aparținând %s."
+
+#, c-format
+msgid "Deleted %s from session-limit exception list."
+msgstr "A fost înlăturat(ă) %s din lista de excepții privind limita de sesiune."
+
+#, c-format
+msgid "Deleted %s from the %s list."
+msgstr "A fost înlăturat(ă) %s din lista %s."
+
+#, c-format
+msgid "Deleted %s from the AKILL list."
+msgstr "A fost înlăturat(ă) %s din lista AKILL."
+
+#, c-format
+msgid "Deleted %u entry from your message queue."
+msgid_plural "Deleted %u entries from your message queue."
+msgstr[0] "%u intrare a fost ștearsă din coada de mesaje."
+msgstr[1] "%u intrări au fost șterse din coada de mesaje."
+
+#, c-format
+msgid "Deleted info from %s."
+msgstr "Informațiile din %s au fost șterse."
+
+msgid ""
+"Deletes the specified memo or memos. You can supply multiple memo numbers or ranges of numbers instead of a single number, as in the second example below.\n"
+"\n"
+"If LAST is given, the last memo will be deleted.\n"
+"\n"
+"If ALL is given, deletes all of your memos.\n"
+"\n"
+"Examples:\n"
+"\n"
+"   DEL1\n"
+"      Deletes your first memo.\n"
+"\n"
+"   DEL2-5,7-9\n"
+"      Deletes memos numbered 2 through 5 and 7 through 9."
+msgstr ""
+"Șterge misiva sau misivele specificate. Puteți furniza mai multe numere de misive, sau intervale de numere în loc de un singur număr, ca în al doilea exemplu de mai jos.\n"
+"\n"
+"Dacă LAST este specificat, atunci ultima misivă este ștearsă.\n"
+"\n"
+"Dacă ALL este specificat, atunci sunt șterse toate misivele.\n"
+"\n"
+"Exemple:\n"
+"\n"
+"   DEL1\n"
+"      Șterge prima misivă a dumneavoastră.\n"
+"\n"
+"   DEL2-5,7-9\n"
+"      Șterge misivele numerotate de la 2 la 5 și de la 7 la 9."
+
+msgid "Deletes the vhost assigned to the given nick from the database."
+msgstr "Șterge gazda virtuală atribuită pseudonimului precizat din baza de date."
+
+msgid "Deletes the vhost for all nicks in an account"
+msgstr "Șterge gazda virtuală pentru toate pseudonimele dintr-un cont"
+
+msgid "Deletes the vhost for all nicks in the same account as that of the given nick."
+msgstr "Șterge gazda virtuală pentru toate pseudonimele din același cont cu cel al pseudonimului precizat."
+
+#, c-format
+msgid "Depooled %s."
+msgstr "%s a fost decolectivizat."
+
+msgid "Description"
+msgstr "Descriere"
+
+#, c-format
+msgid "Description of %s changed to %s."
+msgstr "Descrierea aparținând %s a fost schimbată în %s."
+
+#, c-format
+msgid "Description of %s unset."
+msgstr "Descrierea aparținând %s a fost de-setată."
+
+msgid "Disabled"
+msgstr "Dezactivat"
+
+msgid ""
+"Disallows anyone from using the given channel. May be cancelled by using the UNSUSPEND command to preserve all previous channel data/settings. If an expiry is given the channel will be unsuspended after that period of time, else the default expiry from the configuration is used.\n"
+"\n"
+"Reason may be required on certain networks."
+msgstr ""
+"Interzice oricui să utilizeze canalul precizat. Aceasta poate fi anulată folosind comanda UNSUSPEND pentru a păstra toate datele și setările anterioare ale canalului. Dacă este specificată o perioadă de expirare, canalul va fi reactivat după acea perioadă de timp, altfel va fi utilizată expirarea implicită din configurație.\n"
+"\n"
+"În anumite rețele, este posibil să fie necesar un motiv."
+
+#, c-format
+msgid "Displayed %d records (%d total)."
+msgstr "S-au afișat %d înregistrări (%d în total)."
+
+#, c-format
+msgid "Displayed all records (count: %d)."
+msgstr "S-au afișat toate înregistrările (număr: %d)."
+
+#, c-format
+msgid "Displayed records from %d to %d."
+msgstr "S-au afișat înregistrările de la %d la %d."
+
+#, c-format
+msgid "Displayed records matching key %s (count: %d)."
+msgstr "S-au afișat înregistrările corespunzând cheii %s (număr: %d)."
+
+msgid "Displays information about a given nickname"
+msgstr "Afișează informații despre un pseudonim specificat"
+
+msgid "Displays information about the given nickname, such as the nick's owner, last seen address and time, and nick options. If no nick is given, and you are identified, your account name is used, else your current nickname is used."
+msgstr "Afișează informații despre pseudonimul specificat, cum ar fi proprietarul pseudonimului, adresa și ora ultime accesări, cât și opțiunile pentru pseudonimul respectiv. Dacă nu este menționat niciun pseudonim și sunteți identificat(ă), numele contului dumneavoastră este folosit, altfel este folosit pseudonimul curent."
+
+msgid "Displays information about your memos"
+msgstr "Afișează informații despre misivele dumneavoastră"
+
+msgid "Displays one or more vhost entries"
+msgstr "Afișează una sau mai multe intrări de gazde virtuale"
+
+msgid "Displays the top 10 users of a channel"
+msgstr "Afișează top 10 utilizatori ai unui canal"
+
+msgid "Displays the top 10 users of the network"
+msgstr "Afișează top 10 utilizatori ai rețelei"
+
+msgid "Displays the top 3 users of a channel"
+msgstr "Afișează top 3 utilizatori ai unui canal"
+
+msgid "Displays the top 3 users of the network"
+msgstr "Afișează top 3 utilizatori ai rețelei"
+
+msgid "Displays this list and give information about commands"
+msgstr "Afișează această listă și oferă informații despre commenzi"
+
+msgid "Displays your Channel Stats"
+msgstr "Afișează statisticile canalului dumneavoastră"
+
+msgid "Displays your Global Stats"
+msgstr "Afișează statisticile globale ale dumneavoastră"
+
+msgid "Don't use AMSGs!"
+msgstr "Nu folosiți AMSG!"
+
+msgid "Don't use bolds on this channel!"
+msgstr "Nu folosiți îngroșări în acest canal!"
+
+msgid "Don't use colors on this channel!"
+msgstr "Nu folosiți culori în acest canal!"
+
+msgid "Don't use italics on this channel!"
+msgstr "Nu folosiți înclinări în acest canal!"
+
+msgid "Don't use reverses on this channel!"
+msgstr "Nu folosiți inversări în acest canal!"
+
+#, c-format
+msgid "Don't use the word \"%s\" on this channel!"
+msgstr "Nu folosiți cuvântul \"%s\" în acest canal!"
+
+msgid "Don't use underlines on this channel!"
+msgstr "Nu folosiți sublinieri în acest canal!"
+
+msgid "Drops the given nick from the database. Once your nickname is dropped you may lose all of your access and channels that you may own. Any other user will be able to gain control of this nick."
+msgstr "Radiază pseudonimul precizat din baza de date. Odată ce ați abandonat pseudonimul, puteți pierde toate accesele și canalele pe care le dețineți. Orice alt utilizator va putea obține controlul asupra acestui pseudonim."
+
+#, c-format
+msgid "Edits or displays the list of logon news messages. When a user connects to the network, these messages will be sent to them. However, no more than %d messages will be sent in order to avoid flooding the user. If there are more news messages, only the most recent will be sent."
+msgstr "Editează sau afișează lista de mesaje privind știrile la conectare. Când un utilizator se conectează la rețea, aceste mesaje îi vor fi trimise. Totuși, nu vor fi trimise mai mult de %d mesaje pentru a evita inundarea utilizatorului. Dacă există mai multe mesaje de știri, vor fi trimise doar cele mai recente."
+
+#, c-format
+msgid "Edits or displays the list of oper news messages. When a user opers up (with the /OPER command), these messages will be sent to them. However, no more than %d messages will be sent in order to avoid flooding the user. If there are more news messages, only the most recent will be sent."
+msgstr "Editează sau afișează lista de mesaje privind știrile la Operare. Când un utilizator devine Operator de rețea (prin comanda /OPER), aceste mesaje îi vor fi trimise. Totuși, nu vor fi trimise mai mult de %d mesaje pentru a evita inundarea utilizatorului. Dacă există mai multe mesaje de știri, vor fi trimise doar cele mai recente."
+
+msgid "Edits or displays the list of random news messages. When a user connects to the network, one (and only one) of the random news will be randomly chosen and sent to them."
+msgstr "Editează sau afișează lista de mesaje privind știrile aleatorii. Când un utilizator se conectează la rețea, una (și numai una) dintre știrile aleatorii va fi aleasă aleatoriu și trimisă către acesta."
+
+msgid "Email address"
+msgstr "Adresa de email"
+
+#, c-format
+msgid "Email address for %s changed to %s."
+msgstr "Adresa de email pentru %s a fost schimbată în %s."
+
+#, c-format
+msgid "Email address for %s unset."
+msgstr "Adresa de email pentru %s a fost de-setată."
+
+#, c-format
+msgid "Email for %s is invalid."
+msgstr "Adresa de email pentru %s este invalidă."
+
+#, c-format
+msgid "Email matched: %s (%s) to %s."
+msgstr "Email corespunzător: %s (%s) pentru %s."
+
+msgid "Enable fantasy commands"
+msgstr "Activează comenzile fanteziste"
+
+msgid "Enable greet messages"
+msgstr "Activează mesajele de întâmpinare"
+
+msgid "Enable or disable keep modes"
+msgstr "Activează sau dezactivează păstrarea modurilor"
+
+msgid "Enabled"
+msgstr "Activat"
+
+#, c-format
+msgid ""
+"Enables or disables fantasy mode on a channel. When it is enabled, users will be able to use fantasy commands on a channel when prefixed with one of the following fantasy characters: %s\n"
+"\n"
+"Note that users wanting to use fantasy commands MUST have enough access for both the FANTASY privilege and the command they are executing."
+msgstr ""
+"Activează sau dezactivează modul fantezie într-un canal. Când acesta este activat, utilizatorii vor putea folosi comenzile fanteziste într-un canal, atunci când au ca prefix unul dintre următoarele caractere de fantezie: %s\n"
+"\n"
+"Rețineți că utilizatorii care doresc să utilizeze comenzile fanteziste TREBUIE să aibă acces suficient atât pentru privilegiul FANTASY, cât și pentru comanda pe care o execută."
+
+msgid "Enables or disables greet mode on a channel. When it is enabled, the bot will display greet messages of users joining the channel, provided they have enough access to the channel."
+msgstr "Activează sau dezactivează modul întâmpinare într-un canal. Când este activat, botul va afișa mesaje de întâmpinare ale utilizatorilor care se alătură canalului, cu condiția ca aceștia să aibă suficient acces în canal."
+
+msgid "Enables or disables ops protection mode on a channel. When it is enabled, ops won't be kicked by the bot even if they don't match the NOKICK level."
+msgstr "Activează sau dezactivează modul de protecție a operatorilor într-un canal. Când este activat, operatorii nu vor fi izgoniți de bot, chiar dacă nu corespund nivelului NOKICK."
+
+msgid "Enables or disables voices protection mode on a channel. When it is enabled, voices won't be kicked by the bot even if they don't match the NOKICK level."
+msgstr "Activează sau dezactivează modul de protecție voce într-un canal. Când este activat, membrii voce nu vor fi izgoniți de bot, chiar dacă nu corespund nivelului NOKICK."
+
+#, c-format
+msgid "Enables or disables %s's autoop feature for a channel. When disabled, users who join the channel will not automatically gain any status from %s."
+msgstr "Activează sau dezactivează operarea automată de către %s într-un canal. Când este dezactivată, utilizatorii care se alătură canalului nu vor obține automat niciun statut de la %s."
+
+msgid "Enables or disables keepmodes for the given channel. If keep modes is enabled, services will remember modes set on the channel and attempt to re-set them the next time the channel is created."
+msgstr "Activează sau dezactivează păstrarea modurilor pentru canalul precizat. Dacă este activată opțiunea de păstrare a modurilor, serviciile vor reține modurile setate în canal și vor încerca să le reașeze data viitoare când canalul este creat."
+
+msgid "Enables or disables keepmodes for the given nick. If keep modes is enabled, services will remember users' usermodes and attempt to re-set them the next time they authenticate."
+msgstr "Activează sau dezactivează păstrarea modurilor pentru pseudonimul precizat. Dacă este activată opțiunea de păstrare a modurilor, serviciile vor reține modurile de utilizator ale utilizatorilor și vor încerca să le reașeze data viitoare când se identifică."
+
+msgid "Enables or disables keepmodes for your nick. If keep modes is enabled, services will remember your usermodes and attempt to re-set them the next time you authenticate."
+msgstr "Activează sau dezactivează păstrarea modurilor pentru pseudonimul dumneavoastră. Dacă este activată opțiunea de păstrare a modurilor, serviciile vor reține modurile de utilizator și vor încerca să le reașeze data viitoare când vă identificați."
+
+msgid ""
+"Enables or disables signed kicks for a channel. When SIGNKICK is set, kicks issued with the KICK command will have the nick that used the command in their reason.\n"
+"\n"
+"If you use LEVEL, those who have a level that is superior or equal to the SIGNKICK level on the channel won't have their kicks signed."
+msgstr ""
+"Activează sau dezactivează izgonirile semnate într-un canal. Când opțiunea SIGNKICK este activă, izgonirile efectuate prin comanda KICK vor conține pseudonimul care a folosit comanda în motivul lor.\n"
+"\n"
+"Dacă utilizați LEVEL, cei care au un nivel superior sau egal cu nivelul SIGNKICK din canal nu vor avea izgonirile semnate."
+
+#, c-format
+msgid "Enables or disables the peace option for a channel. When peace is set, a user won't be able to kick, ban or remove a channel status of a user that has a level superior or equal to theirs via %s commands."
+msgstr "Activează sau dezactivează opțiunea de pace într-un canal. Când opțiunea de pace este activă, un utilizator nu va putea izgoni, bloca sau înlătura statutul în canal al altui utilizator care are un nivel superior sau egal cu al său prin comenzile %s."
+
+msgid "Enables or disables the private option for a channel."
+msgstr "Activează sau dezactivează opțiunea de privat într-un canal."
+
+msgid "Enables or disables the restricted access option for a channel. When restricted access is set, users not on the access list will instead be kicked and banned from the channel."
+msgstr "Activează sau dezactivează opțiunea de acces restricționat într-un canal. Când opțiunea de acces restricționat este activă, utilizatorii care nu se află în lista de accese vor fi izgoniți și blocați din canal."
+
+msgid "Enables or disables the secure founder option for a channel. When secure founder is set, only the real founder will be able to drop the channel, change its founder and its successor, and not those who have founder level access through the access/qop command."
+msgstr "Activează sau dezactivează opțiunea de fondator securizat într-un canal. Când opțiunea de fondator securizat este activă, doar fondatorul real va avea dreptul să radieze canalul, să schimbe fondatorul și succesorul acestuia; dar nu și cei care au acces la nivel de fondator prin comanda acces/qop."
+
+msgid "Enables or disables the secure ops option for a channel. When secure ops is set, users who are not on the access list will not be allowed channel operator status."
+msgstr "Activează sau dezactivează opțiunea de operator securizat într-un canal. Când opțiunea de operator securizat este activă, utilizatorii care nu se află în lista de accese nu vor putea avea statut de operator în canal."
+
+#, c-format
+msgid "Enables or disables the topic retention option for a channel. When %s is set, the topic for the channel will be remembered by %s even after the last user leaves the channel, and will be restored the next time the channel is created."
+msgstr "Activează sau dezactivează opțiunea de păstrare a subiectului într-un canal. Când opțiunea de %s este activă, subiectul canalului va fi păstrat de %s chiar și după ce ultimul utilizator părăsește canalul, și va fi restaurat data viitoare când canalul este creat."
+
+#, c-format
+msgid ""
+"Enables or disables the persistent channel setting. When persistent is set, the service bot will remain in the channel when it has emptied of users. \n"
+"\n"
+"If your IRCd does not have a permanent (persistent) channel mode you must have a service bot in your channel to set persist on, and it can not be unassigned while persist is on.\n"
+"\n"
+"If this network does not have %s enabled and does not have a permanent channel mode, %s will join your channel when you set persist on (and leave when it has been set off).\n"
+"\n"
+"If your IRCd has a permanent (persistent) channel mode and it is set or unset (for any reason, including MODE LOCK), persist is automatically set and unset for the channel as well. Additionally, services will set or unset this mode when you set persist on or off."
+msgstr ""
+"Activează sau dezactivează setarea canalului persistent. Când opțiunea de persistență este activă, botul de servicii va rămâne în canal după ce acesta se golește de utilizatori.\n"
+"\n"
+"Dacă serverul dumneavoastră de IRCd nu are un mod de canal permanent (persistent), trebuie să aveți un bot de servicii în canalul dumneavoastră pentru a activa persistența, iar acesta nu va putea fi disociat cât timp persistența este activă.\n"
+"\n"
+"Dacă această rețea nu are activat serviciul %s și nu are un mod de canal permanent, %s se va alătura canalului dumneavoastră când activați persistența (și-l va părăsi când o dezactivați).\n"
+"\n"
+"Dacă serverul dumneavoastră de IRCd are un mod de canal permanent (persistent) și acesta este deja setat sau nu (din orice motiv, inclusiv MODE LOCK), persistența canalului va fi setată și de-setată automat. În plus, serviciile vor activa sau dezactiva acest mod atunci când activați sau dezactivați opțiunea de persistență."
+
+msgid "End of AKILL list."
+msgstr "Sfârșitul listei AKILL."
+
+msgid "End of access list"
+msgstr "Sfârșitul listei de accese."
+
+#, c-format
+msgid "End of access list - %d/%d entries shown."
+msgstr "Sfârșitul listei de accese - %d/%d intrări afișate."
+
+msgid "End of access list."
+msgstr "Sfârșitul listei de accese."
+
+msgid "End of autokick list"
+msgstr "Sfârșitul listei de izgoniri automate."
+
+msgid "End of bad words list."
+msgstr "Sfârșitul listei de cuvinte nepotrivite."
+
+#, c-format
+msgid "End of channel list. %u channels shown."
+msgstr "Sfârșitul listei de canale. %u canale afișate."
+
+msgid "End of configuration."
+msgstr "Sfârșitul configurării."
+
+msgid "End of entry message list."
+msgstr "Sfârșitul listei mesajelor de intrare."
+
+#, c-format
+msgid "End of forbid list - %zu/%zu entries shown."
+msgstr "Sfârșitul listei de interziceri - %zu/%zu intrări afișate."
+
+msgid "End of forbid list."
+msgstr "Sfârșitul listei de interziceri."
+
+#, c-format
+msgid "End of list - %d channels shown."
+msgstr "Sfârșitul listei - %d canale afișate."
+
+#, c-format
+msgid "End of list - %d/%d matches shown."
+msgstr "Sfârșitul listei - %d/%d corespunderi afișate."
+
+msgid "End of news list."
+msgstr "Sfârșitul listei de știri."
+
+#, c-format
+msgid "End of users list. %u users shown."
+msgstr "Sfârșitul listei de utilizatori - %u utilizatori afișați."
+
+msgid "Enforce various channel modes and set options"
+msgstr "Impune diverse moduri de canal și opțiuni de setări"
+
+msgid ""
+"Enforce various channel modes and set options. The channel option indicates what channel to enforce the modes and options on. The what option indicates what modes and options to enforce, and can be any of SECUREOPS, RESTRICTED, REGONLY, SSLONLY, BANS, or LIMIT.\n"
+"\n"
+"Use SECUREOPS to enforce the SECUREOPS option, even if it is not enabled. Use RESTRICTED to enforce the RESTRICTED option, also if it's not enabled. Use REGONLY to kick all unregistered users from the channel. Use SSLONLY to kick all users not using a secure connection from the channel. BANS will enforce bans on the channel by kicking users affected by them, and LIMIT will kick users until the user count drops below the channel limit, if one is set."
+msgstr ""
+"Impune diverse moduri de canal și opțiuni de setări. Opțiunea canal indică în ce canal să se impună modurile și opțiunile. Opțiunea ce indică ce moduri și opțiuni să fie impuse, iar aceasta poate fi oricare dintre SECUREOPS, RESTRICTED, REGONLY, SSLONLY, BANS, ori LIMIT.\n"
+"\n"
+"Utilizați SECUREOPS pentru a impune opțiunea de SECUREOPS, chiar dacă aceasta nu este activată. Folosiți RESTRICTED pentru a impune opțiunea de RESTRICTED, de asemenea dacă nu este activată. Utilizați REGONLY pentru a izgoni toți utilizatorii neînregistrați din canal. Folosiți SSLONLY pentru a izgoni din canal toți utilizatorii care nu utilizează o conexiune securizată. BANS va impune blocările în canal prin înlăturarea utilizatorilor afectați de acestea, iar LIMIT va izgoni utilizatorii până când numărul acestora scade sub limita de canal, dacă este setată o limită."
+
+msgid "English"
+msgstr "Română"
+
+#, c-format
+msgid "Entry message %i for %s deleted."
+msgstr "Mesajul de intrare %i pentru %s a fost șters."
+
+#, c-format
+msgid "Entry message %s not found on channel %s."
+msgstr "Mesajul de intrare %s nu a fost găsit în canalul %s."
+
+#, c-format
+msgid "Entry message added to %s"
+msgstr "Mesajul de intrare a fost adăugat în %s"
+
+#, c-format
+msgid "Entry message list for %s is empty."
+msgstr "Lista mesajelor de intrare pentru %s este goală."
+
+#, c-format
+msgid "Entry message list for %s:"
+msgstr "Lista mesajelor de intrare pentru %s este după cum urmează:"
+
+#, c-format
+msgid "Entry messages for %s have been cleared."
+msgstr "Mesajele de intrare pentru %s au fost golite."
+
+#, c-format
+msgid "Error reloading configuration file: %s"
+msgstr "Eroare la reîncărcarea fișierului de configurare: %s"
+
+#, c-format
+msgid "Error! The vhost is too long, please use a hostname shorter than %zu characters."
+msgstr "Eroare! Gazda virtuală este prea lungă, vă rugăm să utilizați un nume de gazdă mai scurt de %zu caractere."
+
+#, c-format
+msgid "Error! The vident is too long, please use an ident shorter than %zu characters."
+msgstr "Eroare! Identitatea virtuală este prea lungă, vă rugăm utilizați o identitate mai scurtă de %zu caractere."
+
+#, c-format
+msgid "Exception for %s has been updated to %d."
+msgstr "Excepția pentru %s a fost actualizată la %d."
+
+msgid "Expires"
+msgstr "Expiră"
+
+#, c-format
+msgid "Expiry and reason updated for %s."
+msgstr "Expirarea și motivul au fost actualizate pentru %s."
+
+#, c-format
+msgid "Expiry for %s updated."
+msgstr "Expirarea pentru %s a fost actualizată."
+
+msgid "Fantasy"
+msgstr "Fantezie"
+
+#, c-format
+msgid "Fantasy commands may be prefixed with one of the following characters: %s"
+msgstr "Comenzile fanteziste pot avea ca prefix unul dintre următoarele caractere: %s"
+
+#, c-format
+msgid "Fantasy mode is now off on channel %s."
+msgstr "Modul fantezie este acum dezactivat în canalul %s."
+
+#, c-format
+msgid "Fantasy mode is now on on channel %s."
+msgstr "Modul fantezie este acum activat în canalul %s."
+
+msgid "Find a user's status on a channel"
+msgstr "Află statutul unui utilizator într-un canal"
+
+#, c-format
+msgid "Fingerprint %s already present on %s's certificate list."
+msgstr "Amprenta digitală %s este deja prezentă în lista de certificate aparținând %s."
+
+#, c-format
+msgid "Fingerprint %s is already in use."
+msgstr "Amprenta digitală %s este deja utilizată."
+
+msgid "Fixed layout"
+msgstr "Aspect fix"
+
+msgid "Flags"
+msgstr "Stegulețe"
+
+#, c-format
+msgid "Flags for %s on %s set to +%s"
+msgstr "Stegulețele pentru %s în %s sunt setate la +%s"
+
+#, c-format
+msgid "Flags list for %s"
+msgstr "Lista de stegulețe pentru %s"
+
+msgid "Flexible layout"
+msgstr "Aspect flexibil"
+
+msgid "Flood kicker"
+msgstr "Izgonire la inundări"
+
+msgid "Forbid allows you to forbid usage of certain nicknames, channels, and email addresses. Wildcards are accepted for all entries."
+msgstr "Forbid vă permite să interziceți utilizarea anumitor pseudonime, canale și adrese de email. Se acceptă caractere wildcard pentru toate intrările."
+
+msgid "Forbid list is empty."
+msgstr "Lista de interziceri este goală."
+
+msgid "Forbid list:"
+msgstr "Lista de interziceri este după cum urmează:"
+
+#, c-format
+msgid "Forbid on %s was not found."
+msgstr "Interzicerea pentru %s nu a fost găsită."
+
+msgid "Forbid usage of nicknames, channels, and emails"
+msgstr "Interzice utilizarea pseudonimelor, canalelor și adreselor de email"
+
+msgid "Force the services databases to be updated immediately"
+msgstr "Forțează actualizarea imediată a bazelor de date aparținând serviciilor"
+
+msgid "Forcefully change a user's nickname"
+msgstr "Schimbă forțat pseudonimul unui utilizator"
+
+msgid "Forcefully changes a user's nickname from nick to newnick."
+msgstr "Schimbă forțat pseudonimul unui utilizator din pseudonim în pseudonim-nou."
+
+msgid "Forcefully join a user to a channel"
+msgstr "Alătură forțat un utilizator într-un canal"
+
+msgid "Forcefully join a user to a channel."
+msgstr "Alătură forțat un utilizator într-un canal."
+
+msgid "Forcefully part a user from a channel"
+msgstr "Îndepărtează forțat un utilizator dintr-un canal"
+
+msgid "Forcefully part a user from a channel."
+msgstr "Îndepărtează forțat un utilizator dintr-un canal."
+
+msgid "Founder"
+msgstr "Fondator"
+
+#, c-format
+msgid "Founder of %s changed to %s."
+msgstr "Fondatorul %s a fost schimbat în %s."
+
+msgid "Ghost with your nick has been killed."
+msgstr "Utilizatorul fantomă folosind pseudonimul dumneavoastră a fost deconectat."
+
+#, c-format
+msgid "Gives %s status to the selected nicks on a channel. If nick is not given, it will %s you."
+msgstr "Oferă statutul de %s pseudonimului selectat într-un canal. Dacă pseudonimul nu este precizat, atunci veți primi dumneavoastră statutul de %s."
+
+#, c-format
+msgid "Gives you or the specified nick %s status on a channel"
+msgstr "Vă oferă dumneavoastră sau pseudonimului specificat statutul de %s într-un canal"
+
+msgid "Greet"
+msgstr "Întâmpinare"
+
+msgid "Greet message displayed on join"
+msgstr "Mesaj de întâmpinare afișat la alăturare"
+
+#, c-format
+msgid "Greet message for %s changed to %s."
+msgstr "Mesajul de întâmpinare pentru %s a fost schimbat în %s."
+
+#, c-format
+msgid "Greet message for %s unset."
+msgstr "Mesajul de întâmpinare pentru %s a fost de-setat."
+
+#, c-format
+msgid "Greet mode is now off on channel %s."
+msgstr "Modul de întâmpinare este acum dezactivat în canalul %s."
+
+#, c-format
+msgid "Greet mode is now on on channel %s."
+msgstr "Modul de întâmpinare este acum activat în canalul %s."
+
+msgid "Helps you reset lost passwords"
+msgstr "Vă ajută să resetați parola pierdută"
+
+msgid "Hide certain pieces of nickname information"
+msgstr "Ascunde anumite informații despre pseudonim"
+
+msgid "Hide channel from the LIST command"
+msgstr "Ascunde canalul din comanda LIST"
+
+msgid "Host"
+msgstr "Gazdă"
+
+#, c-format
+msgid "Hosts with at least %d sessions:"
+msgstr "Gazdele cu cel puțin %d sesiuni sunt după cum urmează:"
+
+msgid "ID"
+msgstr "ID"
+
+msgid "INFO [type]"
+msgstr "INFO [tip]"
+
+msgid "IP"
+msgstr "IP"
+
+#, c-format
+msgid "IP %s already exists for %s."
+msgstr "Adresa IP %s există deja pentru %s."
+
+#, c-format
+msgid "IP %s does not exist for %s."
+msgstr "Adresa IP %s nu există pentru %s."
+
+msgid "Identify yourself with your password"
+msgstr "Vă identifică la servicii prin parolă"
+
+msgid "Ignore list has been cleared."
+msgstr "Lista de ignorări a fost golită."
+
+msgid "Ignore list is empty."
+msgstr "Lista de ignorări este goală."
+
+msgid "Incorrect email address."
+msgstr "Adresa de email este incorectă."
+
+msgid "Incorrect range specified. The correct syntax is #from-to."
+msgstr "Intervalul specificat este incorect. Sintaxa corectă este #început-sfârșit."
+
+msgid "Info about a loaded module"
+msgstr "Informații despre un modul încărcat"
+
+#, c-format
+msgid "Information about bot %s:"
+msgstr "Informațiile despre botul %s sunt după cum urmează:"
+
+#, c-format
+msgid "Information about channel %s:"
+msgstr "Informațiile despre canalul %s sunt după cum urmează:"
+
+#, c-format
+msgid "Information about nick %s:"
+msgstr "Informațiile despre pseudonimul %s sunt după cum urmează:"
+
+#, c-format
+msgid "Invalid duration %s, using %d days."
+msgstr "Durata %s este invalidă, se utilizează %d zile."
+
+msgid "Invalid expiry time."
+msgstr "Timpul de expirare este invalid."
+
+msgid "Invalid hostmask. Only real hostmasks are valid, as exceptions are not matched against nicks or usernames."
+msgstr "Masca de gazdă este invalidă. Doar măștile de gazdă reale sunt valide, deoarece excepțiile nu sunt comparate cu pseudonimule sau cu numele de utilizator."
+
+#, c-format
+msgid "Invalid limit %s, using %d."
+msgstr "Limita %s este invalidă, se utilizează %d."
+
+#, c-format
+msgid "Invalid session limit. It must be a valid integer greater than or equal to zero and less than %d."
+msgstr "Limita de sesiuni este invalidă. Aceasta trebuie să fie un număr întreg valid, mai mare sau egal cu zero și mai mic decât %d."
+
+msgid "Invalid threshold value. It must be a valid integer greater than 1."
+msgstr "Valoarea pragului este invalidă. Aceasta trebuie să fie un număr întreg valid, mai mare decât 1."
+
+msgid "Invalid value for LIMIT. Must be numerical."
+msgstr "Valoarea pentru LIMIT este invalidă. Aceasta să fie o valoare numerică."
+
+msgid "Invites you or an optionally specified nick into a channel"
+msgstr "Vă invită într-un canal pe dumneavoastră, sau pe un pseudonim specificat opțional"
+
+msgid "Italics kicker"
+msgstr "Izgonire la înclinări"
+
+msgid "Keep modes"
+msgstr "Păstrare moduri"
+
+#, c-format
+msgid "Keep modes for %s is now off."
+msgstr "Păstrarea modurilor pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Keep modes for %s is now on."
+msgstr "Păstrarea modurilor pentru %s este acum activată."
+
+msgid "Key"
+msgstr "Cheie"
+
+#, c-format
+msgid "Key for channel %s is %s."
+msgstr "Cheia pentru canalul %s este %s."
+
+msgid "Kick a user from a channel"
+msgstr "Izgonește un utilizator dintr-un canal"
+
+#, c-format
+msgid "Kicked %d/%d users matching %s from %s."
+msgstr "Au fost izgoniți %d/%d utilizatori care corespund %s din %s."
+
+msgid "Kicks a specified nick from a channel"
+msgstr "Izgonește un pseudonim specificat dintr-un canal"
+
+msgid ""
+"Kicks a specified nick from a channel.\n"
+"\n"
+"By default, limited to AOPs or those with level 5 access and above on the channel. Channel founders can also specify masks."
+msgstr ""
+"Izgonește un utilizator specificat dintr-un canal.\n"
+"\n"
+"În mod implicit, se limitează la AOP-uri ori la cei cu acces de nivel 5 sau superior în canal. Fondatorii canalului pot specifica și măști."
+
+msgid "Kill a user"
+msgstr "Deconectează un utilizator"
+
+msgid "LIMIT enforced by "
+msgstr "LIMIT impus de "
+
+#, c-format
+msgid "LIMIT enforced on %s, %zu users removed."
+msgstr "LIMIT impus pentru %s, %zu utilizatori înlăturați."
+
+msgid "LIST threshold"
+msgstr "LIST de prag"
+
+msgid "LIST [mask | list | id]"
+msgstr "LIST [mască | listă | id]"
+
+msgid "LIST [mask | list]"
+msgstr "LIST [mască | listă]"
+
+msgid "LIST [nickname]"
+msgstr "LIST [pseudonim]"
+
+#, c-format
+msgid "Language changed to %s."
+msgstr "Limba a fost schimbată în %s."
+
+#, c-format
+msgid "Language for %s changed to %s."
+msgstr "Limba pentru %s a fost schimbată în %s."
+
+msgid "Last mask"
+msgstr "Ultima mască"
+
+#, c-format
+msgid "Last memo to %s has been cancelled."
+msgstr "Ultima misivă către %s a fost anulată."
+
+msgid "Last quit message"
+msgstr "Ultimul mesaj de plecare din rețea"
+
+msgid "Last seen"
+msgstr "Ultima dată văzut(ă)"
+
+msgid "Last seen mask"
+msgstr "Ultima mască văzută"
+
+msgid "Last topic"
+msgstr "Ultimul subiect"
+
+msgid "Last used"
+msgstr "Ultima utilizare"
+
+#, c-format
+msgid "Layout is now fixed for %s."
+msgstr "Aspectul este acum fix pentru %s."
+
+#, c-format
+msgid "Layout is now flexible for %s."
+msgstr "Aspectul este acum flexibil pentru %s."
+
+#, c-format
+msgid "Layout is now monospace for %s."
+msgstr "Aspectul este acum monospațial pentru %s."
+
+msgid "Level"
+msgstr "Nivel"
+
+#, c-format
+msgid "Level for %s on channel %s changed to %d."
+msgstr "Nivelul pentru %s în canalul %s a fost modificat la %d."
+
+#, c-format
+msgid "Level for %s on channel %s changed to founder only."
+msgstr "Nivelul pentru %s în canalul %s a fost schimbat doar în fondator."
+
+#, c-format
+msgid "Level must be between %d and %d inclusive."
+msgstr "Nivelul trebuie să fie între %d și %d inclusiv."
+
+msgid "Limit"
+msgstr "Limită"
+
+msgid "List all registered nicknames that match a given pattern"
+msgstr "Listează toate pseudonimele înregistrate care corespund unui anumit model"
+
+msgid "List channels you have access on"
+msgstr "Listează canalele la care aveți acces"
+
+#, c-format
+msgid "List for mode %c is full."
+msgstr "Lista pentru modul %c este plină."
+
+msgid "List loaded modules"
+msgstr "Listează modulele încărcate"
+
+#, c-format
+msgid "List of entries matching %s:"
+msgstr "Lista intrărilor care corespund cu %s este după cum urmează:"
+
+#, c-format
+msgid "List of nicknames belonging to %s:"
+msgstr "Lista pseudonimelor care aparțin lui %s este după cum urmează:"
+
+msgid "List of nicknames belonging to your account:"
+msgstr "Lista pseudonimelor aparținând contului dumneavoastră este după cum urmează:"
+
+msgid "List the options"
+msgstr "Listează opțiunile"
+
+msgid "List your memos"
+msgstr "Listează misivele dumneavoastră"
+
+msgid ""
+"Lists all available bots on this network.\n"
+"\n"
+"If the OPERONLY, UNUSED or VANITY options are given only bots which, respectively, are oper-only, unused or were added at runtime will be displayed. If multiple options are given, all nicks matching at least one option will be displayed.\n"
+"\n"
+"Note that these options are limited to Services Operators."
+msgstr ""
+"Listează toți boții disponibili în această rețea.\n"
+"\n"
+"Dacă sunt specificate opțiunile OPERONLY, UNUSED sau VANITY, vor fi afișați doar boții care sunt oper-only, neutilizați sau au fost adăugați în timpul execuției. Dacă se dau opțiuni multiple, vor fi afișate toate pseudonimele care corespund cu cel puțin o opțiune.\n"
+"\n"
+"Rețineți că aceste opțiuni sunt limitate la Operatorii de Servicii."
+
+msgid "Lists all channel records"
+msgstr "Listează toate canalele"
+
+msgid ""
+"Lists all channels currently in use on the IRC network, whether they are registered or not.\n"
+"\n"
+"If pattern is given, lists only channels that match it. If a nickname is given, lists only the channels the user using it is on. If SECRET is specified, lists only channels matching pattern that have the +s or +p mode."
+msgstr ""
+"Listează toate canalele utilizate în prezent în rețeaua IRC, indiferent dacă sunt înregistrate sau nu.\n"
+"\n"
+"Dacă este precizat un model, listează doar canalele care îi corespund. Dacă este precizat un pseudonim, listează doar canalele în care se află utilizatorul precizat. Dacă se specifică SECRET, listează doar canalele care corespund modelului și care au modul +s ori +p."
+
+msgid ""
+"Lists all channels you have access on.\n"
+"\n"
+"Channels that have the NOEXPIRE option set will be prefixed by an exclamation mark. The nickname parameter is limited to Services Operators."
+msgstr ""
+"Listează toate canalele în care aveți acces.\n"
+"\n"
+"Canalele care au setată opțiunea NOEXPIRE vor fi precedate de un semn de exclamare. Parametrul de pseudonim este limitat la Operatorii de Servicii."
+
+msgid "Lists all nicknames in your account"
+msgstr "Listează toate pseudonimele din contul dumneavoastră"
+
+msgid "Lists all nicknames that belong to your account."
+msgstr "Listează toate pseudonimele care aparțin contului dumneavoastră."
+
+msgid "Lists all registered channels matching the given pattern"
+msgstr "Listează toate canalele înregistrate care corespund modelului specificat"
+
+msgid ""
+"Lists all registered channels matching the given pattern. Channels with the PRIVATE option set will only be displayed to Services Operators with the proper access. Channels with the NOEXPIRE option set will have a ! prefixed to the channel for Services Operators to see.\n"
+"\n"
+"Note that a preceding '#' specifies a range, channel names are to be written without '#'.\n"
+"\n"
+"If the SUSPENDED or NOEXPIRE options are given, only channels which, respectively, are SUSPENDED or have the NOEXPIRE flag set will be displayed. If multiple options are given, all channels matching at least one option will be displayed. Note that these options are limited to Services Operators.\n"
+"\n"
+"Examples:\n"
+"\n"
+"    LIST*anope*\n"
+"        Lists all registered channels with anope in their\n"
+"        names (case insensitive).\n"
+"\n"
+"    LIST*NOEXPIRE\n"
+"        Lists all registered channels which have been set to not expire.\n"
+"\n"
+"    LIST #51-100\n"
+"        Lists all registered channels within the given range (51-100)."
+msgstr ""
+"Listează toate canalele înregistrate care corespund modelului specificat. Canalele cu opțiunea PRIVATE setată vor fi afișate numai Operatorilor de Servicii cu acces corespunzător. Canalele cu opțiunea NOEXPIRE setată vor avea ca prefix un ! pentru ca Operatorii de Servicii să le poată vedea.\n"
+"\n"
+"Rețineți că precedarea cu '#' specifică un interval, numele canalelor trebuie scrise fără '#'.\n"
+"\n"
+"Dacă sunt precizate opțiunile SUSPENDED sau NOEXPIRE, vor fi afișate doar canalele care sunt SUSPENDED sau care au stegulețul NOEXPIRE setat. Dacă sunt specificate mai multe opțiuni, vor fi afișate toate canalele care corespund cel puțin uneia dintre opțiuni. Rețineți că aceste opțiuni sunt limitate la Operatorii de Servicii.\n"
+"\n"
+"Exemple:\n"
+"\n"
+"    LIST*anope*\n"
+"        Listează toate canalele înregistrate cu anope în numele lor (fără distincție între majuscule și minuscule).\n"
+"\n"
+"    LIST*NOEXPIRE\n"
+"        Listează toate canalele înregistrate care au fost setate să nu expire.\n"
+"\n"
+"    LIST #51-100\n"
+"        Listează toate canalele înregistrate din intervalul menționat (51-100)."
+
+msgid ""
+"Lists all registered nicknames which match the given pattern, in nick!user@host format. Nicks with the PRIVATE option set will only be displayed to Services Operators with the proper access. Nicks with the NOEXPIRE option set will have a ! prefixed to the nickname for Services Operators to see.\n"
+"\n"
+"Note that a preceding '#' specifies a range.\n"
+"\n"
+"If the SUSPENDED, UNCONFIRMED or NOEXPIRE options are given, only nicks which, respectively, are SUSPENDED, UNCONFIRMED or have the NOEXPIRE flag set will be displayed. If multiple options are given, all nicks matching at least one option will be displayed. Note that these options are limited to Services Operators.\n"
+"\n"
+"Examples:\n"
+"\n"
+"    LIST *!joeuser@foo.com\n"
+"        Lists all registered nicks owned by joeuser@foo.com.\n"
+"\n"
+"    LIST *Bot*!*@*\n"
+"        Lists all registered nicks with Bot in their\n"
+"        names (case insensitive).\n"
+"\n"
+"    LIST * NOEXPIRE\n"
+"        Lists all registered nicks which have been set to not expire.\n"
+"\n"
+"    LIST #51-100\n"
+"        Lists all registered nicks within the given range (51-100)."
+msgstr ""
+"Listează toate pseudonimele înregistrate care corespund modelului precizat, în formatul pseudonim!utilizator@gazdă. Pseudonimele cu opțiunea PRIVATE setată vor fi afișate doar Operatorilor de Servicii cu accesul corespunzător. Pseudonimele cu opțiunea NOEXPIRE setată vor avea ca prefix un ! pentru ca Operatorii de Servicii să le poată vedea.\n"
+"\n"
+"Rețineți că precedarea cu '#' specifică un interval.\n"
+"\n"
+"Dacă sunt precizate opțiunile SUSPENDED, UNCONFIRMED sau NOEXPIRE, vor fi afișate doar pseudonimele care sunt SUSPENDED, UNCONFIRMED sau au stegulețul NOEXPIRE setat. Dacă sunt specificate mai multe opțiuni, vor fi afișate toate pseudonimele care corespund cu cel puțin o opțiune. Rețineți că aceste opțiuni sunt limitate la Operatorii de Servicii.\n"
+"\n"
+"Exemple:\n"
+"\n"
+"    LIST *!ion@popescu.com\n"
+"        Listează toate pseudonimele înregistrate deținute de ion@popescu.com.\n"
+"\n"
+"    LIST *Bot*!*@*\n"
+"        Listează toate pseudonimele înregistrate cu Bot în numele lor (fără distincție între majuscule și minuscule).\n"
+"\n"
+"    LIST * NOEXPIRE\n"
+"        Listează toate pseudonimele înregistrate care au fost setate să nu expire.\n"
+"\n"
+"    LIST #51-100\n"
+"        Listează toate pseudonimele înregistrate în intervalul menționat (51-100)."
+
+msgid "Lists all user records"
+msgstr "Listează toate înregistrările utilizatorilor"
+
+msgid ""
+"Lists all users currently online on the IRC network, whether their nick is registered or not.\n"
+"\n"
+"If pattern is given, lists only users that match it (it must be in the format nick!user@host[#realname]). If channel is given, lists only users that are on the given channel. If INVISIBLE is specified, only users with the +i flag will be listed."
+msgstr ""
+"Listează toți utilizatorii online din rețeaua IRC, indiferent dacă pseudonimul lor este înregistrat sau nu.\n"
+"\n"
+"Dacă este specificat un model, listează doar utilizatorii care corespund acestuia (trebuie să aibă formatul pseudonim!utilizator@gazdă[#nume-real]). Dacă este specificat canalul, sunt listați doar utilizatorii care se află în canalul precizat. Dacă este specificat INVISIBLE, vor fi listați doar utilizatorii cu stegulețul +i."
+
+msgid ""
+"Lists any memos you currently have. With NEW, lists only new (unread) memos. Unread memos are marked with a \"*\" to the left of the memo number. You can also specify a list of numbers, as in the example below:\n"
+"   LIST 2-5,7-9\n"
+"      Lists memos numbered 2 through 5 and 7 through 9."
+msgstr ""
+"Listează toate misivele pe care le aveți în prezent. Cu NEW, listează doar misivele noi (necitite). Misivele necitite sunt marcate cu o \"*\" în stânga numărului misivei. De asemenea, puteți specifica o listă de numere, ca în exemplul de mai jos:\n"
+"   LIST 2-5,7-9\n"
+"      Listează misivele numerotate de la 2 la 5 și de la 7 la 9."
+
+msgid "Lists available bots"
+msgstr "Listează boții disponibili"
+
+msgid "Lists currently loaded modules."
+msgstr "Listează modulele încărcate în prezent."
+
+msgid "Lists information about the specified registered channel"
+msgstr "Listează informații despre canalul înregistrat specificat"
+
+msgid "Lists information about the specified registered channel, including its founder, time of registration, last time used, and description. If the user issuing the command has the appropriate access for it, then the successor, last topic set, settings and expiration time will also be displayed when applicable."
+msgstr "Listează informații despre canalul înregistrat specificat, inclusiv fondatorul său, ora înregistrării, ultima utilizare și descrierea acestuia. Dacă utilizatorul care execută comanda are accesul corespunzător pentru aceasta, atunci când este cazul vor fi afișate și succesorul, ultimul subiect stabilit, setările și timpul de expirare."
+
+msgid "Load a module"
+msgstr "Încarcă un modul"
+
+msgid "Local channels cannot be registered."
+msgstr "Canalele locale nu pot fi înregistrate."
+
+#, c-format
+msgid "Log list for %s:"
+msgstr "Lista de jurnale pentru %s este după cum urmează:"
+
+#, c-format
+msgid "Logging changed for command %s on %s, now using log method %s%s%s."
+msgstr "Înregistrarea în jurnal a fost modificată pentru comanda %s în %s, acum se folosește metoda de înregistrare în jurnal %s%s%s."
+
+#, c-format
+msgid "Logging for command %s on %s with log method %s%s%s has been removed."
+msgstr "Înregistrarea în jurnal pentru comanda %s în %s cu metoda de înregistrare %s%s%s a fost înlăturată."
+
+#, c-format
+msgid "Logging is now active for command %s on %s, using log method %s%s%s."
+msgstr "Înregistrarea în jurnal este acum activă pentru comanda %s în %s, utilizând metoda de înregistrare în jurnal %s%s%s."
+
+#, c-format
+msgid "Login to %s"
+msgstr "Vă identifică la %s"
+
+#, c-format
+msgid "Logon news item #%s not found!"
+msgstr "Știrea la conectare #%s nu a fost găsită!"
+
+#, c-format
+msgid "Logon news item #%u deleted."
+msgstr "Știrea la conectare #%u a fost ștersă."
+
+msgid "Logon news items:"
+msgstr "Știrile la conectare sunt după cum urmează:"
+
+#, c-format
+msgid "Logout from %s"
+msgstr "Vă deidentifică de la %s"
+
+#, c-format
+msgid "Logs you in to %s so you gain Services Operator privileges. This command may be unnecessary if your oper block is configured without a password."
+msgstr "Vă identifică la %s astfel încât să obțineți privilegiile de Operator de Servicii. Această comandă poate fi inutilă dacă blocul oper al dumneavoastră este configurat fără parolă."
+
+#, c-format
+msgid "Logs you out from %s so you lose Services Operator privileges. This command is only useful if your oper block is configured with a password."
+msgstr "Vă deidentifică de la %s, astfel încât să pierdeți privilegiile de Operator de Servicii. Această comandă este utilă doar dacă blocul oper al dumneavoastră este configurat cu parolă."
+
+#, c-format
+msgid ""
+"Mainly controls mode locks and mode access (which is different from channel access) on a channel.\n"
+"\n"
+"The %sLOCK command allows you to add, delete, and view mode locks on a channel. If a mode is locked on or off, services will not allow that mode to be changed. The SET command will clear all existing mode locks and set the new one given, while ADD and DEL modify the existing mode lock.\n"
+"\n"
+"Example:\n"
+"     %s#channel%sADD+bmnt*!*@*aol*\n"
+"\n"
+"\n"
+"The %sSET command allows you to set modes through services. Wildcards * and ? may be given as parameters for list and status modes.\n"
+"\n"
+"Example:\n"
+"     %s#channelSET+v*\n"
+"       Sets voice status to all users in the channel.\n"
+"\n"
+"     %s#channelSET-b~c:*\n"
+"       Clears all extended bans that start with ~c:\n"
+"\n"
+"The %sCLEAR command is an easy way to clear modes on a channel. what may be any mode name. Examples include bans, excepts, inviteoverrides, ops, halfops, and voices. If what is not given then all basic modes are removed."
+msgstr ""
+"Controlează în principal încuierile modurilor în canale și accesul la moduri în canale (care sunt diferite de accesele în canale).\n"
+"\n"
+"Comanda %sLOCK vă permite să adăugați, să ștergeți și să vizualizați blocări de mod într-un canal. Dacă un mod este încuiat sau nu, serviciile nu vor permite schimbarea modului respectiv. Comanda SET va goli toate încuierile de mod existente și va seta pe cea precizată, în timp ce ADD și DEL modifică încuierea de mod existentă.\n"
+"\n"
+"Exemplu:\n"
+"     %s#canal%sADD+bmnt*!*@*aol*\n"
+"\n"
+"\n"
+"Comanda %sSET vă permite să setați modurile prin intermediul serviciilor. Caracterele wildcard * și ? pot fi menționate ca parametri pentru modurile de listă și statut.\n"
+"\n"
+"Exemplu:\n"
+"     %s#canalSET+v*\n"
+"       Setează statutul de membru voce pentru toți utilizatorii din canal.\n"
+"\n"
+"     %s#canalSET-b~c:*\n"
+"       Golește toate blocările extinse care încep cu ~c:\n"
+"\n"
+"Comanda %sCLEAR este o modalitate ușoară de a goli modurile dintr-un canal. ce poate fi orice nume de mod. Exemplele includ blocări, excepții, suprascrieri de invitații, operatori, semi-operatori și membri voce. Dacă ce nu este menționat, atunci toate modurile de bază sunt înlăturate."
+
+msgid "Maintain the AutoKick list"
+msgstr "Întreține lista de izgoniri automate"
+
+msgid "Maintains network bot list"
+msgstr "Întreține lista de boți de rețea"
+
+#, c-format
+msgid "Maintains the %s list for a channel. Users who match an access entry on the %s list receive the following privileges:"
+msgstr "Întreține lista %s într-un canal. Utilizatorii care corespund unei intrări de acces din lista %s primesc următoarele privilegii:"
+
+#, c-format
+msgid ""
+"Maintains the AutoKick list for a channel. If a user on the AutoKick list attempts to join the channel, %s will ban that user from the channel, then kick the user.\n"
+"\n"
+"The %sADD command adds the given nick or mask to the AutoKick list. If a reason is given with the command, that reason will be used when the user is kicked; if not, the default reason is \"User has been banned from the channel\". When akicking a registered nick the %s account will be added to the akick list instead of the mask. All users within that nickgroup will then be akicked. \n"
+"\n"
+"The %sDEL command removes the given nick or mask from the AutoKick list. It does not, however, remove any bans placed by an AutoKick; those must be removed manually.\n"
+"\n"
+"The %sLIST command displays the AutoKick list, or optionally only those AutoKick entries which match the given mask.\n"
+"\n"
+"The %sVIEW command is a more verbose version of the %sLIST command.\n"
+"\n"
+"The %sENFORCE command causes %s to enforce the current akick list by removing those users who match an akick mask.\n"
+"\n"
+"The %sCLEAR command clears all entries of the akick list."
+msgstr ""
+"Întreține lista de izgoniri automate într-un canal. Dacă un utilizator din lista de izgoniri automate încearcă să se alăture canalului, %s va bloca acel utilizator din canal, apoi îl va izgoni.\n"
+"\n"
+"Comanda %sADD adaugă pseudonimul sau masca precizată la lista de izgoniri automate. Dacă este menționat un motiv odată cu comanda, acel motiv va fi folosit când utilizatorul este izgonit; dacă nu, motivul implicit este \"Utilizatorul a fost blocat din canal\". Când izgoniți automat un pseudonim înregistrat, contul %s va fi adăugat la lista de izgoniri automate în loc de mască. Toți utilizatorii din acel grup de pseudonime vor fi apoi izgoniți automat.\n"
+"\n"
+"Comanda %sDEL înlătură pseudonimul sau masca precizată din lista de izgoniri automate. Totuși, nu înlătură nicio blocare plasată anterior de izgonirile automate; acestea trebuie înlăturate manual.\n"
+"\n"
+"Comanda %sLIST afișează lista de izgoniri automate sau, opțional, doar acele intrări care corespund măștii precizate.\n"
+"\n"
+"Comanda %sVIEW este o versiune mai detaliată a comenzii %sLIST.\n"
+"\n"
+"Comanda %sENFORCE determină %s să impună lista curentă de izgoniri automate prin înlăturarea utilizatorilor care corespund deja unei măști izgonite.\n"
+"\n"
+"Comanda %sCLEAR golește toate intrările din lista de izgoniri automate."
+
+#, c-format
+msgid ""
+"Maintains the access list for a channel. The access list specifies which users are allowed chanop status or access to %s commands on the channel. Different user levels allow for access to different subsets of privileges. Any registered user not on the access list has a user level of 0, and any unregistered user has a user level of -1.\n"
+"\n"
+"The %sADD command adds the given mask to the access list with the given user level; if the mask is already present on the list, its access level is changed to the level specified in the command. The level specified may be a numerical level or the name of a privilege (eg AUTOOP). When a user joins the channel the access they receive is from the highest level entry in the access list."
+msgstr ""
+"Întreține lista de accese într-un canal. Lista de accese specifică căror utilizatori li se permite statutul de operator de canal sau accesul la comenzile %s în canal. Diferite niveluri de utilizator permit accesul la diferite subseturi de privilegii. Orice utilizator înregistrat care nu se află în lista de accese are un nivel de utilizator de 0, iar orice utilizator neînregistrat are un nivel de utilizator de -1.\n"
+"\n"
+"Comanda %sADD adaugă masca precizată la lista de accese cu nivelul de utilizator precizat; dacă masca este deja prezentă în listă, nivelul său de acces este modificat la nivelul specificat în comandă. Nivelul specificat poate fi un nivel numeric sau numele unui privilegiu (de exemplu AUTOOP). Când un utilizator se alătură canalului, accesul pe care îl primește este cel de la intrarea cu cel mai înalt nivel din lista de accese."
+
+#, c-format
+msgid ""
+"Maintains the bad words list for a channel. The bad words list determines which words are to be kicked when the bad words kicker is enabled. For more information, type %sKICK%s.\n"
+"\n"
+"The ADD command adds the given word to the bad words list. If SINGLE is specified, a kick will be done only if a user says the entire word. If START is specified, a kick will be done if a user says a word that starts with word. If END is specified, a kick will be done if a user says a word that ends with word. If you don't specify anything, a kick will be issued every time word is said by a user. This will be shown in the LIST output as ANY.\n"
+"\n"
+"The DEL command removes the given word from the bad words list. If a list of entry numbers is given, those entries are deleted.  (See the example for LIST below.)\n"
+"\n"
+"The LIST command displays the bad words list. If a wildcard mask is given, only those entries matching the mask are displayed. If a list of entry numbers is given, only those entries are shown; for example:\n"
+"   #channelLIST2-5,7-9\n"
+"      Lists bad words entries numbered 2 through 5 and\n"
+"      7 through 9.\n"
+"\n"
+"The CLEAR command clears all entries from the bad words list."
+msgstr ""
+"Întreține lista de cuvinte nepotrivite într-un canal. Lista de cuvinte nepotrivite stabilește la ce cuvinte se vor face izgoniri atunci când este activată opțiunea de izgonire la cuvinte nepotrivite. Pentru mai multe informații, tastați %sKICK%s.\n"
+"\n"
+"Comanda ADD adaugă cuvântul precizat la lista de cuvinte nepotrivite. Dacă se specifică SINGLE, se va executa o izgonire numai dacă utilizatorul scrie întregul cuvânt. Dacă se specifică START, o izgonire va fi executată dacă un utilizator scrie un cuvânt care începe cu cuvântul. Dacă se specifică END, se va executa o izgonire dacă un utilizator scrie un cuvânt care se termină cu cuvântul. Dacă nu specificați nimic, se va executa o izgonire de fiecare dată când un utilizator scrie cuvântul; aceasta va apărea în LIST ca ANY.\n"
+"\n"
+"Comanda DEL înlătură cuvântul precizat din lista de cuvinte nepotrivite. Dacă este furnizată o listă de numere de intrare, acele intrări sunt șterse.  (Vezi exemplul pentru LIST de mai jos.)\n"
+"\n"
+"Comanda LIST afișează lista de cuvinte nepotrivite. Dacă este precizată o mască wildcard, vor fi afișate doar intrările care corespund măștii. Dacă este furnizată o listă de numere de intrare, sunt afișate doar acele intrări; de exemplu:\n"
+"   #canalLIST2-5,7-9\n"
+"      Listează intrările de cuvinte vulgare numerotate de la 2 la 5 și de la 7 la 9.\n"
+"\n"
+"Comanda CLEAR golește toate intrările din lista de cuvinte nepotrivite."
+
+msgid "Maintains the bad words list"
+msgstr "Întreține lista de cuvinte nepotrivite"
+
+msgid "Makes the bot do the equivalent of a \"/me\" command"
+msgstr "Face ca botul să execute echivalentul unei comenzi \"/me\""
+
+msgid "Makes the bot do the equivalent of a \"/me\" command on the specified channel using the specified text."
+msgstr "Face ca botul să execute echivalentul unei comenzi \"/me\" în canalul specificat folosind textul specificat."
+
+msgid "Makes the bot say the specified text on the specified channel"
+msgstr "Face ca botul să scrie textul specificat în canalul specificat"
+
+msgid "Makes the bot say the specified text on the specified channel."
+msgstr "Face ca botul să scrie textul specificat în canalul specificat."
+
+msgid "Makes the given message the greet of the nickname, that will be displayed when joining a channel that has GREET option enabled, provided that the user has the necessary access on it."
+msgstr "Face ca mesajul specificat să fie întâmpinarea pseudonimului, care va fi afișată la alăturarea într-un canal ce are opțiunea GREET activată, cu condiția ca utilizatorul să aibă accesul necesar în acesta."
+
+msgid "Makes the given message the greet of your nickname, that will be displayed when joining a channel that has GREET option enabled, provided that you have the necessary access on it."
+msgstr "Face ca mesajul specificat să fie întâmpinarea pseudonimului dumneavoastră, care va fi afișată atunci când vă alăturați într-un canal care are opțiunea GREET activată, cu condiția să aveți accesul necesar în acesta."
+
+msgid "Manage DNS zones for this network"
+msgstr "Gestionează zonele DNS pentru această rețea"
+
+msgid "Manage the channel's entry messages"
+msgstr "Gestionează mesajele de întâmpinare ale canalului"
+
+msgid "Manage the memo ignore list"
+msgstr "Gestionează lista de ignorare a misivelor"
+
+msgid "Manage your auto join list"
+msgstr "Gestionează lista de alăturări automate"
+
+msgid "Manages your pending message queue."
+msgstr "Gestionează coada de mesaje în așteptare."
+
+#, c-format
+msgid "Manipulate the %s list"
+msgstr "Manipulează lista %s"
+
+msgid "Manipulate the AKILL list"
+msgstr "Manipulează lista de AKILL"
+
+msgid "Manipulate the DefCon system"
+msgstr "Manipulează sistemul DEFCON"
+
+msgid "Manipulate the topic of the specified channel"
+msgstr "Manipulează subiectul canalului specificat"
+
+msgid "Mask"
+msgstr "Mască"
+
+msgid "Mask must be in the form user@host."
+msgstr "Masca trebuie să aibă forma utilizator@gazdă."
+
+msgid "Masks and unregistered users may not be on access lists."
+msgstr "Este posibil ca măștile și utilizatorii neînregistrați să nu fie în listele de acces."
+
+msgid "Matches and returns all users that registered using given email address"
+msgstr "Corespunde și returnează toți utilizatorii care s-au înregistrat folosind adresa de email precizată"
+
+#, c-format
+msgid "Matches for %s:"
+msgstr "Corespunderile pentru %s sunt după cum urmează:"
+
+#, c-format
+msgid "Maximum users: %zu (%s)"
+msgstr "Utilizatori maximi: %zu (%s)"
+
+#, c-format
+msgid "Memo %d from %s (%s)."
+msgstr "Misiva %d de la %s (%s)."
+
+#, c-format
+msgid "Memo %d has been deleted."
+msgstr "Misiva %d a fost ștearsă."
+
+#, c-format
+msgid "Memo %zu has been deleted."
+msgstr "Misiva %zu a fost ștearsă."
+
+msgid "Memo ignore list is empty."
+msgstr "Lista de ignorare a misivelor este goală."
+
+msgid "Memo ignore list:"
+msgstr "Lista de ignorare a misivelor este după cum urmează:"
+
+#, c-format
+msgid "Memo limit disabled for %s."
+msgstr "Limita de misive a fost dezactivată pentru %s."
+
+#, c-format
+msgid "Memo limit for %s set to %d."
+msgstr "Limita de misive pentru %s a fost setată la %d."
+
+#, c-format
+msgid "Memo limit for %s set to 0."
+msgstr "Limita de misive pentru %s a fost setată la 0."
+
+#, c-format
+msgid "Memo sent to %s."
+msgstr "Misiva a fost expediată către %s."
+
+#, c-format
+msgid "Memos for %s:"
+msgstr "Misivele pentru %s sunt după cum urmează:"
+
+msgid "Message"
+msgstr "Mesaj"
+
+msgid "Message mode"
+msgstr "Mod de mesaj"
+
+msgid "Method"
+msgstr "Metodă"
+
+#, c-format
+msgid "Missing parameter for mode %c."
+msgstr "Parametru lipsă pentru modul %c."
+
+#, c-format
+msgid "Missing passwords: %zu"
+msgstr "Parole lipsă: %zu"
+
+msgid "Mode"
+msgstr "Mod"
+
+#, c-format
+msgid "Mode %s is a virtual mode and can't be cleared."
+msgstr "Modul %s este un mod virtual și nu poate fi golit."
+
+#, c-format
+msgid "Mode %s is not a status or list mode."
+msgstr "Modul %s nu este un mod de statut sau de listă."
+
+msgid "Mode lock"
+msgstr "Încuiere de mod"
+
+#, c-format
+msgid "Mode locks for %s:"
+msgstr "Încuierile de mod pentru %s sunt după cum urmează:"
+
+msgid "Modes"
+msgstr "Moduri"
+
+#, c-format
+msgid "Modes cleared on %s and the channel destroyed."
+msgstr "Modurile au fost golite în %s și canalul a fost distrus."
+
+#, c-format
+msgid ""
+"Modifies or displays the certificate list for your nick. If you connect to IRC and provide a client certificate with a matching fingerprint in the cert list, you will be automatically identified to services. Services Operators may provide a nick to modify other users' certificate lists.\n"
+"\n"
+"Examples:\n"
+"\n"
+"    %sADD\n"
+"        Adds your current fingerprint to the certificate list and\n"
+"        automatically identifies you when you connect to IRC\n"
+"        using this fingerprint.\n"
+"\n"
+"    %sDEL<fingerprint>\n"
+"        Removes the fingerprint <fingerprint> from your certificate list.\n"
+"\n"
+"    %sLIST\n"
+"        Displays the current certificate list."
+msgstr ""
+"Modifică sau afișează lista de certificate pentru pseudonimul dumneavoastră. Dacă vă conectați la IRC și furnizați un certificat de client cu o amprentă digitală potrivită în lista de certificate, veți fi identificat(ă) automat la servicii. Operatorii de Servicii pot prezenta un pseudonim pentru a modifica listele de certificate ale altor utilizatori.\n"
+"\n"
+"Exemple:\n"
+"\n"
+"    %sADD\n"
+"        Adaugă amprenta digitală curentă a dumneavoastră la lista de certificate și vă identifică automat atunci când vă conectați la IRC folosind această amprentă.\n"
+"\n"
+"    %sDEL<fingerprint>\n"
+"        Înlătură amprenta digitală <fingerprint> din lista de certificate.\n"
+"\n"
+"    %sLIST\n"
+"        Afișează lista curentă de certificate."
+
+#, c-format
+msgid "Modify the list of %s users"
+msgstr "Modifică lista de utilizatori %s"
+
+msgid "Modify the list of privileged users"
+msgstr "Modifică lista de utilizatori privilegiați"
+
+msgid "Modify the nickname client certificate list"
+msgstr "Modifică lista de certificate client a pseudonimului"
+
+msgid "Modify the services ignore list"
+msgstr "Modifică lista de ignorări a serviciilor"
+
+msgid "Modify the session-limit exception list"
+msgstr "Modifică lista de excepții pentru limita de sesiune"
+
+#, c-format
+msgid "Module %s is already loaded."
+msgstr "Modulul %s este deja încărcat."
+
+#, c-format
+msgid "Module %s isn't loaded."
+msgstr "Modulul %s nu este încărcat."
+
+#, c-format
+msgid "Module %s loaded."
+msgstr "Modulul %s a fost încărcat."
+
+#, c-format
+msgid "Module %s reloaded."
+msgstr "Modulul %s a fost reîncărcat."
+
+#, c-format
+msgid "Module %s unloaded."
+msgstr "Modulul %s a fost scos."
+
+msgid "Module Name"
+msgstr "Numele Modulului"
+
+msgid "Module settings:"
+msgstr "Setările modulului sunt după cum urmează:"
+
+#, c-format
+msgid "Module: %s Version: %s Author: %s Loaded: %s"
+msgstr "Modul: %s Versiune: %s Autor: %s Încărcat: %s"
+
+#, c-format
+msgid "Module: %s [%s] [%s]"
+msgstr "Modul: %s [%s] [%s]"
+
+msgid "Monospace layout"
+msgstr "Aspect monospațial"
+
+#, c-format
+msgid "Multiple languages matched %s. Please be more specific."
+msgstr "Mai multe limbi corespund cu %s. Vă rugăm să fiți mai precis(ă)."
+
+#, c-format
+msgid "Multiple timezones matched %s. Please be more specific."
+msgstr "Mai multe fusuri orare corespund cu %s. Vă rugăm să fiți mai precis(ă)."
+
+msgid "NOTICE: In order to register a channel, you must have first registered your nickname."
+msgstr "ATENȚIE: Pentru a înregistra un canal, trebuie mai întâi să vă fi înregistrat pseudonimul."
+
+msgid "Name"
+msgstr "Nume"
+
+msgid "Name     Type"
+msgstr "Nume     Tip"
+
+#, c-format
+msgid "Network stats for %s:"
+msgstr "Statisticile de rețea pentru %s sunt după cum urmează:"
+
+msgid "Never"
+msgstr "Niciodată"
+
+msgid "Never op"
+msgstr "Niciodată operator"
+
+msgid "Nick"
+msgstr "Pseudonim"
+
+#, c-format
+msgid "Nick %s has been confirmed."
+msgstr "Pseudonimul %s a fost confirmat."
+
+#, c-format
+msgid "Nick %s is already an operator."
+msgstr "Pseudonimul %s este deja operator."
+
+#, c-format
+msgid "Nick %s is already confirmed."
+msgstr "Pseudonimul %s este deja confirmat."
+
+#, c-format
+msgid "Nick %s is an illegal nickname and cannot be used."
+msgstr "Pseudonimul %s este un pseudonim ilegal și nu poate fi utilizat."
+
+#, c-format
+msgid "Nick %s is currently in use."
+msgstr "Pseudonimul %s este folosit în prezent."
+
+#, c-format
+msgid "Nick %s is forbidden by %s: %s"
+msgstr "Pseudonimul %s este interzis de %s: %s"
+
+#, c-format
+msgid "Nick %s is forbidden."
+msgstr "Pseudonimul %s este interzis."
+
+#, c-format
+msgid "Nick %s is not a Services Operator."
+msgstr "Pseudonimul %s nu este Operator de Servicii."
+
+#, c-format
+msgid "Nick %s is part of this Network's Services."
+msgstr "Pseudonimul %s face parte din serviciile acestei rețele."
+
+#, c-format
+msgid "Nick %s isn't currently in use."
+msgstr "Pseudonimul %s nu este folosit momentan."
+
+#, c-format
+msgid "Nick %s isn't registered."
+msgstr "Pseudonimul %s nu este înregistrat."
+
+#, c-format
+msgid "Nick %s was truncated to %zu characters."
+msgstr "Pseudonimul %s a fost trunchiat la %zu caractere."
+
+#, c-format
+msgid "Nick %s will expire."
+msgstr "Pseudonimul %s va expira."
+
+#, c-format
+msgid "Nick %s will not expire."
+msgstr "Pseudonimul %s nu va expira."
+
+#, c-format
+msgid "Nick %s does not belong to your account."
+msgstr "Pseudonimul %s nu aparține contului dumneavoastră."
+
+#, c-format
+msgid "Nick %s doesn't have a memo from you."
+msgstr "Pseudonimul %s nu are o misivă de la dumneavoastră."
+
+#, c-format
+msgid "Nick %s has been logged out."
+msgstr "Pseudonimul %s a fost deidentificat."
+
+#, c-format
+msgid "Nick %s has been ungrouped from %s."
+msgstr "Pseudonimul %s a fost degrupat din %s."
+
+#, c-format
+msgid "Nick %s is currently suspended."
+msgstr "Pseudonimul %s este momentan suspendat."
+
+#, c-format
+msgid "Nick %s is not suspended."
+msgstr "Pseudonimul %s nu este suspendat."
+
+#, c-format
+msgid "Nick %s is now released."
+msgstr "Pseudonimul %s este acum eliberat."
+
+#, c-format
+msgid "Nick %s is now suspended."
+msgstr "Pseudonimul %s este acum suspendat."
+
+msgid "Nick registered"
+msgstr "Pseudonim înregistrat"
+
+#, c-format
+msgid "Nick too long, max length is %zu characters."
+msgstr "Pseudonimul este prea lung, lungimea maximă este de %zu caractere."
+
+#, c-format
+msgid "Nickname %s has been dropped."
+msgstr "Pseudonimul %s a fost radiat."
+
+#, c-format
+msgid "Nickname %s is already registered!"
+msgstr "Pseudonimul %s este deja înregistrat!"
+
+#, c-format
+msgid "Nickname %s may not be registered."
+msgstr "Pseudonimul %s nu poate fi înregistrat."
+
+#, c-format
+msgid "Nickname %s registered."
+msgstr "Pseudonimul %s a fost înregistrat."
+
+msgid "No auto-op"
+msgstr "Fără operare automată"
+
+msgid "No bot"
+msgstr "Fără bot"
+
+msgid "No expiry"
+msgstr "Fără expirare"
+
+#, c-format
+msgid "No help available for %s."
+msgstr "Nu există ajutor disponibil pentru %s."
+
+#, c-format
+msgid "No information about module %s is available."
+msgstr "Nu sunt disponibile informații despre modulul %s."
+
+#, c-format
+msgid "No limit is set on %s."
+msgstr "Nu este setată nicio limită pentru %s."
+
+#, c-format
+msgid "No matches for %s found."
+msgstr "Nu s-au găsit corespunderi pentru %s."
+
+msgid "No matching entries in your message queue."
+msgstr "Nu există intrări corespunzătoare în coada de mesaje."
+
+#, c-format
+msgid "No matching entries on %s %s list."
+msgstr "Nu există intrări corespunzătoare în lista %2$s de %1$s."
+
+#, c-format
+msgid "No matching entries on %s access list."
+msgstr "Nu există intrări corespunzătoare în lista de accese aparținând %s."
+
+#, c-format
+msgid "No matching entries on %s autokick list."
+msgstr "Nu există intrări corespunzătoare în lista de izgoniri automate aparținând %s."
+
+#, c-format
+msgid "No matching entries on %s bad words list."
+msgstr "Nu există intrări corespunzătoare în lista de cuvinte nepotrivite %s."
+
+msgid "No matching entries on session-limit exception list."
+msgstr "Nu există intrări corespunzătoare în lista de excepții privind limita de sesiune."
+
+#, c-format
+msgid "No matching entries on the %s list."
+msgstr "Nu există intrări corespunzătoare în lista %s."
+
+msgid "No matching entries on the AKILL list."
+msgstr "Nu există intrări corespunzătoare în lista AKILL."
+
+msgid "No memo was cancelable."
+msgstr "Nicio misivă nu putea fi anulată."
+
+msgid "No memos to display."
+msgstr "Nu există nicio misivă de afișat."
+
+msgid "No modules currently loaded matching that criteria."
+msgstr "Niciun modul încărcat în prezent nu corespunde acestor criterii."
+
+msgid "No one is using your nick, and services are not holding it."
+msgstr "Nimeni nu vă folosește pseudonimul, iar serviciile nu-l țin."
+
+msgid "No oper block for your nick."
+msgstr "Nu există niciun block Operator pentru pseudonimul dumneavoastră."
+
+msgid "No records to display."
+msgstr "Nu există nicio înregistrare de afișat."
+
+#, c-format
+msgid "No registrations matching %s were found."
+msgstr "Nu au fost găsite înregistrări care să corespundă cu %s."
+
+#, c-format
+msgid "No request for nick %s found."
+msgstr "Nu a fost găsită nicio solicitare pentru pseudonimul %s."
+
+msgid "No signed kick when SIGNKICK LEVEL is used"
+msgstr "Fără izgonire semnată când se utilizează SIGNKICK LEVEL"
+
+#, c-format
+msgid "No stats for %s."
+msgstr "Nu există nicio statistică pentru %s."
+
+#, c-format
+msgid "No such info \"%s\" on %s."
+msgstr "Nu există astfel de informații \"%s\" în %s."
+
+#, c-format
+msgid "No users on %s match %s."
+msgstr "Niciun utilizator din %s nu corespunde cu %s."
+
+#, c-format
+msgid "No-bot mode is now off on channel %s."
+msgstr "Modul fără boți este acum dezactivat în canalul %s."
+
+#, c-format
+msgid "No-bot mode is now on on channel %s."
+msgstr "Modul fără boți este acum activat în canalul %s."
+
+#, c-format
+msgid "Non-status modes cleared on %s."
+msgstr "Modurile fără de statut au fost golite în %s."
+
+msgid "None"
+msgstr "Niciuna"
+
+#, c-format
+msgid "Note that any channel which is not used for %s (i.e. which no user on the channel's access list enters for that period of time) will be automatically dropped."
+msgstr "Rețineți că orice canal care nu este utilizat pentru %s (adică în care nu intră niciun utilizator din lista de accese a canalului în această perioadă de timp) va fi radiat automat."
+
+#, c-format
+msgid "Note, however, if the successor already has too many channels registered (%u), they will not be able to become the new founder and it will be as if the channel had no successor set."
+msgstr "Rețineți, totuși, dacă succesorul are deja prea multe canale înregistrate (%u), acesta nu va putea deveni noul fondator și va fi ca și cum canalul nu ar avea un succesor setat."
+
+msgid "Nothing to do."
+msgstr "Nu este nimic de făcut."
+
+msgid "Number"
+msgstr "Număr"
+
+msgid "Online from"
+msgstr "Conectat(ă) din"
+
+#, c-format
+msgid "Oper %s is configured in the configuration file(s) and can not be removed by this command."
+msgstr "Operatorul %s este configurat în fișierele de configurare și nu poate fi înlăturat(ă) cu această comandă."
+
+msgid "Oper Info"
+msgstr "Informații Operator"
+
+#, c-format
+msgid "Oper info list for %s is empty."
+msgstr "Lista cu informații de Operatori pentru %s este goală."
+
+#, c-format
+msgid "Oper news item #%s not found!"
+msgstr "Știrea la Operare #%s nu a fost găsită!"
+
+#, c-format
+msgid "Oper news item #%u deleted."
+msgstr "Știrea la Operare #%u a fost ștearsă."
+
+msgid "Oper news items:"
+msgstr "Știrile la Operare sunt după cum urmează:"
+
+#, c-format
+msgid "Oper privileges removed from %s (%s)."
+msgstr "Privilegiile de Operator au fost înlăturate de la %s (%s)."
+
+#, c-format
+msgid "Oper type %s has not been configured."
+msgstr "Tipul de Operator %s nu a fost configurat."
+
+#, c-format
+msgid "Opertype %s has no allowed commands."
+msgstr "Tipul de Operator %s nu are nicio comandă permisă."
+
+#, c-format
+msgid "Opertype %s has no allowed privileges."
+msgstr "Tipul de Operator %s nu are privilegii permise."
+
+#, c-format
+msgid "Opertype %s receives modes %s once identified."
+msgstr "Tipul de Operator %s primește modurile %s odată identificat."
+
+msgid "Ops protection"
+msgstr "Protecție Operatori"
+
+msgid "Options"
+msgstr "Opțiuni"
+
+msgid "POOL server.name"
+msgstr "POOL nume.server"
+
+msgid "Param"
+msgstr "Parametru"
+
+msgid "Password accepted - you are now recognized."
+msgstr "Parolă acceptată - acum ești recunoscut(ă)."
+
+msgid "Password accepted."
+msgstr "Parolă acceptată."
+
+#, c-format
+msgid "Password for %s changed."
+msgstr "Parola pentru %s a fost schimbată."
+
+msgid "Password incorrect."
+msgstr "Parola este incorectă."
+
+#, c-format
+msgid "Password reset email for %s has been sent."
+msgstr "A fost trimis mesajul de email de resetare a parolei pentru %s."
+
+msgid "Passwords can not be changed right now. Please try again later."
+msgstr "Parolele nu pot fi schimbate momentan. Vă rugăm să încercați din nou mai târziu."
+
+#, c-format
+msgid "Passwords encrypted with %s: %zu"
+msgstr "Parolele criptate cu %s: %zu"
+
+msgid "Peace"
+msgstr "Pace"
+
+#, c-format
+msgid "Peace option for %s is now off."
+msgstr "Opțiunea de pace pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Peace option for %s is now on."
+msgstr "Opțiunea de pace pentru %s este acum activată."
+
+msgid "Persistent"
+msgstr "Persistent"
+
+#, c-format
+msgid "Please confirm that you want to drop %s with %s%s%s"
+msgstr "Vă rugăm confirmați că doriți să radiați %s cu %s%s%s"
+
+msgid "Please contact an Operator to get a vhost assigned to this nick."
+msgstr "Vă rugăm să contactați un Operator pentru a obține o gazdă virtuală atribuită acestui pseudonim."
+
+msgid "Please try again with a more obscure password. Passwords should not be something that could be easily guessed (e.g. your real name or your nick) and cannot contain the space or tab characters."
+msgstr "Vă rugăm să încercați din nou cu o parolă mai puțin cunoscută. Parolele nu ar trebui să fie ceva care ar putea fi ușor de ghicit (de exemplu, numele dumneavoastră real sau pseudonimul dumneavoastră) și trebuie să nu conțină spațiu ori caractere de tabulare."
+
+msgid "Please use a valid server name when juping."
+msgstr "Vă rugăm să folosiți un nume de server valid pentru juping."
+
+msgid "Please use the symbol of # when attempting to register."
+msgstr "Vă rugăm să folosiți și simbolul # atunci când doriți să înregistrați un canal."
+
+#, c-format
+msgid "Please wait %s and retry."
+msgstr "Vă rugăm să așteptați %s și să încercați din nou."
+
+#, c-format
+msgid "Please wait %s before requesting a new vhost."
+msgstr "Vă rugăm să așteptați %s înainte de a solicita o nouă gazdă virtuală."
+
+#, c-format
+msgid "Please wait %s before using the %s command again."
+msgstr "Vă rugăm să așteptați %s înainte de a utiliza iar comanda %s."
+
+#, c-format
+msgid "Please wait %s before using the GROUP command again."
+msgstr "Vă rugăm să așteptați %s înainte de a utiliza iar comanda GROUP."
+
+#, c-format
+msgid "Please wait %s before using the REGISTER command again."
+msgstr "Vă rugăm să așteptați %s înainte de a utiliza iar comanda REGISTER."
+
+#, c-format
+msgid "Pooled %s."
+msgstr "%s a fost colectivizat."
+
+msgid "Pooled/Active"
+msgstr "Colectivizat/Activ"
+
+msgid "Pooled/Not Active"
+msgstr "Colectivizat/Inactiv"
+
+msgid "Prevent a bot from being assigned by non Services Operators"
+msgstr "Împiedică asocierea unui bot de către altcineva decât Operatorii de Servicii"
+
+msgid "Prevent a bot from being assigned to a channel"
+msgstr "Împiedică asocierea unui bot într-un canal"
+
+msgid "Prevent a channel from being used preserving channel data and settings"
+msgstr "Împiedică utilizărea unui canal, păstrând datele și setările canalului"
+
+msgid "Prevent the channel from expiring"
+msgstr "Împiedică expirarea canalului"
+
+msgid "Prevent the nickname from appearing in the LIST command"
+msgstr "Împiedică apariția pseudonimului în comanda LIST"
+
+msgid "Prevent the nickname from expiring"
+msgstr "Împiedică expirarea pseudonimului"
+
+msgid "Prevents users being kicked by services"
+msgstr "Împiedică izgonirea utilizatorilor de către servicii"
+
+msgid "Private"
+msgstr "Privat"
+
+#, c-format
+msgid "Private mode of bot %s is now off."
+msgstr "Modul privat al botului %s este acum dezactivat."
+
+#, c-format
+msgid "Private mode of bot %s is now on."
+msgstr "Modul privat al botului %s este acum activat."
+
+#, c-format
+msgid "Private option for %s is now off."
+msgstr "Opțiunea privată pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Private option for %s is now on."
+msgstr "Opțiunea privată pentru %s este acum activată."
+
+#, c-format
+msgid "Private option is now off for %s."
+msgstr "Opțiunea privată este acum dezactivată pentru %s."
+
+#, c-format
+msgid "Private option is now on for %s."
+msgstr "Opțiunea privată este acum activată pentru %s."
+
+#, c-format
+msgid "Privilege %s added to %s on %s, new flags are +%s"
+msgstr "Privilegiul %s a fost adăugat la %s din %s; noile stegulețe sunt +%s"
+
+#, c-format
+msgid "Privilege %s removed from %s on %s, new flags are +%s"
+msgstr "Privilegiul %s a fost înlăturat de la %s din %s; noile stegulețe sunt +%s"
+
+msgid "Protection"
+msgstr "Protecție"
+
+msgid "Protection after"
+msgstr "Protecție după"
+
+#, c-format
+msgid "Protection delay must be between %s and %s."
+msgstr "Întârzierea protecției trebuie să fie între %s și %s."
+
+#, c-format
+msgid "Protection is now off for %s."
+msgstr "Protecția este acum dezactivată pentru %s."
+
+#, c-format
+msgid "Protection is now on after %lu seconds for %s."
+msgstr "Protecția este acum activată după %lu secunde pentru %s."
+
+#, c-format
+msgid "Protection is now on for %s."
+msgstr "Protecția este acum activată pentru %s."
+
+msgid "Puts an AKILL for every nick on the specified channel. It uses the entire real ident@host for every nick, and then enforces the AKILL."
+msgstr "Pune un AKILL pentru fiecare pseudonim din canalul specificat. Aceasta folosește întregul format real utilizator@gazdă pentru fiecare pseudonim, apoi impune AKILL-ul."
+
+msgid "REGONLY enforced by "
+msgstr "REGONLY impus de "
+
+msgid "RESTRICTED enforced by "
+msgstr "RESTRICTED impus de "
+
+msgid "REVOKE server"
+msgstr "REVOKE server"
+
+#, c-format
+msgid "Random news item #%s not found!"
+msgstr "Știrea aleatorie #%s nu a fost găsită!"
+
+#, c-format
+msgid "Random news item #%u deleted."
+msgstr "Știrea aleatorie #%u a fost ștearsă."
+
+msgid "Random news items:"
+msgstr "Știrile aleatorii sunt după cum urmează:"
+
+msgid "Read a memo or memos"
+msgstr "Afișează o misivă sau mai multe"
+
+msgid "Real name"
+msgstr "Nume real"
+
+msgid "Realname"
+msgstr "Nume real"
+
+msgid "Reason"
+msgstr "Motiv"
+
+#, c-format
+msgid "Reason for %s updated."
+msgstr "Motivul pentru %s a fost actualizat."
+
+msgid "Recovers your nick from another user or from services. If services are currently holding your nick, the hold will be released. If another user is holding your nick and is identified they will be killed (similar to the old GHOST command). If they are not identified they will be forced off of the nick."
+msgstr "Recuperează pseudonimul dumneavoastră de la un alt utilizator sau de la servicii. Dacă serviciile vă țin pseudonimul în prezent, această ținere va fi eliberată. Dacă un alt utilizator vă deține pseudonimul și este identificat, acel utilizator va fi deconectat (similar cu vechea comandă GHOST). Dacă acel utilizator nu este identificat, atunci i se va schimba pseudonimul."
+
+msgid "Redefine the meanings of access levels"
+msgstr "Redefinește semnificațiile nivelurilor de acces"
+
+msgid "Regains control of your nick"
+msgstr "Recapătă controlul asupra pseudonimului dumneavoastră"
+
+msgid "Regex is disabled."
+msgstr "Expresia regulată este dezactivată."
+
+#, c-format
+msgid "Regex matches are also supported using the %s engine. Enclose your mask in // if this is desired."
+msgstr "Corespunderile regex sunt de asemenea acceptate folosind motorul %s. Includeți masca dumneavoastră între // dacă doriți."
+
+#, c-format
+msgid "Regex matches are also supported using the %s engine. Enclose your pattern in // if this is desired."
+msgstr "Corespunderile Regex sunt de asemenea acceptate folosind motorul %s. Includeți modelul dumneavoastră între // dacă doriți."
+
+msgid "Register a channel"
+msgstr "Înregistrează un canal"
+
+msgid "Register a nickname"
+msgstr "Înregistrează un pseudonim"
+
+msgid "Registered"
+msgstr "Înregistrat"
+
+#, c-format
+msgid "Registered accounts: %zu entries, %zu buckets, longest chain is %zu"
+msgstr "Conturi înregistrate: %zu intrări, %zu compartimente, cel mai lung lanț este %zu"
+
+#, c-format
+msgid "Registered channels: %zu entries, %zu buckets, longest chain is %zu"
+msgstr "Canale înregistrate: %zu intrări, %zu compartimente, cel mai lung lanț este %zu"
+
+#, c-format
+msgid "Registered nicknames: %zu entries, %zu buckets, longest chain is %zu"
+msgstr "Pseudonime înregistrate: %zu intrări, %zu compartimente, cel mai lung lanț este %zu"
+
+#, c-format
+msgid "Registered only enforced on %s."
+msgstr "Doar pseudonimele înregistrate sunt permise în %s."
+
+#, c-format
+msgid ""
+"Registers a channel in the %s database. In order to use this command, you must first be a channel operator on the channel you're trying to register. The description, which is optional, is a general description of the channel's purpose. \n"
+"\n"
+"When you register a channel, you are recorded as the \"founder\" of the channel. The channel founder is allowed to change all of the channel settings for the channel; %s will also automatically give the founder channel operator privileges when they enter the channel."
+msgstr ""
+"Înregistrează un canal în baza de date %s. Pentru a utiliza această comandă, trebuie mai întâi să fiți operator de canal în canalul pe care încercați să-l înregistrați. Descrierea, care este opțională, reprezintă o descriere generală a scopului canalului.\n"
+"\n"
+"Când înregistrați un canal, sunteți înregistrat(ă) ca \"fondator\" al canalului. Fondatorul canalului are permisiunea de a modifica toate setările canalului; %s va acorda automat fondatorului canalului privilegiile de operator al canalului atunci când acesta intră în canal."
+
+#, c-format
+msgid ""
+"Registers your nickname in the %s database. Once your nick is registered, you can use the SET and ACCESS commands to configure your nick's settings as you like them. Make sure you remember the password you use when registering - you'll need it to make changes to your nick later. (Note that case matters! ANOPE, Anope, and anope are all different passwords!) \n"
+"\n"
+"Guidelines on choosing passwords:\n"
+"\n"
+"Passwords should not be easily guessable. For example, using your real name as a password is a bad idea. Using your nickname as a password is a much worse idea ;) and, in fact, %s will not allow it. Also, short passwords are vulnerable to trial-and-error searches, so you should choose a password at least %u characters long. Finally, the space character cannot be used in passwords."
+msgstr ""
+"Înregistrează pseudonimul dumneavoastră în baza de date %s. Odată ce pseudonimul dumneavoastră este înregistrat, puteți utiliza comenzile SET și ACCESS pentru a configura setările pseudonimului dumneavoastră după cum doriți. Asigurați-vă că vă amintiți parola pe care o utilizați atunci când vă înregistrați - veți avea nevoie de ea pentru a face modificări la pseudonimul dumneavoastră mai târziu. (Rețineți că majusculele și minusculele contează! De exemplu: ANOPE, Anope, și anope sunt parole diferite!)\n"
+"\n"
+"Instrucțiuni privind alegerea parolelor:\n"
+"\n"
+"Parolele nu ar trebui să fie ușor de ghicit. De exemplu, folosirea numelui dumneavoastră real ca parolă nu este deloc o idee bună. A folosi pseudonimul ca parolă este o idee și mai rea, iar %s nu va permite acest lucru. De asemenea, parolele scurte sunt vulnerabile la căutări prin încercări, așadar ar trebui să alegeți o parolă cu o lungime de cel puțin %u caractere. În cele din urmă, caracterul spațiu nu poate fi utilizat în parole."
+
+msgid "Registration is currently disabled."
+msgstr "Înregistrarea este momentan dezactivată."
+
+msgid "Regulate the use of critical commands"
+msgstr "Moderează utilizarea comenzilor critice"
+
+msgid "Reject the requested vhost for the given nick."
+msgstr "Respinge gazda virtuală solicitată pentru pseudonimul precizat."
+
+msgid "Reject the requested vhost of a user"
+msgstr "Respinge gazda virtuală solicitată de un utilizator"
+
+msgid "Releases a suspended channel"
+msgstr "Eliberează un canal suspendat"
+
+msgid "Releases a suspended channel. All data and settings are preserved from before the suspension."
+msgstr "Eliberează un canal suspendat. Toate datele și setările sunt păstrate de dinainte de suspendare."
+
+msgid "Reload a module"
+msgstr "Reîncarcă un modul"
+
+msgid "Reload services' configuration file"
+msgstr "Reîncarcă fișierul de configurare al serviciilor"
+
+msgid "Remove a nick from an account"
+msgstr "Înlătură un pseudonim dintr-un cont"
+
+msgid "Remove all bans preventing a user from entering a channel"
+msgstr "Înlătură toate blocările care împiedică un utilizator să intre într-un canal"
+
+msgid "Remove all operators from a server remotely"
+msgstr "Înlătură de la distanță toți operatorii dintr-un server"
+
+#, c-format
+msgid "Removed IP %s from %s."
+msgstr "Adresa IP %s a fost înlăturată din %s."
+
+#, c-format
+msgid "Removed server %s from zone %s."
+msgstr "Serverul %s a fost înlăturat din zona %s."
+
+#, c-format
+msgid "Removed server %s."
+msgstr "Serverul %s a fost înlăturat."
+
+#, c-format
+msgid "Removes %s status from the selected nicks on a channel. If nick is not given, it will de%s you."
+msgstr "Înlătură statutul %s de la pseudonimul selectat într-un canal. Dacă pseudonimul nu este specificat, statutul dumneavoastră %s va fi înlăturat."
+
+#, c-format
+msgid "Removes %s status from you or the specified nick on a channel"
+msgstr "Înlătură statutul %s de la dumneavoastră sau de la pseudonimul specificat dintr-un canal"
+
+msgid "Removes a selected nicks status from a channel"
+msgstr "Înlătură statutul unui pseudonim selectat într-un canal"
+
+msgid "Removes a selected nicks status modes on a channel. If nick is omitted then your status is removed. If channel is omitted then your channel status is removed on every channel you are in."
+msgstr "Înlătură modurile de statut ale pseudonimului selectat într-un canal. Dacă pseudonimul nu este specificat, atunci statutul dumneavoastră este înlăturat. Dacă canalul nu este specificat, atunci statutul duneavoastră de canal este înlăturat din fiecare canal în care vă aflați."
+
+#, c-format
+msgid "Removing %s because %s covers it."
+msgstr "Se înlătură %s deoarece %s îl acoperă."
+
+msgid "Repeat kicker"
+msgstr "Izgonire la repetări"
+
+msgid "Request a vhost for your nick"
+msgstr "Solicită o gazdă virtuală pentru pseudonimul dumneavoastră"
+
+msgid "Request the given vhost to be activated for your nick by the network administrators. Please be patient while your request is being considered."
+msgstr "Solicită ca administratorii de rețea să activeze gazda virtuală precizată, pentru pseudonimul dumneavoastră. Vă rugăm să aveți răbdare în timp ce solicitarea dumneavoastră este analizată."
+
+msgid "Resend registration confirmation email"
+msgstr "Retrimite mesajul email de confirmare a înregistrării"
+
+msgid "Restrict access to the channel"
+msgstr "Restricționează accesul în canal"
+
+msgid "Restricted access"
+msgstr "Acces restricționat"
+
+#, c-format
+msgid "Restricted access option for %s is now off."
+msgstr "Opțiunea de acces restricționat pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Restricted access option for %s is now on."
+msgstr "Opțiunea de acces restricționat pentru %s este acum activată."
+
+#, c-format
+msgid "Restricted enforced on %s."
+msgstr "Restricționare impusă în %s."
+
+msgid "Retain modes when channel is not in use"
+msgstr "Păstrează modurile atunci când canalul nu este utilizat"
+
+msgid "Retain topic when channel is not in use"
+msgstr "Păstrează subiectul atunci când canalul nu este utilizat"
+
+msgid "Retrieves the vhost requests"
+msgstr "Preia solicitările de gazdă virtuală"
+
+msgid "Returns the key of the given channel"
+msgstr "Returnează cheia canalului precizat"
+
+msgid "Returns the key of the given channel."
+msgstr "Returnează cheia canalului precizat."
+
+msgid "Returns the matching accounts that used given email."
+msgstr "Returnează conturile corespunzătoare care au folosit adresa de email precizată."
+
+msgid "Reverses kicker"
+msgstr "Izgonire la inversări"
+
+msgid "Reverses the effect of the IDENTIFY command, i.e. make you not recognized as the real owner of the nick anymore. Note, however, that you won't be asked to reidentify yourself."
+msgstr "Inversează efectul comenzii IDENTIFY, adică vă face să nu mai fiți recunoscut(ă) ca proprietarul real al pseudonimului. Rețineți, totuși, că nu vi se va cere să vă reidentificați."
+
+msgid "Reverses the effect of the IDENTIFY command"
+msgstr "Inversează efectul comenzii IDENTIFY"
+
+msgid "SET server"
+msgstr "SET server"
+
+msgid "SET server.name option value"
+msgstr "SET nume.server opțiune valoare"
+
+#, c-format
+msgid "SSL certificate fingerprint accepted, you are now identified to %s."
+msgstr "Amprenta digitală a certificatului SSL a fost acceptată, acum sunteți identificat(ă) la %s."
+
+msgid "SSL certificate fingerprint accepted, you are now identified."
+msgstr "Amprenta digitală a certificatului SSL a fost acceptată, acum sunteți identificat(ă)."
+
+#, c-format
+msgid "SSL only enforced on %s."
+msgstr "Este impusă restricția de conectare doar prin SSL în %s."
+
+msgid "SSLONLY enforced by "
+msgstr "Restricția de conectare doar prin SSL este impusă de "
+
+msgid "Save databases and restart services"
+msgstr "Salvează bazele de date și reporniți serviciile"
+
+msgid "Searches logs for a matching pattern"
+msgstr "Caută în jurnale un model corespunzător"
+
+msgid "Secure founder"
+msgstr "Fondator securizat"
+
+#, c-format
+msgid "Secure founder option for %s is now off."
+msgstr "Opțiunea de fondator securizat pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Secure founder option for %s is now on."
+msgstr "Opțiunea de fondator securizat pentru %s este acum activată."
+
+msgid "Secure ops"
+msgstr "Operator securizat"
+
+#, c-format
+msgid "Secure ops option for %s is now off."
+msgstr "Opțiunea de operator securizat pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Secure ops option for %s is now on."
+msgstr "Opțiunea de operator securizat pentru %s este acum activată."
+
+#, c-format
+msgid "Secureops enforced on %s."
+msgstr "Opțiunea de operator securizat este impusă în %s."
+
+#, c-format
+msgid "See %s for more information about the access list."
+msgstr "Vedeți %s pentru mai multe informații despre lista de accese."
+
+#, c-format
+msgid "See %s for more information about the flags system."
+msgstr "Vedeți %s pentru mai multe informații despre sistemul de stegulețe."
+
+#, c-format
+msgid "See the %s command (%sACCESS) for information on giving a subset of these privileges to other channel users."
+msgstr "Consultați comanda %s (%sACCESS) pentru informații despre acordarea unui subset al acestor privilegii altor utilizatori ai canalului."
+
+msgid "Send a memo to a nick or channel"
+msgstr "Expediază o misivă către un pseudonim sau canal"
+
+msgid "Send a memo to all opers/admins"
+msgstr "Expediază o misivă tuturor Operatorilor sau Administratorilor de Rețea"
+
+msgid "Send a memo to all registered users"
+msgstr "Expediază o misivă tuturor utilizatorilor înregistrați"
+
+msgid "Send a message to all users"
+msgstr "Expediază un mesaj tuturor utilizatorilor"
+
+msgid "Send a message to all users on a server"
+msgstr "Expediază un mesaj tuturor utilizatorilor dintr-un server"
+
+msgid "Sender"
+msgstr "Expeditor"
+
+msgid "Sends a confirmation code to the nickname's email address with instructions on how to reset their password. email must be the email address associated with the account."
+msgstr "Trimite un cod de confirmare la adresa de email a pseudonimului cu instrucțiuni despre cum să reseteze parola. Adresa de email trebuie să fie adresa de email atribuită contului."
+
+msgid "Sends a memo and requests a read receipt"
+msgstr "Expediază o misivă și solicită o confirmare de citire"
+
+msgid "Sends all registered users a memo containing memo-text."
+msgstr "Expediază tuturor utilizatorilor înregistrați o misivă care conține un mesaj-text."
+
+msgid "Sends all services staff a memo containing memo-text."
+msgstr "Expediază întregului personal de Servicii o misivă care conține un mesaj-text."
+
+msgid "Sends the named nick or channel a memo containing memo-text. When sending to a nickname, the recipient will receive a notice that they have a new memo. The target nickname/channel must be registered."
+msgstr "Expediază pseudonimului sau canalului specificat o misivă care conține un mesaj-text. Când expediați mesaj către un pseudonim, destinatarul va primi o notificare că are un nou mesaj. Pseudonimul ori canalul destinație trebuie să fie înregistrate."
+
+msgid "Sends the named nick or channel a memo containing memo-text. When sending to a nickname, the recipient will receive a notice that they have a new memo. The target nickname/channel must be registered. Once the memo is read by its recipient, an automatic notification memo will be sent to the sender informing them that the memo has been read."
+msgstr "Expediază pseudonimului sau canalului specificat o misivă care conține un mesaj-text. Când expediați un mesaj către un pseudonim, destinatarul va primi o notificare că are un nou mesaj. Pseudonimul ori canalul destinație trebuie să fie înregistrate. După ce misiva este citită de destinatar, o misivă de notificare automată va fi trimisă expeditorului, ca o informare că mesajul a fost citit."
+
+msgid ""
+"Sends you the text of the memos specified. If LAST is given, sends you the memo you most recently received. If NEW is given, sends you all of your new memos. If ALL is given, sends you all of your memos. Otherwise, sends you memo number num. You can also give a list of numbers, as in this example:\n"
+"\n"
+"   READ 2-5,7-9\n"
+"      Displays memos numbered 2 through 5 and 7 through 9."
+msgstr ""
+"Vă afișează textul misivelor specificate. Dacă se introduce LAST, vă afișează cea mai recentă misivă primită. Dacă este specificat NEW, vă afișează toate noile misive. Dacă se dă ALL, vă afișează toate notițele dumneavoastră. Altfel, vă afișează numărul misivei număr. De asemenea, puteți oferi o listă de numere, ca în exemplul următor:\n"
+"\n"
+"   READ 2-5,7-9\n"
+"      Afișează misivele numerotate de la 2 la 5 și de la 7 la 9."
+
+msgid "Server"
+msgstr "Server"
+
+#, c-format
+msgid "Server %s is not linked to the network."
+msgstr "Serverul %s nu este legat la rețea."
+
+#, c-format
+msgid "Server %s added to zone %s."
+msgstr "Serverul %s a fost adăugat la zona %s."
+
+#, c-format
+msgid "Server %s already exists."
+msgstr "Serverul %s există deja."
+
+#, c-format
+msgid "Server %s does not exist."
+msgstr "Serverul %s nu există."
+
+#, c-format
+msgid "Server %s has no configured IPs."
+msgstr "Serverul %s nu are adrese IP configurate."
+
+#, c-format
+msgid "Server %s is already in zone %s."
+msgstr "Serverul %s se află deja în zona %s."
+
+#, c-format
+msgid "Server %s is already pooled."
+msgstr "Serverul %s este colectivizat deja."
+
+#, c-format
+msgid "Server %s is not currently linked."
+msgstr "Serverul %s nu este legat momentan."
+
+#, c-format
+msgid "Server %s is not in zone %s."
+msgstr "Serverul %s nu se află în zona %s."
+
+#, c-format
+msgid "Server %s is not linked to the network."
+msgstr "Serverul %s nu este legat la rețea."
+
+#, c-format
+msgid "Server %s is not pooled."
+msgstr "Serverul %s nu este colectivizat."
+
+#, c-format
+msgid "Server %s must be quit before it can be deleted."
+msgstr "Serverul %s trebuie îndepărtat înainte de a putea fi șters."
+
+msgid "Server: {server} = {ip} -- limit: {limit}; state: {state}"
+msgstr "Server: {server} = {ip} -- limită: {limit}; statut: {state}"
+
+msgid "Servers"
+msgstr "Servere"
+
+#, c-format
+msgid "Servers found: %zu"
+msgstr "Servere găsite: %zu"
+
+msgid "Service"
+msgstr "Serviciu"
+
+msgid "Services Operator commands"
+msgstr "Comenzile Operatorilor de Servicii"
+
+msgid "Services Operators can also drop any nickname without needing to identify for the nick, and may view the access list for any nickname."
+msgstr "Operatorii de Servicii pot, de asemenea, să radieze orice pseudonim fără a fi nevoie să se identifice pentru pseudonim și pot vizualiza lista de accese pentru orice pseudonim."
+
+msgid "Services Operators can also, depending on their access drop any channel, view (and modify) the access, levels and akick lists and settings for any channel."
+msgstr "Operatorii de Servicii pot, de asemenea, în funcție de accesul lor, să radieze orice canal, să vizualizeze (și să modifice) accesul, nivelurile, listele de accese și setările pentru orice canal."
+
+msgid "Services are in DefCon mode, please try again later."
+msgstr "Serviciile sunt în modul DEFCON, vă rugăm să încercați mai târziu."
+
+#, c-format
+msgid "Services are now at DEFCON %d."
+msgstr "Serviciile sunt acum la DEFCON %d."
+
+#, c-format
+msgid "Services are now in debug mode (level %u)."
+msgstr "Serviciile sunt acum în modul depanare (nivelul %u)."
+
+msgid "Services are now in debug mode."
+msgstr "Serviciile sunt acum în modul depanare."
+
+msgid "Services are now in expire mode."
+msgstr "Serviciile sunt acum în modul expirare."
+
+msgid "Services are now in no expire mode."
+msgstr "Serviciile sunt acum în modul fără expirare."
+
+msgid "Services are now in non-debug mode."
+msgstr "Serviciile sunt acum în modul fără depanare."
+
+msgid "Services are now in read-only mode."
+msgstr "Serviciile sunt acum în modul numai citire."
+
+msgid "Services are now in read-write mode."
+msgstr "Serviciile sunt acum în modul citire și scriere."
+
+msgid "Services are temporarily in read-only mode."
+msgstr "Serviciile sunt temporar în modul numai citire."
+
+msgid "Services have been configured to not send mail."
+msgstr "Serviciile au fost configurate să nu trimită mesaje email."
+
+msgid "Services ignore list:"
+msgstr "Lista de ignorare a serviciilor este după cum urmează:"
+
+msgid "Services is unable to change modes. Are your servers' U:lines configured correctly?"
+msgstr "Serviciile nu pot schimba modurile. Sunt configurate corect liniile U:line ale serverelor dumneavoastră?"
+
+#, c-format
+msgid "Services up %s."
+msgstr "Servicii active %s."
+
+#, c-format
+msgid "Services will from now on set status modes on %s in channels."
+msgstr "Serviciile vor seta de acum înainte moduri de statut pentru %s în canale."
+
+#, c-format
+msgid "Services will no longer automatically give modes to users in %s."
+msgstr "Serviciile nu vor mai oferi automat moduri utilizatorilor în %s."
+
+#, c-format
+msgid "Services will no longer set status modes on %s in channels."
+msgstr "Serviciile nu vor mai seta moduri de statut pentru %s în canale."
+
+#, c-format
+msgid "Services will now automatically give modes to users in %s."
+msgstr "Serviciile vor oferi de acum automat moduri utilizatorilor în %s."
+
+#, c-format
+msgid "Services will now reply to %s with messages."
+msgstr "Serviciile vor răspunde de acum pentru %s cu mesaje."
+
+#, c-format
+msgid "Services will now reply to %s with notices."
+msgstr "Serviciile vor răspunde de acum pentru %s cu notificări."
+
+msgid "Services' configuration has been reloaded."
+msgstr "Configurația serviciilor a fost reîncărcată."
+
+#, c-format
+msgid "Services' hold on %s has been released."
+msgstr "Ținerea serviciilor pentru %s a fost eliberată."
+
+msgid "Session"
+msgstr "Sesiune"
+
+#, c-format
+msgid "Session limit for %s set to %d."
+msgstr "Limita de sesiuni pentru %s a fost setată la %d."
+
+msgid "Session limiting is disabled."
+msgstr "Limitarea de sesiuni este dezactivată."
+
+#, c-format
+msgid "Sessions: %zu entries, %zu buckets, longest chain is %zu"
+msgstr "Sesiuni: %zu intrări, %zu compartimente, cel mai lung lanț este %zu"
+
+msgid "Set SET-options on another nickname"
+msgstr "Setează opțiunile SET pentru un alt pseudonim"
+
+msgid "Set channel options and information"
+msgstr "Setează opțiunile și informațiile canalului"
+
+msgid "Set how services make bans on the channel"
+msgstr "Setează modul în care serviciile fac blocări în canal"
+
+msgid "Set nickname options and information"
+msgstr "Setează opțiunile și informațiile pseudonimului"
+
+msgid "Set options related to memos"
+msgstr "Setează opțiunile legate de misive"
+
+msgid "Set read-only or read-write mode"
+msgstr "Selectează modul numai-citire sau modul citire-scriere"
+
+msgid "Set the channel as permanent"
+msgstr "Setează canalul ca persistent"
+
+msgid "Set the channel description"
+msgstr "Setează descrierea canalului"
+
+msgid "Set the display nickname for your account"
+msgstr "Setează pseudonimul de afișare pentru contul dumneavoastră"
+
+msgid "Set the founder of a channel"
+msgstr "Setează fondatorul canalului"
+
+msgid "Set the language services will use when messaging you"
+msgstr "Setează limba pe care serviciile o vor folosi când vă vor trimite mesaje"
+
+msgid "Set the nickname password"
+msgstr "Setează parola pseudonimului"
+
+msgid "Set the successor for a channel"
+msgstr "Setează succesorul unui canal"
+
+msgid "Set the timezone services will use when messaging you"
+msgstr "Setează fusul orar pe care îl vor folosi serviciile când vă vor trimite mesaje"
+
+msgid "Set the vhost for all nicks in an account"
+msgstr "Setează gazda virtuală pentru toate pseudonimele dintr-un cont"
+
+msgid "Set the vhost of another user"
+msgstr "Setează gazda virtuală a unui alt utilizator"
+
+msgid "Set various global services options"
+msgstr "Setează diverse opțiuni de servicii globale"
+
+msgid "Set your nickname password"
+msgstr "Setează parola pseudonimului dumneavoastră"
+
+#, c-format
+msgid ""
+"Sets the AMSG kicker on or off. When enabled, the bot will kick users who send the same message to multiple channels where %s bots are.\n"
+"\n"
+"ttb is the number of times a user can be kicked before they get banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la AMSG. Când este activată, botul va izgoni utilizatorii care trimit același mesaj către mai multe canale unde se află %s boți.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+#, c-format
+msgid ""
+"Sets the bad words kicker on or off. When enabled, this option tells the bot to kick users who say certain words on the channels.\n"
+"\n"
+"You can define bad words for your channel using the BADWORDS command. Type %sBADWORDS for more information.\n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la cuvinte nepotrivite. Când este activată, această opțiune informează botul să izgonească utilizatorii care rostesc anumite cuvinte în canale.\n"
+"\n"
+"Puteți defini cuvinte nepotrivite pentru canalul dumneavoastră folosind comanda BADWORDS. Tastați %sBADWORDS pentru mai multe informații.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid ""
+"Sets the ban type that will be used by services whenever they need to ban someone from your channel.\n"
+"\n"
+"Bantype is a number between 0 and 3 that means:\n"
+"\n"
+"0: ban in the form *!user@host\n"
+"1: ban in the form *!*user@host\n"
+"2: ban in the form *!*@host\n"
+"3: ban in the form *!*user@*.domain"
+msgstr ""
+"Setează tipul de blocare care va fi utilizat de servicii ori de câte ori trebuie să blocheze pe cineva în canalul dumneavoastră.\n"
+"\n"
+"Tipul de blocare este un număr între 0 și 3 care înseamnă:\n"
+"\n"
+"0: blocare de tip *!utilizator@gazdă\n"
+"1: blocare de tip *!*utilizator@gazdă\n"
+"2: blocare de tip *!*@gazdă\n"
+"3: blocare de tip *!*utilizator@*.domeniu"
+
+msgid ""
+"Sets the bolds kicker on or off. When enabled, this option tells the bot to kick users who use bolds.\n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la îngroșări. Când este activată, această opțiune informează botul să izgonească utilizatorii care folosesc caractere îngroșate.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+#, c-format
+msgid ""
+"Sets the caps kicker on or off. When enabled, this option tells the bot to kick users who are talking in CAPS.\n"
+"\n"
+"The bot kicks only if there are at least min caps and they constitute at least percent%% of the total text line (if not given, it defaults to 10 characters and 25%%).\n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la majuscule. Când este activată, această opțiune informează botul să izgonească utilizatorii care folosesc caractere majuscule.\n"
+"\n"
+"Botul izgonește doar dacă există un cel puțin un minim de caractere majuscule iar acestea constituie cel puțin un procentaj%% din totalul liniei de text (dacă nu sunt specificate, valorile implicite sunt de 10 caractere și 25%%).\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid ""
+"Sets the colors kicker on or off. When enabled, this option tells the bot to kick users who use colors.\n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la culori. Când este activată, această opțiune informează botul să izgonească utilizatorii care folosesc culori.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid "Sets the description for the channel, which shows up with the LIST and INFO commands."
+msgstr "Setează descrierea canalului, care va apărea prin comenzile LIST și INFO."
+
+msgid ""
+"Sets the flood kicker on or off. When enabled, this option tells the bot to kick users who are flooding the channel using at least ln lines in secs seconds (if not given, it defaults to 6 lines in 10 seconds). \n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la inundări. Când este activată, această opțiune informează botul să izgonească utilizatorii care inundă în canal folosind un minim de linii în secunde (dacă nu sunt specificate, valorile implicite sunt 6 linii în 10 secunde).\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid ""
+"Sets the italics kicker on or off. When enabled, this option tells the bot to kick users who use italics. \n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la înclinări. Când este activată, această opțiune informează botul să izgonească utilizatorii care folosesc caractere înclinate.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid "Sets the maximum number of memos you can receive"
+msgstr "Setează numărul maxim de misive pe care le puteți primi"
+
+msgid ""
+"Sets the repeat kicker on or off. When enabled, this option tells the bot to kick users who are repeating themselves num times (if num is not given, it defaults to 3).\n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la repetări. Când este activată, această opțiune informează botul să izgonească utilizatorii care se repetă de un număr de ori (dacă valoarea numerică nu este specificată, valoarea implicită este 3).\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid ""
+"Sets the reverses kicker on or off. When enabled, this option tells the bot to kick users who use reverses. \n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la inversări. Când este activată, această opțiune informează botul să izgonească utilizatorii care folosesc inversări.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid "Sets the time bot bans expire in. If enabled, any bans placed by bots, such as flood kicker, badwords kicker, etc. will automatically be removed after the given time. Set to 0 to disable bans from automatically expiring."
+msgstr "Setează timpul în care expiră blocările făcute de boți. Dacă este activată, orice blocare plasată de boți, cum ar fi izgonirea la inundări, izgonirea la cuvinte nepotrivite și așa mai departe, vor fi înlăturate automat după expirarea timpului precizat. Setați 0 pentru a dezactiva expirarea automată a blocărilor."
+
+msgid ""
+"Sets the underlines kicker on or off. When enabled, this option tells the bot to kick users who use underlines. \n"
+"\n"
+"ttb is the number of times a user can be kicked before it gets banned. Don't give ttb to disable the ban system once activated."
+msgstr ""
+"Activează sau dezactivează izgonirea la sublinieri. Când este activată, această opțiune informează botul să izgonească utilizatorii care folosesc sublinieri.\n"
+"\n"
+"ttb reprezintă de câte ori un utilizator poate fi izgonit înainte de a fi blocat. Nu utilizați ttb pentru a dezactiva blocările activate."
+
+msgid ""
+"Sets the vhost for all nicks in the same account as that of the given nick. If your IRCD supports vidents, then using SETALL <nick> <ident>@<hostmask> will set idents for users as well as vhosts.\n"
+"\n"
+"* NOTE, this will not update the vhost for any nicks added to the account after this command was used."
+msgstr ""
+"Setează gazda virtuală să fe pentru toate pseudonimele din același cont, la fel ca cea a pseudonimului precizat. Dacă serverul dumneavoastră de IRCd acceptă schimbarea identității virtuale, atunci utilizarea comenzii SETALL <pseudonim> <ident>@<hostmask> va schimba și identitatea, împreună cu gazda virtuală.\n"
+"\n"
+"* Rețineți totuși că această comandă nu va actualiza gazda virtuală pentru pseudonimele adăugate contului după utilizarea acestei comenzi."
+
+msgid "Sets the vhost for the given nick to that of the given hostmask. If your IRCD supports vidents, then using SET <nick> <ident>@<hostmask> set idents for users as well as vhosts."
+msgstr "Setează gazda virtuală pentru pseudonimul precizat, la masca de gazdă aleasă. Dacă serverul dumneavoastră de IRCd acceptă schimbarea identității virtuale, atunci utilizarea comenzii SET <pseudonim> <ident>@<hostmask> va schimba și identitatea, împreună cu gazda virtuală."
+
+msgid "Sets various global services options. Option names currently defined are:"
+msgstr "Setează diverse opțiuni globale pentru servicii. Numele opțiunilor definite în prezent sunt după cum urmează:"
+
+msgid "Sets various memo options.  option can be one of:"
+msgstr "Setează diverse opțiuni ale misivelor. opțiunea poate fi după cum urmează:"
+
+msgid "Sets various nickname options. option can be one of:"
+msgstr "Setează diverse opțiuni ale pseudonimului. opțiunea poate fi după cum urmează:"
+
+msgid "Sets whether services should set channel status modes on you automatically."
+msgstr "Setează dacă serviciile ar trebui să seteze automat modurile de statut în canal pentru dumneavoastră."
+
+msgid "Sets whether the given channel will expire. Setting this to ON prevents the channel from expiring."
+msgstr "Setează dacă canalul precizat va expira. Activarea acestei opțiuni previne expirarea canalului."
+
+msgid "Sets whether the given nickname can be added to a channel access list."
+msgstr "Setează dacă pseudonimul precizat poate fi adăugat la o listă de accese a vreunui canal."
+
+#, c-format
+msgid "Sets whether the given nickname will be given its status modes in channels automatically. Set to ON to allow %s to set status modes on the given nickname automatically when it is entering channels. Note that depending on channel settings some modes may not get set automatically."
+msgstr "Setează dacă pseudonimul precizat va primi automat modurile sale de statut în canale. Setați la ON pentru a permite %s să seteze automat modurile de statut pentru pseudonimul precizat atunci când acesta intră în canale. Rețineți că, în funcție de setările canalelor, este posibil ca unele moduri să nu fie setate automat."
+
+msgid "Sets whether the given nickname will expire. Setting this to ON prevents the nickname from expiring."
+msgstr "Setează dacă pseudonimul precizat va expira. Setarea acestei opțiuni la ON previne expirarea pseudonimului."
+
+msgid "Sets whether you can be added to a channel access list."
+msgstr "Setează dacă puteți fi adăugat(ă) la o listă de accese a vreunui canal."
+
+#, c-format
+msgid "Sets whether you will be given your channel status modes automatically. Set to ON to allow %s to set status modes on you automatically when entering channels. Note that depending on channel settings some modes may not get set automatically."
+msgstr "Setează dacă veți primi automat modurile de statut în canale. Setați la ON pentru a permite %s să vă seteze automat modurile de statut atunci când intrați în canale. Rețineți că, în funcție de setările canalelor, este posibil ca unele moduri să nu fie setate automat."
+
+#, c-format
+msgid "Setting %s not known. Type %sLEVELS for a list of valid settings."
+msgstr "Setarea %s nu este cunoscută. Tastați %sLEVELS pentru o listă de setări valide."
+
+msgid "Setting for DEBUG must be ON, OFF, or a positive number."
+msgstr "Setarea pentru DEBUG trebuie să fie ON, OFF sau un număr pozitiv."
+
+msgid "Setting for NOEXPIRE must be ON or OFF."
+msgstr "Setarea pentru NOEXPIRE trebuie să fie ON sau OFF."
+
+msgid "Setting for READONLY must be ON or OFF."
+msgstr "Setarea pentru READONLY trebuie să fie ON sau OFF."
+
+msgid "Setting for super admin must be ON or OFF."
+msgstr "Setarea pentru SUPERADMIN trebuie să fie ON sau OFF."
+
+msgid "Should services automatically give status to users"
+msgstr "Setează automatizarea statutului utilizatorilor"
+
+msgid "Show status of services and network"
+msgstr "Afișează statutul serviciilor și al rețelei"
+
+#, c-format
+msgid "Showed %zu/%zu matches for %s."
+msgstr "Au fost afișate %zu/%zu corespunderi pentru %s."
+
+msgid "Sign kicks that are done with the KICK command"
+msgstr "Semnează izgonirie executate prin comanda KICK"
+
+#, c-format
+msgid "Signed kick option for %s is now off."
+msgstr "Opțiunea de izgoniri semnate pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Signed kick option for %s is now on, but depends of the level of the user that is using the command."
+msgstr "Opțiunea de izgoniri semnate pentru %s este acum activată, dar depinde de nivelul utilizatorului care folosește comanda."
+
+#, c-format
+msgid "Signed kick option for %s is now on."
+msgstr "Opțiunea de izgoniri semnate pentru %s este acum activată."
+
+msgid "Signed kicks"
+msgstr "Izgoniri semnate"
+
+#, c-format
+msgid "Sorry, %s currently has too many memos and cannot receive more."
+msgstr "Ne pare rău, %s are în prezent prea multe misive și nu mai poate primi altele."
+
+#, c-format
+msgid "Sorry, %s is temporarily unavailable."
+msgstr "Ne pare rău, %s este temporar indisponibil."
+
+#, c-format
+msgid "Sorry, I have not seen %s."
+msgstr "Ne pare rău, nu am văzut pe %s."
+
+#, c-format
+msgid "Sorry, the maximum of %d auto join entries has been reached."
+msgstr "Ne pare rău, a fost atins numărul maxim de %d intrări pentru alăturări automate."
+
+#, c-format
+msgid "Sorry, the maximum of %d certificate entries has been reached."
+msgstr "Ne pare rău, a fost atins numărul maxim de %d intrări pentru certificate."
+
+#, c-format
+msgid "Sorry, the memo ignore list for %s is full."
+msgstr "Ne pare rău, lista de ignorare a misivelor pentru %s este plină."
+
+#, c-format
+msgid "Sorry, you can only have %d access entries on a channel, including access entries from other channels."
+msgstr "Ne pare rău, puteți avea doar %d intrări de accese într-un canal, inclusiv intrările de accese în alte canale."
+
+#, c-format
+msgid "Sorry, you can only have %d autokick masks on a channel."
+msgstr "Ne pare rău, puteți avea doar %d măști de izgoniri automate într-un canal."
+
+#, c-format
+msgid "Sorry, you can only have %d bad words entries on a channel."
+msgstr "Ne pare rău, puteți avea doar %d intrări de cuvinte nepotrivite într-un canal."
+
+#, c-format
+msgid "Sorry, you have already exceeded your limit of %d channels."
+msgstr "Ne pare rău, ați depășit deja limita de %d canale."
+
+#, c-format
+msgid "Sorry, you have already reached your limit of %d channels."
+msgstr "Ne pare rău, ați atins deja limita de %d canale."
+
+msgid "State"
+msgstr "Statut"
+
+msgid "Statistics and maintenance for seen data"
+msgstr "Statistici și întreținere pentru datele vizualizate"
+
+msgid "Statistics reset."
+msgstr "Statisticile au fost resetate."
+
+msgid "Status updated (memos, vhost, chmodes, flags)."
+msgstr "Statutul a fost actualizat (misive, gazde virtuale, moduri, stegulețe)."
+
+msgid "Stop flooding!"
+msgstr "Vă rugăm opriți inundarea!"
+
+msgid "Stop repeating yourself!"
+msgstr "Vă rugăm nu vă mai repetați!"
+
+msgid "Stricter control of channel founder status"
+msgstr "Securizează statutul fondatorului de canal"
+
+msgid "Stricter control of chanop status"
+msgstr "Securizează statutul operatorului de canal"
+
+msgid "Successor"
+msgstr "Succesor"
+
+#, c-format
+msgid "Successor for %s changed to %s."
+msgstr "Succesorul pentru %s a fost schimbat în %s."
+
+#, c-format
+msgid "Successor for %s unset."
+msgstr "Succesorul pentru %s a fost de-setat."
+
+msgid "Super admin can not be set because it is not enabled in the configuration."
+msgstr "Super-administratorul nu poate fi setat deoarece nu este activat în configurație."
+
+msgid "Suspend a given nick"
+msgstr "Suspendă un pseudonim precizat"
+
+msgid "Suspend reason"
+msgstr "Motivul suspendării"
+
+msgid "Suspended"
+msgstr "Suspendat(ă)"
+
+msgid "Suspended by"
+msgstr "Suspendat(ă) de"
+
+msgid "Suspended on"
+msgstr "Suspendat(ă) pe"
+
+msgid "Suspends a registered nickname, which prevents it from being used while keeping all the data for that nick. If an expiry is given the nick will be unsuspended after that period of time, else the default expiry from the configuration is used."
+msgstr "Suspendă un pseudonim înregistrat, ceea ce împiedică utilizarea acestuia, păstrând în același timp toate datele pentru pseudonimul respectiv. Dacă este precizată o perioadă de expirare, pseudonimul va fi reactivat după acea perioadă de timp, altfel se va utiliza data de expirare implicită din configurație."
+
+msgid "Suspension expires"
+msgstr "Suspendarea expiră"
+
+msgid "Sync users channel modes"
+msgstr "Sincronizează modurile de canal ale utilizatorilor"
+
+msgid "Syncs all modes set on users on the channel with the modes they should have based on their access."
+msgstr "Sincronizează toate modurile setate pentru utilizatorii din canal cu modurile pe care ar trebui să le aibă în funcție de accesul lor."
+
+msgid "Syncs the vhost for all nicks in an account"
+msgstr "Sincronizează gazda virtuală pentru toate pseudonimele dintr-un cont"
+
+msgid "Syntax"
+msgstr "Sintaxă"
+
+msgid ""
+"Syntax: DEBUG {ON | OFF}\n"
+"\n"
+"Sets debug mode on or off.\n"
+"\n"
+"This option is equivalent to the command-line option --debug."
+msgstr ""
+"Sintaxă: DEBUG {ON | OFF}\n"
+"\n"
+"Activează sau dezactivează modul de depanare.\n"
+"\n"
+"Această opțiune este echivalentă cu opțiunea din linia de comandă --debug."
+
+#, c-format
+msgid ""
+"Syntax: LIMIT [channel] limit\n"
+"\n"
+"Sets the maximum number of memos you (or the given channel) are allowed to have. If you set this to 0, no one will be able to send any memos to you. However, you cannot set this any higher than %d."
+msgstr ""
+"Sintaxă: LIMIT [canal] limită\n"
+"\n"
+"Setează numărul maxim de misive pe care dumneavoastră (sau canalul precizat) aveți voie să le aveți. Dacă setați această limită la 0, nimeni nu vă va putea expedia misive. Cu toate acestea, nu puteți seta mai mult de %d."
+
+#, c-format
+msgid ""
+"Syntax: LIMIT [user | channel] {limit | NONE} [HARD]\n"
+"\n"
+"Sets the maximum number of memos a user or channel is allowed to have. Setting the limit to 0 prevents the user from receiving any memos; setting it to NONE allows the user to receive and keep as many memos as they want. If you do not give a nickname or channel, your own limit is set.\n"
+"\n"
+"Adding HARD prevents the user from changing the limit. Not adding HARD has the opposite effect, allowing the user to change the limit (even if a previous limit was set with HARD).\n"
+"\n"
+"This use of the SETLIMIT command is limited to Services Operators. Other users may only enter a limit for themselves or a channel on which they have such privileges, may not remove their limit, may not set a limit above %d, and may not set a hard limit."
+msgstr ""
+"Sintaxă: LIMIT [utilizator | canal] {limită | NONE} [HARD]\n"
+"\n"
+"Setează numărul maxim de misive permise unui utilizator sau canal. Setarea limitei la 0 împiedică utilizatorul să primească misive; setarea acesteia la NONE permite utilizatorului să primească și să păstreze oricâte misive dorește. Dacă nu specificați un pseudonim sau un canal, se setează propria limită.\n"
+"\n"
+"Adăugarea funcției HARD împiedică utilizatorul să modifice limita. Neadăugarea funcției HARD are efectul opus, permițând utilizatorului să modifice limita (chiar dacă o limită anterioară a fost setată cu HARD).\n"
+"\n"
+"Această utilizare a comenzii SETLIMIT este limitată la Operatorii de Servicii. Alți utilizatori pot introduce o limită doar pentru ei înșiși sau pentru un canal în care au astfel de privilegii; nu își pot înlătura limita, nu pot seta o limită peste %d și nu pot seta o limită strictă."
+
+#, c-format
+msgid ""
+"Syntax: LIST\n"
+"\n"
+"Display the various %s settings."
+msgstr ""
+"Sintaxă: LIST\n"
+"\n"
+"Afișează diverse opțiuni despre %s."
+
+msgid ""
+"Syntax: NOEXPIRE {ON | OFF}\n"
+"\n"
+"Sets no expire mode on or off. In no expire mode, nicks, channels, akills and exceptions won't expire until the option is unset.\n"
+"\n"
+"This option is equivalent to the command-line option --noexpire."
+msgstr ""
+"Sintaxă: NOEXPIRE {ON | OFF}\n"
+"\n"
+"Activează sau dezactivează modul fără expirare. În modul fără expirare, pseudonimele, canalele, abilitățile și excepțiile nu expiră până când opțiunea nu este de-setată.\n"
+"\n"
+"Această opțiune este echivalentă cu opțiunea din linia de comandă --noexpire."
+
+msgid ""
+"Syntax: NOTIFY {ON | LOGON | NEW | MAIL | NOMAIL | OFF}\n"
+"\n"
+"Changes when you will be notified about new memos:"
+msgstr ""
+"Sintaxă: NOTIFY {ON | LOGON | NEW | MAIL | NOMAIL | OFF}\n"
+"\n"
+"Schimbă momentul în care veți fi notificat(ă) despre noile misive după cum urmează:"
+
+msgid ""
+"Syntax: READONLY {ON | OFF}\n"
+"\n"
+"Sets read-only mode on or off. In read-only mode, normal users will not be allowed to modify any services data, including channel access lists, etc. Server operators with sufficient services privileges will be able to modify Services' AKILL, SQLINE, SNLINE and ignore lists, drop, suspend or forbid nicknames and channels, and manage news, oper info and DNS, but any such changes will not be saved unless read-only mode is deactivated before services are terminated or restarted.\n"
+"\n"
+"This option is equivalent to the command-line option --readonly."
+msgstr ""
+"Sintaxă: READONLY {ON | OFF}\n"
+"\n"
+"Activează sau dezactivează modul numai citire. În modul numai citire, utilizatorii obișnuiți nu vor avea voie să modifice datele serviciilor, inclusiv listele de accese în canale. Operatorii de server cu suficiente privilegii de servicii vor putea modifica listele AKILL, SQLINE, SNLINE și listele de ignorare ale serviciilor, vor putea radia, suspenda ori interzice pseudonime și canale, vor putea gestiona știri, informații despre operatori și DNS, dar astfel de modificări nu vor fi salvate decât dacă modul numai citire este dezactivat înainte ca serviciile să fie oprite ori repornite.\n"
+"\n"
+"Această opțiune este echivalentă cu opțiunea din linia de comandă --readonly."
+
+msgid ""
+"Syntax: SUPERADMIN {ON | OFF}\n"
+"\n"
+"Setting this will grant you extra privileges such as the ability to be \"founder\" on all channels, etc...\n"
+"\n"
+"This option is not persistent, and should only be used when needed, and set back to OFF when no longer needed."
+msgstr ""
+"Sintaxă: SUPERADMIN {ON | OFF}\n"
+"\n"
+"Setarea acestei opțiuni vă va oferi privilegii suplimentare, cum ar fi posibilitatea de a fi \"fondator\" în toate canalele.\n"
+"\n"
+"Această opțiune nu este persistentă și ar trebui utilizată doar atunci când este nevoie, apoi setată din nou pe OFF când nu mai este necesară."
+
+#, c-format
+msgid "Tells %s that you are really the owner of this nick. Many commands require you to authenticate yourself with this command before you use them. The password should be the same one you sent with the REGISTER command."
+msgstr "Informează %s că sunteți proprietarul real al acestui pseudonim. Multe comenzi necesită identificare cu această comandă înainte de a fi utilizate. Parola este cea pe care ați furnizat-o odată cu comanda REGISTER."
+
+#, c-format
+msgid ""
+"Tells %s to invite you or an optionally specified nick into the given channel.\n"
+"\n"
+"By default, limited to AOPs or those with level 5 access and above on the channel."
+msgstr ""
+"Solicită de la %s să vă invite pe dumneavoastră sau pe un pseudonim specificat în canalul precizat.\n"
+"\n"
+"Implicit, se limitează la AOP sau la cei cu acces de nivel 5 ori superior în canal."
+
+#, c-format
+msgid ""
+"Tells %s to remove all bans preventing you or the given user from entering the given channel. If no channel is given, all bans affecting you in channels you have access in are removed.\n"
+"\n"
+"By default, limited to AOPs or those with level 5 access and above on the channel."
+msgstr ""
+"Solicită de la %s să înlăture toate blocările ce vă impiedică pe dumneavoastră sau pe utilizatorul precizat să accesați canalul specificat. Dacă nu este specificat un canal, sunt înlăturate toate blocările care vă afectează în canalele la care aveți acces.\n"
+"\n"
+"Implicit, se limitează la AOP sau la cei cu acces de nivel 5 ori superior în canal."
+
+msgid "Tells services to jupiter a server -- that is, to create a fake \"server\" connected to services which prevents the real server of that name from connecting. The jupe may be removed using a standard SQUIT. If a reason is given, it is placed in the server information field; otherwise, the server information field will contain the text \"Juped by <nick>\", showing the nickname of the person who jupitered the server."
+msgstr "Solicită de la servicii să facă \"jupiter\" unui server - adică să creeze un server fals conectat la servicii, ceea ce împiedică serverul real cu acel nume să se conecteze. Acțiunea \"jupe\" poate fi înlăturată utilizând comanda standard SQUIT. Dacă este precizat un motiv, acesta este plasat în câmpul de informații al serverului; altfel va conține textul \"Juped by <pseudonim>\", afișând pseudonimul persoanei care a făcut \"jupiter\" serverului."
+
+msgid "Tells you about the last time a user was seen"
+msgstr "Vă informează despre ultima dată când a fost văzut un utilizator"
+
+msgid "Terminate services WITHOUT saving"
+msgstr "Oprește serviciile FĂRĂ salvare"
+
+msgid "Terminate services with save"
+msgstr "Oprește serviciile cu salvare"
+
+msgid "Text"
+msgstr "Text"
+
+#, c-format
+msgid ""
+"The %s command allows fine control over the meaning of the numeric access levels used for channels. With this command, you can define the access level required for most of %s's functions. (The SETFOUNDER and this command are always restricted to the channel founder).\n"
+"\n"
+"%sSET allows the access level for a function or group of functions to be changed. %sDISABLE (or DIS for short) disables an automatic feature or disallows access to a function by anyone, INCLUDING the founder (although, the founder can always re-enable it). Use %sSET founder to make a level founder only.\n"
+"\n"
+"%sLIST shows the current levels for each function or group of functions. %sRESET resets the levels to the default levels of a newly-created channel.\n"
+"\n"
+"For a list of the features and functions whose levels can be set, see HELP%sDESC."
+msgstr ""
+"Comanda %s permite un control fin asupra semnificației nivelurilor numerice de acces utilizate pentru canale. Cu această comandă, puteți defini nivelul de acces necesar pentru majoritatea funcțiilor lui %s. (Comanda SETFOUNDER și această comandă sunt întotdeauna restricționate la fondatorul canalului).\n"
+"\n"
+"%sSET permite modificarea nivelului de acces pentru o funcție sau un grup de funcții. %sDISABLE (sau pe scurt DIS) dezactivează o funcție automată sau interzice accesul la o funcție oricui, INCLUSIV fondatorului (deși fondatorul o poate reactiva oricând). Folosiți %sSET founder doar pentru a crea un nivel de fondator.\n"
+"\n"
+"%sLIST afișează nivelurile curente pentru fiecare funcție sau grup de funcții. %sRESET resetează nivelurile la nivelurile implicite ale unui canal nou creat.\n"
+"\n"
+"Pentru o listă a caracteristicilor și funcțiilor ale căror niveluri pot fi setate, consultați HELP%sDESC."
+
+#, c-format
+msgid ""
+"The %sADD command adds the given nickname to the %s list.\n"
+"\n"
+"The %sDEL command removes the given nick from the %s list. If a list of entry numbers is given, those entries are deleted. (See the example for LIST below.)\n"
+"\n"
+"The %sLIST command displays the %s list. If a wildcard mask is given, only those entries matching the mask are displayed. If a list of entry numbers is given, only those entries are shown; for example:\n"
+"   %s#channelLIST2-5,7-9\n"
+"      Lists %s entries numbered 2 through 5 and\n"
+"      7 through 9.\n"
+"\n"
+"The %sCLEAR command clears all entries of the %s list."
+msgstr ""
+"Comanda %sADD adaugă pseudonimul precizat la lista %s.\n"
+"\n"
+"Comanda %sDEL înlătură pseudonimul precizat din lista %s. Dacă este specificată o listă cu numere de intrare, acele intrări sunt înlăturate. (Vedeți exemplul pentru LIST de mai jos.)\n"
+"\n"
+"Comanda %sLIST afișează lista %s. Dacă este precizată o mască wildcard, sunt afișate doar intrările care corespund măștii. Dacă este specificată o listă de numere de intrare, sunt afișate doar acele intrări; de exemplu:\n"
+"   %s#canalLIST2-5,7-9\n"
+"      Listează intrările %s numerotate de la 2 la 5 și de la 7 la 9.\n"
+"\n"
+"Comanda %sCLEAR golește toate intrările din lista %s."
+
+#, c-format
+msgid ""
+"The %sDEL command removes the given mask from the AKILL list if it is present. If a list of entry numbers is given, those entries are deleted.  (See the example for LIST below.)\n"
+"\n"
+"The %sLIST command displays the AKILL list. If a wildcard mask is given, only those entries matching the mask are displayed. If a list of entry numbers is given, only those entries are shown; for example:\n"
+"   %sLIST2-5,7-9\n"
+"      Lists AKILL entries numbered 2 through 5 and 7\n"
+"      through 9.\n"
+"\n"
+"%sVIEW is a more verbose version of %sLIST, and will show who added an AKILL, the date it was added, and when it expires, as well as the user@host/ip mask and reason.\n"
+"\n"
+"%sCLEAR clears all entries of the AKILL list."
+msgstr ""
+"Comanda %sDEL înlătură masca precizată din lista AKILL dacă este prezentă. Dacă este specificată o listă de numere de intrare, acele intrări sunt înlăturate. (Vedeți exemplul pentru LIST de mai jos.)\n"
+"\n"
+"Comanda %sLIST afișează lista AKILL. Dacă este precizată o mască wildcard, sunt afișate doar intrările care corespund măștii. Dacă este specificată o listă de numere de intrare, sunt afișate doar acele intrări; de exemplu:\n"
+"   %sLIST2-5,7-9\n"
+"      Listează intrările AKILL numerotate de la 2 la 5 și de la 7 la 9.\n"
+"\n"
+"%sVIEW este o versiune mai detaliată a %sLIST și va afișa cine a adăugat un AKILL, data la care a fost adăugat și când expiră, precum și masca utilizator@gazdă/ip și motivul.\n"
+"\n"
+"%sCLEAR golește toate intrările din lista AKILL."
+
+#, c-format
+msgid ""
+"The %sDEL command removes the given nick from the access list. If a list of entry numbers is given, those entries are deleted.  (See the example for LIST below.) You may remove yourself from an access list, even if you do not have access to modify that list otherwise.\n"
+"\n"
+"The %sLIST command displays the access list. If a wildcard mask is given, only those entries matching the mask are displayed. If a list of entry numbers is given, only those entries are shown; for example:\n"
+"   %s#channelLIST2-5,7-9\n"
+"      Lists access entries numbered 2 through 5 and\n"
+"      7 through 9.\n"
+"\n"
+"The %sVIEW command displays the access list similar to %sLIST but shows the creator and last used time.\n"
+"\n"
+"The %sCLEAR command clears all entries of the access list."
+msgstr ""
+"Comanda %sDEL înlătură pseudonimul precizat din lista de accese. Dacă este furnizată o listă de numere de intrare, acele intrări sunt înlăturate. (Vedeți exemplul pentru LIST de mai jos.) Vă puteți înlătura dintr-o listă de acces, chiar dacă nu aveți acces pentru a modifica lista respectivă în alt mod.\n"
+"\n"
+"Comanda %sLIST afișează lista de accese. Dacă este precizată o mască wildcard, sunt afișate doar intrările care corespund măștii. Dacă este specificată o listă de numere de intrare, sunt afișate doar acele intrări; de exemplu:\n"
+"   %s#canalLIST2-5,7-9\n"
+"      Listează intrările de accese numerotate de la 2 la 5 și de la 7 la 9.\n"
+"\n"
+"Comanda %sVIEW afișează lista de accese similară cu comanda %sLIST, dar arată în plus creatorul și timpul ultimei utilizări.\n"
+"\n"
+"%sCLEAR golește toate intrările din lista de accese."
+
+msgid ""
+"The SNLINEDEL command removes the given mask from the SNLINE list if it is present. If a list of entry numbers is given, those entries are deleted.  (See the example for LIST below.)\n"
+"\n"
+"The SNLINELIST command displays the SNLINE list. If a wildcard mask is given, only those entries matching the mask are displayed. If a list of entry numbers is given, only those entries are shown; for example:\n"
+"   SNLINELIST2-5,7-9\n"
+"      Lists SNLINE entries numbered 2 through 5 and 7\n"
+"      through 9.\n"
+"\n"
+"SNLINEVIEW is a more verbose version of SNLINELIST, and will show who added an SNLINE, the date it was added, and when it expires, as well as the realname mask and reason.\n"
+"\n"
+"SNLINECLEAR clears all entries of the SNLINE list."
+msgstr ""
+"Comanda SNLINEDEL înlătură masca precizată din lista SNLINE dacă aceasta este prezentă. Dacă este furnizată o listă de numere de intrare, acele intrări sunt înlăturate. (Vedeți exemplul pentru LIST de mai jos.)\n"
+"\n"
+"Comanda SNLINELIST LIST afișează lista SNLINE. Dacă este precizată o mască wildcard, vor fi afișate doar intrările care corespund măștii. Dacă este furnizată o listă de numere de intrare, sunt afișate doar acele intrări; de exemplu:\n"
+"   SNLINELIST2-5,7-9\n"
+"      Listează intrările SNLINE numerotate de la 2 la 5 și de la 7 la 9.\n"
+"\n"
+"SNLINEVIEW este o versiune mai detaliată a SNLINELIST și va afișa cine a adăugat un SNLINE, data la care a fost adăugat și când expiră, precum și masca numelui real și motivul.\n"
+"\n"
+"SNLINECLEAR golește toate intrările din lista SNLINE."
+
+msgid ""
+"The SQLINEDEL command removes the given mask from the SQLINE list if it is present. If a list of entry numbers is given, those entries are deleted. (See the example for LIST below.)\n"
+"\n"
+"The SQLINELIST command displays the SQLINE list. If a wildcard mask is given, only those entries matching the mask are displayed. If a list of entry numbers is given, only those entries are shown; for example:\n"
+"   SQLINELIST2-5,7-9\n"
+"      Lists SQLINE entries numbered 2 through 5 and 7\n"
+"      through 9.\n"
+"\n"
+"SQLINEVIEW is a more verbose version of SQLINELIST, and will show who added an SQLINE, the date it was added, and when it expires, as well as the mask and reason.\n"
+"\n"
+"SQLINECLEAR clears all entries of the SQLINE list."
+msgstr ""
+"Comanda SQLINEDEL înlătură masca precizată din lista SQLINE dacă aceasta este prezentă. Dacă este furnizată o listă de numere de intrare, acele intrări sunt înlăturate. (Vedeți exemplul pentru LIST de mai jos.)\n"
+"\n"
+"Comanda SQLINELIST afișează lista SQLINE. Dacă este precizată o mască wildcard, sunt afișate doar intrările care corespund măștii. Dacă este specificată o listă de numere de intrare, sunt afișate doar acele intrări; de exemplu:\n"
+"   SQLINELIST2-5,7-9\n"
+"      Listează intrările SQLINE numerotate de la 2 la 5 și de la 7 la 9.\n"
+"\n"
+"SQLINEVIEW este o versiune mai detaliată a SQLINELIST și va afișa cine a adăugat un SQLINE, data la care a fost adăugat și când expiră, precum și masca și motivul.\n"
+"\n"
+"SQLINECLEAR golește toate intrările din lista SQLINE."
+
+#, c-format
+msgid ""
+"The STATS command prints out statistics about stored nicks and memory usage.\n"
+"\n"
+"The CLEAR command lets you clean the database by removing all entries from the database that were added within time.\n"
+"\n"
+"Example:\n"
+" %sCLEAR30m\n"
+" Will remove all entries that were added within the last 30 minutes."
+msgstr ""
+"Comanda STATS oferă statistici despre pseudonimele stocate și utilizarea memoriei.\n"
+"\n"
+"Comanda CLEAR vă permite să goliți baza de date prin ștergerea tuturor intrărilor din baza de date care au fost adăugate în intervalul de timp specificat.\n"
+"\n"
+"Exemplu:\n"
+" %sCLEAR30m\n"
+" Va goli toate intrările adăugate în ultimele 30 de minute."
+
+msgid "The email parameter is optional and will set the email address for your nick immediately. You may also wish to SETHIDE it after registering if it isn't the default setting already."
+msgstr "Parametrul email este opțional și va seta imediat adresa de email pentru pseudonimul dumneavoastră. Este posibil să doriți, de asemenea, a utiliza SETHIDE după înregistrare, dacă ascunderea adresei de email nu este deja o setare implicită."
+
+#, c-format
+msgid ""
+"The %s command allows users to configure logging settings for their channel. If no parameters are given this command lists the current logging methods in place for this channel.\n"
+"\n"
+"Otherwise, command must be a command name, and method is one of the following logging methods:\n"
+"\n"
+" MESSAGE[status], NOTICE[status], MEMO\n"
+"\n"
+"Which are used to message, notice, and memo the channel respectively. With MESSAGE or NOTICE you must have a service bot assigned to and joined to your channel. Status may be a channel status such as @ or +.\n"
+"\n"
+"To remove a logging method use the same syntax as you would to add it.\n"
+"\n"
+"Example:\n"
+" %s#anopechanserv/accessMESSAGE@\n"
+" Would message any channel operators whenever someone used the ACCESS command on ChanServ on the channel."
+msgstr ""
+"Comanda %s permite utilizatorilor să configureze setările de înregistrare în jurnal pentru canalele lor. Dacă nu sunt furnizați parametri, această comandă listează metodele de înregistrare curente pentru acest canal.\n"
+"\n"
+"Altfel, comanda trebuie să fie un nume de comandă, iar metoda este una dintre următoarele metode de înregistrare în jurnal:\n"
+"\n"
+" MESSAGE [statut], NOTICE [statut], MEMO\n"
+"\n"
+"Care sunt folosite pentru a trimite mesaje, a notifica, și a trimite misive canalului respectiv. Pentru mesaj (MESSAGE) sau notificare (NOTICE) trebuie să aveți un bot de serviciu asociat și alăturat canalului dumneavoastră. Statutul poate fi un statut al canalului, cum ar fi @ sau +.\n"
+"\n"
+"Pentru a înlătura o metodă de înregistrare în jurnal, utilizați aceeași sintaxă ca pentru a o adăuga.\n"
+"\n"
+"Examplu:\n"
+" %s#anopechanserv/accessMESSAGE@\n"
+" Trimite un mesaj tuturor operatorilor de fiecare dată când cineva folosește în canal comanda ACCESS aparținând serviciului ChanServ."
+
+#, c-format
+msgid "The %s list for %s is full."
+msgstr "Lista %s pentru %s este plină."
+
+#, c-format
+msgid "The %s list has been cleared."
+msgstr "Lista %s a fost golită."
+
+msgid "The AKILL list has been cleared."
+msgstr "Lista AKILL a fost golită."
+
+#, c-format
+msgid "The Defcon level is now at: %d"
+msgstr "Nivelul DEFCON este acum la: %d"
+
+#, c-format
+msgid "The confirmation code for %s has been re-sent to %s."
+msgstr "Codul de confirmare pentru %s a fost retrimis către %s."
+
+msgid "The defcon system can be used to implement a pre-defined set of restrictions to services useful during an attempted attack on the network."
+msgstr "Sistemul DEFCON poate fi utilizat pentru a implementa un set predefinit de restricții pentru servicii, utile în timpul unei tentative de atac asupra rețelei."
+
+#, c-format
+msgid "The email address %s has reached its usage limit of %u user."
+msgid_plural "The email address %s has reached its usage limit of %u users."
+msgstr[0] "Adresa de email %s a atins limita de utilizare de %u utilizator."
+msgstr[1] "Adresa de email %s a atins limita de utilizare de %u utilizatori."
+
+#, c-format
+msgid "The email address change confirmation code you specified for %s is incorrect."
+msgstr "Codul de confirmare a schimbării adresei de email specificat pentru %s este incorect."
+
+#, c-format
+msgid "The email address change request for %s has expired."
+msgstr "Solicitarea de schimbare a adresei de email pentru %s a expirat."
+
+#, c-format
+msgid "The email address of %s will now be hidden from %s INFO displays."
+msgstr "Adresa de email a utilizatorului %s va fi acum ascunsă în comanda INFO a %s."
+
+#, c-format
+msgid "The email address of %s will now be shown in %s INFO displays."
+msgstr "Adresa de email a utilizatorului %s va fi acum afișată în comanda INFO a %s."
+
+#, c-format
+msgid "The email address of %s has been changed from %s to %s."
+msgstr "Adresa de email a utilizatorului %s a fost schimbată de la %s la %s."
+
+#, c-format
+msgid "The entry message list for %s is full."
+msgstr "Lista de mesaje de intrare pentru %s este plină."
+
+msgid "The following feature/function names are available:"
+msgstr "Următoarele nume de caracteristici sau funcții sunt disponibile:"
+
+msgid "The given mask may also be a channel, which will use the access list from the other channel up to the given level."
+msgstr "Masca precizată poate fi și un canal, care va folosi lista de accese de la celălalt canal până la nivelul specificat."
+
+#, c-format
+msgid "The host %s currently has %d sessions with a limit of %d because it matches entry: %s."
+msgstr "Gazda %s are în prezent %d sesiuni cu o limită de %d deoarece corespunde cu intrarea: %s."
+
+#, c-format
+msgid "The last memo you sent to %s (sent on %s) has been read."
+msgstr "Ultima misivă pe care ați expediat-o către %s (trimisă la %s) a fost citită."
+
+#, c-format
+msgid "The last memo you sent to %s (sent on %s) has not yet been read."
+msgstr "Ultima misivă pe care ați expediat-o către %s (trimisă la %s) nu a fost citită încă."
+
+#, c-format
+msgid "The last quit message of %s will now be hidden from %s INFO displays."
+msgstr "Ultimul mesaj de plecare din rețea al utilizatorului %s va fi acum ascuns în comanda INFO a %s."
+
+#, c-format
+msgid "The last quit message of %s will now be shown in %s INFO displays."
+msgstr "Ultimul mesaj de plecare din rețea al utilizatorului %s va fi acum afișat în comanda INFO a %s."
+
+#, c-format
+msgid "The last seen user@host mask of %s will now be hidden from %s INFO displays."
+msgstr "Ultima mască văzută utilizator@gazdă a utilizatorului %s va fi acum ascunsă în comanda INFO a %s."
+
+#, c-format
+msgid "The last seen user@host mask of %s will now be shown in %s INFO displays."
+msgstr "Ultima mască văzută utilizator@gazdă a utilizatorului %s va fi acum afișată în comanda INFO a %s."
+
+#, c-format
+msgid "The limit on %s is not valid."
+msgstr "Limita pentru %s nu este validă."
+
+msgid "The mask must contain at least one non wildcard character."
+msgstr "Masca trebuie să conțină cel puțin un caracter non-wildcard."
+
+#, c-format
+msgid "The memo limit for %s may not be changed."
+msgstr "Limita de misive pentru %s nu poate fi modificată."
+
+#, c-format
+msgid "The mode lock list of %s is full."
+msgstr "Lista de încuieri de mod pentru %s este plină."
+
+#, c-format
+msgid "The network name you specified is incorrect. Did you mean to run %s on a different network?"
+msgstr "Numele de rețea pe care l-ați specificat este incorect. Ați vrut să rulați %s pe o altă rețea?"
+
+#, c-format
+msgid "The new display is now %s."
+msgstr "Noul afișaj este acum %s."
+
+#, c-format
+msgid "The new display nickname must belong to the %s account."
+msgstr "Noul pseudonim de afișare trebuie să aparțină contului %s."
+
+#, c-format
+msgid "The nick %s is now being changed to %s."
+msgstr "Pseudonimul %s este acum schimbat în %s."
+
+msgid "The old information is the same as the new information specified."
+msgstr "Informațiile vechi sunt identice cu noile informații specificate."
+
+#, c-format
+msgid "The oper info already exists on %s."
+msgstr "Informațiile de Operator există deja în %s."
+
+#, c-format
+msgid "The oper info list for %s is full."
+msgstr "Lista de informații de Operator pentru %s este plină."
+
+#, c-format
+msgid "The password reset code you specified for %s is incorrect."
+msgstr "Codul de resetare a parolei specificat pentru %s este incorect."
+
+#, c-format
+msgid "The password reset request for %s has expired."
+msgstr "Solicitarea de resetare a parolei pentru %s a expirat."
+
+#, c-format
+msgid "The registration confirmation code you specified for %s is incorrect."
+msgstr "Codul de confirmare a înregistrării specificat pentru %s este incorect."
+
+#, c-format
+msgid "The services access status of %s will now be hidden from %s INFO displays."
+msgstr "Statutul accesului la servicii al utilizatorului %s va fi acum ascuns în comanda INFO a %s."
+
+#, c-format
+msgid "The services access status of %s will now be shown in %s INFO displays."
+msgstr "Statutul accesului la servicii al utilizatorului %s va fi acum afișat în comanda INFO a %s."
+
+msgid "The session exception list is empty."
+msgstr "Lista de excepții de sesiune este goală."
+
+msgid "The user with your nick has been removed. Use this command again to release services's hold on your nick."
+msgstr "Utilizatorul cu pseudonimul dumneavoastră a fost înlăturat. Folosiți această comandă din nou pentru a elibera actuala ținere a pseudonimului de către servicii."
+
+msgid "There are no bots available at this time. Ask a Services Operator to create one!"
+msgstr "Nu există boți disponibili în acest moment. Puteți solicita de la un Operator de Servicii să creeze unul!"
+
+msgid "There are no configured servers."
+msgstr "Nu există servere configurate."
+
+#, c-format
+msgid "There are no forbids of type %s."
+msgstr "Nu există interdicții de tipul %s."
+
+msgid "There are too many nicks in your account."
+msgstr "Sunt prea multe pseudonime în contul dumneavoastră."
+
+#, c-format
+msgid "There currently are no logging configurations for %s."
+msgstr "În prezent, nu există configurații de înregistrare în jurnal pentru %s."
+
+#, c-format
+msgid "There is %zu memo on channel %s."
+msgid_plural "There are %zu memos on channel %s."
+msgstr[0] "Există %zu misivă către canalul %s."
+msgstr[1] "Există %zu misive către canalul %s."
+
+#, c-format
+msgid "There is a new memo on channel %s. Type %s%s%zu to read it."
+msgstr "Există o nouă misivă către canalul %s. Tastați %s%s%zu pentru a o citi."
+
+#, c-format
+msgid "There is no bot assigned to %s anymore."
+msgstr "Nu mai există niciun bot asociat în %s."
+
+#, c-format
+msgid "There is no email address change confirmation pending for %s."
+msgstr "Nu există nicio confirmare de schimbare a adresei de email în așteptare pentru %s."
+
+msgid "There is no logon news."
+msgstr "Nu există știri la conectare."
+
+msgid "There is no oper news."
+msgstr "Nu există știri la Operare."
+
+#, c-format
+msgid "There is no password reset confirmation pending for %s."
+msgstr "Nu există nicio confirmare de resetare a parolei în așteptare pentru %s."
+
+msgid "There is no random news."
+msgstr "Nu există știri aleatorii."
+
+#, c-format
+msgid "There is no registration confirmation pending for %s."
+msgstr "Nu există nicio confirmare a înregistrării în așteptare pentru %s."
+
+#, c-format
+msgid "There is no such configuration block %s."
+msgstr "Nu există un astfel de bloc de configurare %s."
+
+#, c-format
+msgid "There is no such mode %s."
+msgstr "Nu există un astfel de mod %s."
+
+msgid "There's no email address set for your nick."
+msgstr "Nu a fost setată nicio adresă de email pentru pseudonimul dumneavoastră."
+
+#, c-format
+msgid "This channel has been forbidden: %s"
+msgstr "Acest canal a fost interzis: %s"
+
+msgid "This channel has been suspended."
+msgstr "Acest canal a fost suspendat."
+
+msgid "This channel is suspended."
+msgstr "Acest canal este suspendat."
+
+msgid "This channel may not be used."
+msgstr "Acest canal nu poate fi utilizat."
+
+msgid ""
+"This command allows managing DNS zones used for controlling what servers users are directed to when connecting. Omitting all parameters prints out the status of the DNS zone.\n"
+"\n"
+"ADDZONE adds a zone, eg us.yournetwork.tld. Servers can then be added to this zone with the ADDSERVER command.\n"
+"\n"
+"The ADDSERVER command adds a server to the given zone. When a query is done, the zone in question is served if it exists, else all servers in all zones are served. A server may be in more than one zone.\n"
+"\n"
+"The ADDIP command associates an IP with a server.\n"
+"\n"
+"The POOL and DEPOOL commands actually add and remove servers to their given zones."
+msgstr ""
+"Această comandă permite gestionarea zonelor DNS utilizate pentru controlul serverelor către care sunt direcționați utilizatorii la conectare. Omiterea tuturor parametrilor afișează statutul zonei DNS.\n"
+"\n"
+"ADDZONE adaugă o zonă, de exemplu ro.rețeaua-dumneavoastră.tld. Serverele pot fi apoi adăugate la această zonă prin comanda ADDSERVER.\n"
+"\n"
+"Comanda ADDSERVER adaugă un server în zona precizată. Când o interogare este efectuată, zona în cauză este deservită dacă există, altfel toate serverele din toate zonele sunt deservite. Un server poate fi în mai multe zone.\n"
+"\n"
+"Comanda ADDIP atribuie o adresă IP unui server.\n"
+"\n"
+"Comenzile POOL și DEPOOL adaugă și înlătură servere din zonele lor."
+
+msgid "This command allows users to set the vhost of their CURRENT nick to be the vhost for all nicks in the same group."
+msgstr "Această comandă permite utilizatorilor să aplice gazda pseudonimului utilizat în prezent tuturor pseudonimelor din grupul lor de pseudonime."
+
+#, c-format
+msgid "This command is an alias to the command %s."
+msgstr "Această comandă este un alias pentru comanda %s."
+
+msgid "This command is used by several other commands as a way to confirm changes made to your account. type can be one of:"
+msgstr "Această comandă este utilizată în combinație cu alte comenzi, ca o modalitate de a confirma modificările aduse contului dumneavoastră. Tipul poate fi după cum urmează:"
+
+msgid "This command lists information about the specified loaded module."
+msgstr "Această comandă listează informații despre modulul încărcat specificat."
+
+msgid "This command lists registered vhosts to the operator. If a key is specified, only entries whose nick or vhost match the pattern given in key are displayed e.g. Rob* for all entries beginning with \"Rob\". If a #X-Y style is used, only entries between the range of X and Y will be displayed, e.g. #1-3 will display the first 3 nick/vhost entries."
+msgstr "Această comandă listează Operatorului gazdele virtuale înregistrate. Dacă este specificată o cheie, vor fi afișate doar intrările a căror pseudonim sau vhost corespund modelului precizat în cheie, de exemplu Ion* pentru toate intrările care încep cu \"Ion\". Dacă se folosește stilul #X-Y, vor fi afișate doar intrările din intervalul X și Y, de exemplu #1-3 va afișa primele 3 intrări pseudonim/gazdă."
+
+msgid "This command loads the module named modname from the modules directory."
+msgstr "Această comandă încarcă modulul numit nume-modul din directorul de module."
+
+msgid ""
+"This command makes your nickname join the target nickname's account. password is the password of the target nickname. \n"
+"\n"
+"Joining an account will allow you to share your configuration, memos, and channel privileges with all the nicknames in the account, and much more!\n"
+"\n"
+"An account exists as long as it is useful. This means that even if a nick of the account is dropped, you won't lose the shared things described above, as long as there is at least one nick remaining in the account.\n"
+"\n"
+"You may be able to use this command even if you have not registered your nick yet. If your nick is already registered, you'll need to identify yourself before using this command. \n"
+"\n"
+"It is recommended to use this command with a non-registered nick because it will be registered automatically when using this command. You may use it with a registered nick (to change your account) only if your network administrators allowed it.\n"
+"\n"
+"You can only be in one account at a time. Group merging is not possible. \n"
+"\n"
+"Note: all the nicknames of an account have the same password."
+msgstr ""
+"Această comandă face ca pseudonimul dumneavoastră să se alăture în grupul contului ce conține pseudonimul destinație. Parola este parola pseudonimului destinație.\n"
+"\n"
+"Alăturarea într-un cont vă va permite să vă împărtășiți configurația, misivele și privilegiile canalelor cu toate pseudonimele din cont și multe altele.\n"
+"\n"
+"Un cont există atâta timp cât este util. Aceasta înseamnă că, chiar dacă un pseudonim al contului este radiat, nu veți pierde lucrurile partajate descrise mai sus, atâta timp cât există cel puțin un pseudonim rămas în cont.\n"
+"\n"
+"Este posibil să utilizați această comandă chiar dacă nu v-ați înregistrat încă pseudonimul. Dacă pseudonimul dumneavoastră este deja înregistrat, va trebui să vă identificați înainte de a utiliza această comandă.\n"
+"\n"
+"Se recomandă utilizarea acestei comenzi cu un pseudonim neînregistrat, deoarece acesta va fi înregistrat automat la utilizarea acestei comenzi. Puteți folosi comanda cu un pseudonim înregistrat (pentru a vă schimba contul) numai dacă administratorii dumneavoastră de rețea au permis acest aspect.\n"
+"\n"
+"Puteți fi într-un singur cont la un moment dat. Fuzionarea grupurilor sau conturilor nu este posibilă.\n"
+"\n"
+"Rețineți că toate pseudonimele unui cont au aceeași parolă."
+
+msgid "This command manages your auto join list. When you identify you will automatically join the channels on your auto join list. Services Operators may provide a nick to modify other users' auto join lists."
+msgstr "Această comandă gestionează lista dumneavoastră de alăturare automată. Când vă identificați, vă veți alătura automat canalelor din lista dumneavoastră de alăturare automată. Operatorii de Servicii pot oferi un pseudonim pentru a modifica lista de alăturare automată a altui utilizator."
+
+msgid "This command may not be used on this network because nickname ownership is disabled."
+msgstr "Această comandă nu poate fi utilizată în această rețea, deoarece proprietatea pseudonimelor este dezactivată."
+
+msgid "This command reloads the module named modname."
+msgstr "Această comandă reîncarcă modulul numit nume-modul."
+
+msgid "This command retrieves the vhost requests."
+msgstr "Această comandă preia solicitările de gazdă virtuală."
+
+msgid ""
+"This command searches the services logfiles for messages that match the given pattern. The day and limit argument may be used to specify how many days of logs to search and the number of replies to limit to. By default this command searches one week of logs, and limits replies to 50.\n"
+"\n"
+"For example:\n"
+"    LOGSEARCH+21d+500lAnope\n"
+"      Searches the last 21 days worth of logs for messages\n"
+"      containing Anope and lists the most recent 500 of them."
+msgstr ""
+"Această comandă caută în fișierele de jurnal ale serviciilor mesaje care se potrivesc cu modelul precizat. Argumentele zi și limită pot fi folosite pentru a specifica câte zile de jurnale să caute și numărul de răspunsuri la care să se limiteze. În mod implicit, această comandă caută o săptămână de jurnale și limitează răspunsurile la 50.\n"
+"\n"
+"De exemplu:\n"
+"   LOGSEARCH+21d+500lAnope\n"
+"      Caută în jurnalele din ultimele 21 de zile mesajele care conțin Anope și listează cele mai recente 500 dintre acestea."
+
+msgid "This command tells you what a users access is on a channel and what access entries, if any, they match. Additionally it will tell you of any auto kick entries they match. Usage of this command is limited to users who have the ability to modify access entries on the channel."
+msgstr "Această comandă vă informează ce acces are un utilizator într-un canal și ce intrări de acces corespund, dacă există. În plus, vă va informa despre intrările de izgoniri automate care se potrivesc. Utilizarea acestei comenzi este limitată la utilizatorii care au posibilitatea de a modifica intrările de acces în canal."
+
+msgid "This command ungroups your nick, or if given, the specified nick, from the account it is in. The ungrouped nick keeps its registration time, password, email, greet, language, and url. Everything else is reset. You may not ungroup yourself if there is only one nick in your account."
+msgstr "Această comandă degrupează pseudonimul dumneavoastră sau pseudonimul precizat, din contul în care se află. Pseudonimul degrupat își păstrează ora de înregistrare, parola, adresa de email, salutul, limba și adresa URL. Toate celelalte date sunt resetate. Nu vă puteți degrupa dacă există un singur pseudonim în contul dumneavoastră."
+
+msgid "This command unloads the module named modname."
+msgstr "Această comandă aruncă modulul numit nume-modul."
+
+msgid "This command will resend a registration confirmation email."
+msgstr "Această comandă va retrimite un mesaj email de confirmare a înregistrării."
+
+#, c-format
+msgid "This nickname has been forbidden: %s"
+msgstr "Acest pseudonim a fost interzis: %s"
+
+#, c-format
+msgid "This nickname has been recovered by %s."
+msgstr "Acest pseudonim a fost recuperat de %s."
+
+#, c-format
+msgid "This nickname has been recovered by %s. If you did not do this then %s may have your password, and you should change it."
+msgstr "Acest pseudonim a fost recuperat de %s. Dacă nu ați făcut aceasta, atunci este posibil ca %s să aibă parola dumneavoastră și ar trebui să o schimbați."
+
+msgid "This nickname is suspended."
+msgstr "Acest pseudonim este suspendat."
+
+#, c-format
+msgid "This nickname is registered and has protection enabled. If it belongs to you, type %spassword to identify to your account."
+msgstr "Acest pseudonim este înregistrat și are protecția activată. Dacă vă aparține, tastați %sparola pentru a vă identifica în contul dumneavoastră."
+
+msgid "This option makes a channel unassignable. If a bot is already assigned to the channel, it is unassigned automatically when you enable it."
+msgstr "Această opțiune împiedică asocierea unui bot într-un canal. Dacă un bot este deja asociat, acesta este disociat automat atunci când activați opțiunea."
+
+msgid "This option prevents a bot from being assigned to a channel by users that aren't Services Operators."
+msgstr "Această opțiune împiedică asocierea unui bot într-un canal de către utilizatorii care nu sunt Operatori de Servicii."
+
+#, c-format
+msgid "Timezone changed to %s."
+msgstr "Fusul orar a fost schimbat la %s."
+
+#, c-format
+msgid "Timezone for %s changed to %s."
+msgstr "Fusul orar pentru %s a fost schimbat la %s."
+
+#, c-format
+msgid "To delete, type: %s %d"
+msgstr "Pentru a șterge, tastați: %s %d"
+
+#, c-format
+msgid "To delete, type: %s %s %d"
+msgstr "Pentru a șterge, tastați: %s %s %d"
+
+msgid "To protect ops against bot kicks"
+msgstr "Protejează operatorii împotriva izgonirilor de bot"
+
+msgid "To protect voices against bot kicks"
+msgstr "Protejează membrii voce împotriva izgonirilor de bot"
+
+msgid "To search for channels starting with #, search for the channel name without the #-sign prepended (anope instead of #anope)."
+msgstr "Pentru a căuta canale care încep cu #, căutați numele canalului fără semnul # adăugat înaintea acestuia (anope în loc de #anope)."
+
+#, c-format
+msgid "Too many results for %s."
+msgstr "Prea multe rezultate pentru %s."
+
+#, c-format
+msgid "Top %i of %s"
+msgstr "Top %i din %s"
+
+msgid "Topic"
+msgstr "Subiect"
+
+msgid "Topic lock"
+msgstr "Încuiere subiect"
+
+#, c-format
+msgid "Topic lock option for %s is now off."
+msgstr "Opțiunea de încuiere a subiectului pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Topic lock option for %s is now on."
+msgstr "Opțiunea de încuiere a subiectului pentru %s este acum activată."
+
+msgid "Topic retention"
+msgstr "Păstrarea subiectului"
+
+#, c-format
+msgid "Topic retention option for %s is now off."
+msgstr "Opțiunea de păstrare a subiectului pentru %s este acum dezactivată."
+
+#, c-format
+msgid "Topic retention option for %s is now on."
+msgstr "Opțiunea de păstrare a subiectului pentru %s este acum activată."
+
+msgid "Topic set by"
+msgstr "Subiect stabilit de"
+
+msgid "Turn caps lock OFF!"
+msgstr "Nu mai folosiți multe majuscule!"
+
+msgid "Turn chanstats statistics on or off"
+msgstr "Activează sau dezactivează statisticile chanstats"
+
+msgid "Turn protection on or off"
+msgstr "Activează sau dezactivează protecția pseudonimului"
+
+#, c-format
+msgid "Turns %s's privacy option on or off for the nick. With PRIVATE set, the nickname will not appear in nickname lists generated with %s's LIST command. (However, anyone who knows the nickname can still get information on it using the INFO command.)"
+msgstr "Activează sau dezactivează opțiunea privată a %s pentru pseudonimul specificat. Cu opțiunea PRIVATE, pseudonimul nu va apărea în listele de pseudonime generate prin comanda LIST a %s. (Totuși, oricine cunoaște pseudonimul poate obține informații despre el folosind comanda INFO.)"
+
+#, c-format
+msgid "Turns %s's privacy option on or off for your nick. With PRIVATE set, your nickname will not appear in nickname lists generated with %s's LIST command. (However, anyone who knows your nickname can still get information on it using the INFO command.)"
+msgstr "Activează sau dezactivează opțiunea privată a %s pentru pseudonimul dumneavoastră. Cu opțiunea PRIVATE, pseudonimul dumneavoastră nu va apărea în listele de pseudonime generate prin comanda LIST a %s. (Totuși, oricine cunoaște pseudonimul poate obține informații despre el folosind comanda INFO.)"
+
+#, c-format
+msgid "Turns automatic protection for the nick on or off. With protection on if a user tries to use a nickname from the nick's account they will be given some time to change their nick after which %s will forcibly change their nick."
+msgstr "Activează sau dezactivează protecția automată pentru pseudonimul specificat. Cu protecția activată, dacă un utilizator încearcă să folosească un pseudonim din contul pseudonimului, i se va acorda un timp pentru a-și schimba pseudonimul, după care va fi schimbat forțat de %s."
+
+#, c-format
+msgid "Turns automatic protection for your account on or off. With protection on if another user tries to use a nickname from your account they will be given some time to change their nick after which %s will forcibly change their nick."
+msgstr "Activează sau dezactivează protecția automată pentru pseudonimul dumneavoastră. Cu protecția activată, dacă un alt utilizator încearcă să folosească un pseudonim din contul dumneavoastră, utilizatorului i se va acorda un timp pentru a-și schimba pseudonimul, după care va fi schimbat forțat de %s."
+
+msgid "Turns chanstats channel statistics ON or OFF for this user."
+msgstr "Activează sau dezactivează statisticile de chanstats ale canalului pentru acest utilizator."
+
+msgid "Turns chanstats statistics ON or OFF."
+msgstr "Activează sau dezactivează statisticile de chanstats."
+
+msgid "Type"
+msgstr "Tip"
+
+#, c-format
+msgid "Type %s for more information."
+msgstr "Tastați %s pentru mai multe informații."
+
+#, c-format
+msgid "Type %scommand for help on any of the above commands."
+msgstr "Tastați %scomanda pentru ajutor cu oricare dintre comenzile de mai sus."
+
+#, c-format
+msgid "Type %soption for more information on a particular option."
+msgstr "Tastați %sopțiunea pentru mai multe informații despre o anumită opțiune."
+
+#, c-format
+msgid "Type %soption for more information on a specific option."
+msgstr "Tastați %sopțiunea pentru mai multe informații despre o anumită opțiune."
+
+#, c-format
+msgid ""
+"Type %soption for more information on a specific option.\n"
+"\n"
+"Note: access to this command is controlled by the level SET."
+msgstr ""
+"Tastați %sopțiunea pentru mai multe informații despre o anumită opțiune.\n"
+"\n"
+"Notă: accesul la această comandă este controlat de nivelul SET."
+
+#, c-format
+msgid "Type %soption for more information on a specific option. The options will be set on the given nickname."
+msgstr "Tastați %sopțiunea pentru mai multe informații despre o anumită opțiune. Opțiunile vor fi setate pentru pseudonimul precizat."
+
+#, c-format
+msgid "Type %sregion to list timezones for a region."
+msgstr "Tastați %sregiune pentru a lista fusurile orare ale unei regiuni."
+
+msgid "Un-Load a module"
+msgstr "Aruncă un modul"
+
+#, c-format
+msgid "Unable to find regex engine %s."
+msgstr "Nu se poate găsi motorul de expresii regulate %s."
+
+#, c-format
+msgid "Unable to find the DNS record required to validate %s. If you have not already done this add a TXT record for %s with the value %s and re-execute this command."
+msgstr "Nu se poate găsi înregistrarea DNS necesară pentru a valida %s. Dacă nu ați făcut deja acest lucru, adăugați o înregistrare TXT pentru %s cu valoarea %s și executați din nou această comandă."
+
+#, c-format
+msgid "Unable to load module %s."
+msgstr "Nu se poate încărca modulul %s."
+
+#, c-format
+msgid "Unable to remove module %s."
+msgstr "Nu se poate înlătura modulul %s."
+
+msgid "Unassigns a bot from a channel"
+msgstr "Disociază un bot dintr-un canal"
+
+msgid "Unassigns a bot from a channel. When you use this command, the bot won't join the channel anymore. However, bot configuration for the channel is kept, so you will always be able to reassign a bot later without having to reconfigure it entirely."
+msgstr "Disociază un bot dintr-un canal. Când utilizați această comandă, botul nu se va mai alătura canalului. Cu toate acestea, configurația botului pentru canal este păstrată, astfel încât veți putea întotdeauna să reasociați un bot mai târziu, fără a fi nevoie să-l reconfigurați în întregime."
+
+msgid "Underlines kicker"
+msgstr "Izgonire la sublinieri"
+
+msgid "Unknown SET option."
+msgstr "Opțiune SET necunoscută."
+
+#, c-format
+msgid "Unknown STATS option: %s"
+msgstr "Opțiune STATS necunoscută: %s"
+
+#, c-format
+msgid "Unknown command %s."
+msgstr "Comandă necunoscută %s."
+
+#, c-format
+msgid "Unknown command %s. Did you mean %s?"
+msgstr "Comandă necunoscută %s. Ați vrut %s?"
+
+#, c-format
+msgid "Unknown command %s. Did you mean %s? Type %s for help."
+msgstr "Comandă necunoscută %s. Ați vrut %s? Tastați %s pentru ajutor."
+
+#, c-format
+msgid "Unknown command %s. Type %s for help."
+msgstr "Comandă necunoscută %s. Tastați %s pentru ajutor."
+
+#, c-format
+msgid "Unknown mode character %c ignored."
+msgstr "Caracterul de mod necunoscut %c este ignorat."
+
+#, c-format
+msgid "Unknown parameter: %s"
+msgstr "Parametru necunoscut: %s"
+
+#, c-format
+msgid "Unknown passwords: %zu"
+msgstr "Parole necunoscute: %zu"
+
+msgid "Unpooled"
+msgstr "Decolectivizat"
+
+msgid "Unregisters the named channel. Can only be used by the channel founder."
+msgstr "Radiază înregistrarea canalului specificat. Comanda poate fi folosită doar de fondatorul canalului."
+
+msgid "Unregisters the specified channel. Only Services Operators can drop a channel of which they are not the founder of."
+msgstr "Radiază înregistrarea canalului specificat. Doar Operatorii de Servicii pot radia un canal al căruia ei nu sunt fondatori."
+
+msgid "Unsuspend a given nick"
+msgstr "Anulează suspendarea unui pseudonim precizat"
+
+msgid "Unsuspends a nickname which allows it to be used again."
+msgstr "Anulează suspendarea unui pseudonim, ceea ce permite utilizarea acestuia."
+
+msgid "Updates a selected nicks status modes on a channel. If nick is omitted then your status is updated. If channel is omitted then your channel status is updated on every channel you are in."
+msgstr "Actualizează modurile de statut ale pseudonimului selectat într-un canal. Dacă pseudonimul este omis, atunci statutul dumneavoastră este actualizat. Dacă canalul este omis, atunci statutul dumneavoastră de canal este actualizat în fiecare canal în care vă aflați."
+
+msgid "Updates a selected nicks status on a channel"
+msgstr "Actualizează statutul pseudonimului selectat într-un canal"
+
+msgid "Updates your current status, i.e. it checks for new memos"
+msgstr "Actualizează statutul dumneavoastră actual, adică verifică dacă există noi misive"
+
+msgid "Updates your current status, i.e. it checks for new memos, sets needed channel modes and updates your vhost and your userflags (lastseentime, etc)."
+msgstr "Actualizează statutul dumneavoastră actual, adică verifică dacă există noi misive, setează modurile de canal necesare apoi vă actualizează gazda virtuală și datele salvate (ultima conectare și altele)."
+
+msgid "Updating databases."
+msgstr "Se actualizează bazele de date."
+
+#, c-format
+msgid "Uplink capab: %s"
+msgstr "Capacitate de uplink: %s"
+
+#, c-format
+msgid "Uplink server: %s"
+msgstr "Server de uplink: %s"
+
+#, c-format
+msgid "Use the %sALL command to list all commands and their descriptions."
+msgstr "Utilizați comanda %sALL pentru a lista toate comenzile și descrierile acestora."
+
+msgid "Used on"
+msgstr "Utilizat(ă) în"
+
+msgid "Used to manage channels"
+msgstr "Vă permite să gestionați canale"
+
+msgid "Used to manage the list of privileged users"
+msgstr "Vă permite să gestionați lista de utilizatori privilegiați"
+
+msgid "Used to modify the channel status of you or other users"
+msgstr "Vă permite să modificați statutul de canal al dumneavoastră sau al altor utilizatori"
+
+#, c-format
+msgid "User %s isn't currently logged in to an account."
+msgstr "Utilizatorul %s nu este identificat în prezent la niciun cont."
+
+msgid "User has been banned from the channel"
+msgstr "Utilizatorul a fost blocat din canal"
+
+#, c-format
+msgid "User limit for %s removed."
+msgstr "Limita de utilizatori pentru %s a fost înlăturată."
+
+#, c-format
+msgid "User limit for %s set to %d."
+msgstr "Limita de utilizatori pentru %s a fost setată la %d."
+
+msgid "Users"
+msgstr "Utilizatori"
+
+#, c-format
+msgid "Users (nick): %lu entries, %lu buckets, longest chain is %zu"
+msgstr "Utilizatori (pseudonim): %lu intrări, %lu compartimente, cel mai lung lanț este %zu"
+
+#, c-format
+msgid "Users (uid): %lu entries, %lu buckets, longest chain is %zu"
+msgstr ""
+
+msgid "Users list:"
+msgstr "Listă de utilizatori este după cum urmează:"
+
+msgid "VHost"
+msgstr "Gazdă virtuală"
+
+#, c-format
+msgid "VHost %s has been requested by %s."
+msgstr "Gazda virtuală %s a fost solicitată de %s."
+
+#, c-format
+msgid "VHost for %s removed."
+msgstr "Gazda virtuală pentru %s a fost înlăturată."
+
+#, c-format
+msgid "VHost for %s set to %s."
+msgstr "Gazda virtuală pentru %s a fost setată la %s."
+
+#, c-format
+msgid "VHost for %s has been activated."
+msgstr "Gazda virtuală pentru %s a fost activată."
+
+#, c-format
+msgid "VHost for %s has been rejected."
+msgstr "Gazda virtuală pentru %s a fost respinsă."
+
+#, c-format
+msgid "VHost for %s has been validated using DNS."
+msgstr "Gazda virtuală pentru %s a fost validată utilizând DNS."
+
+#, c-format
+msgid "VHost for account %s set to %s."
+msgstr "Gazda virtuală pentru contul %s a fost setată la %s."
+
+#, c-format
+msgid "VHosts for account %s have been removed."
+msgstr "Gazda virtuală pentru contul %s a fost înlăturată."
+
+msgid "VIEW host"
+msgstr "VIEW gazdă"
+
+msgid "VIEW [mask | list | id]"
+msgstr "VIEW [mască | listă | id]"
+
+msgid "VIEW [mask | list]"
+msgstr "VIEW [mască | listă]"
+
+msgid "Validates a previously requested vhost using DNS"
+msgstr "Validează o gazdă virtuală solicitată, utilizând DNS"
+
+msgid "Validates a previously requested vhost using DNS. If you own the domain you have requested as a vhost you can validate your ownership of it using a DNS TXT record to approve your own vhost."
+msgstr "Validează o gazdă virtuală solicitată anterior folosind DNS. Dacă dețineți domeniul pe care l-ați solicitat drept gazdă virtuală, puteți valida proprietatea acestuia folosind o înregistrare DNS de tip TXT pentru a vă aproba propria gazdă virtuală."
+
+msgid "Value"
+msgstr "Valoare"
+
+#, c-format
+msgid "Value of %s:%s changed to %s"
+msgstr "Valoarea %s:%s a fost schimbată în %s"
+
+msgid "View and change Services Operators"
+msgstr "Vizualizează și modifică Operatorii de Servicii"
+
+msgid "View and change configuration file settings"
+msgstr "Vizualizează și modifică setările fișierului de configurare"
+
+msgid "View the list of host sessions"
+msgstr "Vizualizează lista sesiunilor de gazdă"
+
+msgid "Voices protection"
+msgstr "Protecția membrilor voce"
+
+msgid "Watch your language!"
+msgstr "Aveți grijă la limbaj!"
+
+#, c-format
+msgid "When private is set, the channel will not appear in %s's %s command."
+msgstr "Când PRIVATE este setat, canalul nu va mai apărea în comanda de %s %s."
+
+msgid ""
+"Without a parameter, displays information on the number of memos you have, how many of them are unread, and how many total memos you can receive.\n"
+"\n"
+"With a channel parameter, displays the same information for the given channel.\n"
+"\n"
+"With a nickname parameter, displays the same information for the given nickname. This is limited to Services Operators."
+msgstr ""
+"Fără un parametru, afișează informații despre numărul de misive pe care le aveți, câte dintre ele sunt necitite și câte misive puteți primi în total.\n"
+"\n"
+"Cu un parametru de canal, afișează aceleași informații privind canalul respectiv.\n"
+"\n"
+"Cu un parametru de pseudonim, afișează aceleași informații privind pseudonimul respectiv. Acestă funcție este limitată la Operatorii de Servicii."
+
+msgid ""
+"Without a parameter, lists all nicknames that belong to your account.\n"
+"\n"
+"With a parameter, lists all nicknames that belong to the account of the given nick.\n"
+"\n"
+"Specifying a nick is limited to Services Operators."
+msgstr ""
+"Fără un parametru, listează toate pseudonimele care aparțin contului dumneavoastră.\n"
+"\n"
+"Cu un parametru, listează toate pseudonimele care aparțin contului pseudonimului specificat.\n"
+"\n"
+"Specificarea unui pseudonim este limitată la Operatorii de Servicii."
+
+msgid ""
+"Without a parameter, reverses the effect of the IDENTIFY command, i.e. make you not recognized as the real owner of the nick anymore. Note, however, that you won't be asked to reidentify yourself.\n"
+"\n"
+"With a parameter, does the same for the given nick. If you specify REVALIDATE as well, services will ask the given nick to re-identify. This is limited to Services Operators."
+msgstr ""
+"Fără un parametru, inversează efectul comenzii IDENTIFY, adică face ca dumneavoastră să nu mai fiți recunoscut(ă) ca proprietarul real al pseudonimului. Rețineți, totuși, că nu vi se va cere să vă reidentificați.\n"
+"\n"
+"Cu un parametru, face același lucru pentru pseudonimul precizat. Dacă specificați și REVALIDATE, serviciile vor solicita pseudonimului să se reidentifice. Această funcție este limitată la Operatorii de Servicii."
+
+msgid ""
+"Without any option, shows the current number of users online, and the highest number of users online since services was started, and the length of time services has been running.\n"
+"\n"
+"With the AKILL option, displays the current size of the AKILL list and the current default expiry time.\n"
+"\n"
+"The RESET option currently resets the maximum user count to the number of users currently present on the network.\n"
+"\n"
+"The PASSWORD option displays the encryption algorithms used for user passwords. \n"
+"\n"
+"The UPLINK option displays information about the current server Anope uses as an uplink to the network.\n"
+"\n"
+"The HASH option displays information about the hash maps.\n"
+"\n"
+"The ALL option displays all of the above statistics."
+msgstr ""
+"Fără nicio opțiune, afișează numărul curent de utilizatori online și cel mai mare număr de utilizatori online de la pornirea serviciilor, precum și durata de funcționare a serviciilor.\n"
+"\n"
+"Cu opțiunea AKILL, se afișează dimensiunea curentă a listei AKILL și timpul de expirare implicit curent.\n"
+"\n"
+"Opțiunea RESET resetează numărul maxim de utilizatori la numărul de utilizatori prezenți în rețea.\n"
+"\n"
+"Opțiunea PASSWORD afișează algoritmii de criptare utilizați pentru parolele utilizatorilor.\n"
+"\n"
+"Opțiunea UPLINK afișează informații despre serverul curent utilizat de Anope ca legătură ascendentă către rețea.\n"
+"\n"
+"Opțiunea HASH afișează informații despre hărțile hash.\n"
+"\n"
+"Opțiunea ALL afișează toate statisticile de mai sus."
+
+msgid "Word"
+msgstr "Cuvânt"
+
+#, c-format
+msgid "You are already a member of the account of %s."
+msgstr "Sunteți deja membru al contului %s."
+
+msgid "You are already identified."
+msgstr "Sunteți deja identificat(ă)."
+
+#, c-format
+msgid "You are already in %s!"
+msgstr "Sunteți deja în %s!"
+
+msgid "You are no longer a super admin."
+msgstr "Nu mai sunteți super-administrator."
+
+msgid "You are not identified."
+msgstr "Nu sunteți identificat(ă)."
+
+msgid "You are not permitted to be on this channel."
+msgstr "Nu aveți permisiunea de a fi în acest canal."
+
+msgid "You are not permitted to change your memo limit."
+msgstr "Nu aveți permisiunea de a modifica limita de misive."
+
+msgid "You are not using a client certificate."
+msgstr "Nu utilizați un certificat de client."
+
+msgid "You are now a super admin."
+msgstr "Acum sunteți un super-administrator."
+
+#, c-format
+msgid "You are now identified as %s. Change your password now using %s."
+msgstr "Acum sunteți identificat(ă) ca %s. Schimbați-vă parola acum folosind %s."
+
+#, c-format
+msgid "You are over your maximum number of memos (%d). You will be unable to receive any new memos until you delete some of your current ones."
+msgstr "Ați depășit numărul maxim de misive (%d). Nu veți putea primi misive noi până când nu ștergeți câteva dintre cele actuale."
+
+msgid "You can associate multiple nicknames with your account. All nicknames will share the same configuration, set of memos, and channel privileges."
+msgstr "Puteți atribui mai multe pseudonime contului dumneavoastră. Toate pseudonimele vor împărtăși aceeași configurație, același set de misive și aceleași privilegii de canal."
+
+msgid "You can not NOOP services."
+msgstr "Nu puteți pune NOOP pe servicii."
+
+msgid "You can not disable the founder privilege because it would be impossible to re-enable it at a later time."
+msgstr "Nu puteți dezactiva privilegiul de fondator, deoarece ar fi imposibil să-l reactivați mai târziu."
+
+msgid "You can not jupe an already juped server."
+msgstr "Nu puteți să faceți \"jupe\" unui server deja \"juped\"."
+
+msgid "You can not jupe your services' pseudoserver or your uplink server."
+msgstr "Nu puteți să faceți \"jupe\" pseudoserverului serviiciilor ori serverului de uplink."
+
+msgid "You can not queue any more messages."
+msgstr "Nu mai puteți pune la coadă alte mesaje."
+
+#, c-format
+msgid "You can not reload this module directly, instead reload %s."
+msgstr "Nu puteți reîncărca direct acest modul, în schimb puteți reîncărca %s."
+
+msgid "You can not request a receipt when sending a memo to yourself."
+msgstr "Nu puteți solicita o confirmare atunci când vă trimiteți o misivă dumneavoastră."
+
+msgid "You can not send a single message while you have messages queued."
+msgstr "Nu puteți trimite niciun mesaj cât timp aveți mesaje în coadă."
+
+#, c-format
+msgid "You can't %s yourself!"
+msgstr "Nu puteți folosi %s asupra dumneavoastră!"
+
+msgid "You can't add a channel to its own access list."
+msgstr "Nu puteți adăuga un canal la propria sa listă de acces."
+
+#, c-format
+msgid "You can't logout %s, they are a Services Operator."
+msgstr "Nu puteți deidentifica pe %s deoarece este Operator de Servicii."
+
+#, c-format
+msgid "You cannot set the %c flag."
+msgstr "Nu puteți seta stegulețul %c."
+
+#, c-format
+msgid "You cannot set the memo limit for %s higher than %d."
+msgstr "Nu puteți seta limita de misive pentru %s mai mare de %d."
+
+#, c-format
+msgid "You cannot set your memo limit higher than %d."
+msgstr "Nu puteți seta limita de misive a dumneavoastră mai mare de %d."
+
+msgid "You cannot unassign bots while persist is set on the channel."
+msgstr "Nu puteți disocia boți cât timp persistența este setată în canal."
+
+msgid "You cannot unset the email address on this network."
+msgstr "Nu puteți de-seta adresa de email în această rețea."
+
+msgid "You cannot use this command."
+msgstr "Nu puteți folosi această comandă."
+
+#, c-format
+msgid "You currently have %zu memos, of which %zu are unread."
+msgstr "Aveți în acest moment %zu misive, dintre care %zu sunt necitite."
+
+#, c-format
+msgid "You currently have %zu memos, of which 1 is unread."
+msgstr "Aveți în acest moment %zu misive, dintre care 1 este necitită."
+
+#, c-format
+msgid "You currently have %zu memos."
+msgstr "Aveți în acest moment %zu misive."
+
+#, c-format
+msgid "You currently have %zu memos; all of them are unread."
+msgstr "Aveți în acest moment %zu misive; toate necitite."
+
+msgid "You currently have 1 memo, and it has not yet been read."
+msgstr "Aveți în acest moment 1 misivă și aceasta nu a fost citită încă."
+
+msgid "You currently have 1 memo."
+msgstr "Aveți în acest moment 1 misivă."
+
+msgid "You currently have no memos."
+msgstr "Nu aveți misive în acest moment."
+
+#, c-format
+msgid "You do not have access to set mode %c."
+msgstr "Nu aveți acces să setați modul %c."
+
+msgid "You do not have any messages queued and did not specify a message to send."
+msgstr "Nu aveți niciun mesaj în coadă și nu ați specificat un mesaj de trimis."
+
+msgid "You do not have any queued messages."
+msgstr "Nu aveți niciun mesaj în coadă."
+
+#, c-format
+msgid "You do not have the access to change %s's modes."
+msgstr "Nu aveți acces pentru a schimba modurile aparținând %s."
+
+#, c-format
+msgid "You have %d new memo."
+msgid_plural "You have %d new memos."
+msgstr[0] "Aveți %d misivă nouă."
+msgstr[1] "Aveți %d misive noi."
+
+#, c-format
+msgid "You have a new memo from %s. Type %s%zu to read it."
+msgstr "Aveți o misivă nouă de la %s. Tastați %s%zu pentru a o citi."
+
+#, c-format
+msgid "You have been invited to %s by %s."
+msgstr "Ați fost invitat(ă) în %s de către %s."
+
+#, c-format
+msgid "You have been invited to %s."
+msgstr "Ați fost invitat(ă) în %s."
+
+#, c-format
+msgid "You have been logged in as %s."
+msgstr "Ați fost identificat(ă) ca fiind %s."
+
+msgid "You have been logged out."
+msgstr "Ați fost deidentificat(ă)."
+
+#, c-format
+msgid "You have been unbanned from %s."
+msgstr "Ați fost deblocat(ă) din %s."
+
+#, c-format
+msgid "You have been unbanned from %d channels."
+msgstr "Ați fost deblocat(ă) din %d canale."
+
+msgid "You have no limit on the number of memos you may keep."
+msgstr "Nu aveți nicio limită privind numărul de misive pe care le puteți păstra."
+
+msgid "You have no memos."
+msgstr "Nu aveți misive."
+
+msgid "You have no messages queued."
+msgstr "Nu aveți mesaje în coadă."
+
+msgid "You have no new memos."
+msgstr "Nu aveți misive noi."
+
+#, c-format
+msgid "You have reached your maximum number of memos (%d). You will be unable to receive any new memos until you delete some of your current ones."
+msgstr "Ați atins numărul maxim de misive (%d). Nu veți putea primi misive noi până când nu ștergeți unele dintre cele actuale."
+
+#, c-format
+msgid "You have regained control of %s."
+msgstr "Ați recăpătat controlul asupra %s."
+
+msgid "You may drop any nick within your account."
+msgstr "Puteți radia orice pseudonim din contul dumneavoastră."
+
+#, c-format
+msgid "You may not (un)lock mode %c."
+msgstr "Nu aveți dreptul să descuiați modul %c."
+
+msgid "You may not change the email address of an unconfirmed account."
+msgstr "Nu aveți dreptul să modificați adresa de email a unui cont neconfirmat."
+
+msgid "You may not change the email address of other Services Operators."
+msgstr "Nu aveți dreptul să modificați adresa de email a altor Operatori de Servicii."
+
+msgid "You may not change the password of other Services Operators."
+msgstr "Nu aveți dreptul să schimbați parola altor Operatori de Servicii."
+
+#, c-format
+msgid "You may not drop %s as it is the display nick for the account."
+msgstr "Nu puteți radia %s, deoarece este pseudonimul de afișare al contului."
+
+msgid "You may not drop other Services Operators' nicknames."
+msgstr "Nu aveți dreptul să radiați pseudonimele altor Operatori de Servicii."
+
+msgid "You may not suspend other Services Operators' nicknames."
+msgstr "Nu aveți dreptul să suspendați pseudonimele altor Operatori de Servicii."
+
+msgid "You may view but not modify the certificate list of other Services Operators."
+msgstr "Puteți vizualiza, dar nu puteți modifica lista de certificate a altor Operatori de Servicii."
+
+#, c-format
+msgid "You might see yourself in the mirror, %s."
+msgstr "S-ar putea să vă vedeți în oglindă, %s."
+
+msgid "You must assign a bot to the channel before using this command."
+msgstr "Trebuie să asociați un bot canalului înainte de a utiliza această comandă."
+
+msgid "You must be a channel operator to register the channel."
+msgstr "Trebuie să fiți operator în canal pentru a înregistra canalul."
+
+#, c-format
+msgid "You must be in %s to use this command."
+msgstr "Trebuie să fiți în %s pentru a utiliza această comandă."
+
+msgid "You must be logged into an account to use that command."
+msgstr "Trebuie să fiți identificat(ă) într-un cont pentru a utiliza comanda respectivă."
+
+msgid "You must confirm your account before you can register a channel."
+msgstr "Trebuie să vă confirmați contul înainte de a putea înregistra un canal."
+
+msgid "You must confirm your account before you may request a vhost."
+msgstr "Trebuie să vă confirmați contul înainte de a putea solicita o gazdă virtuală."
+
+msgid "You must confirm your account before you may send a memo."
+msgstr "Trebuie să vă confirmați contul înainte de a putea trimite o misivă."
+
+#, c-format
+msgid "You must have the %s(ME) privilege on the channel to use this command."
+msgstr "Trebuie să aveți privilegiul %s(ME) în canal pentru a utiliza această comandă."
+
+#, c-format
+msgid "You must now supply an email address for your nick. This email address will allow you to recover your account in case you forget your password. Type %semail in order to set your email address."
+msgstr "Trebuie să furnizați acum o adresă de email pentru pseudonimul dumneavoastră. Această adresă de email vă va permite să vă recuperați contul în cazul în care vă uitați parola. Tastați %semail pentru a vă seta adresa de email."
+
+#, c-format
+msgid "You must wait %s before registering your nick."
+msgstr "Trebuie să așteptați %s înainte de a vă înregistra pseudonimul."
+
+#, c-format
+msgid "You must wait for %s before trying DNS validation again."
+msgstr "Trebuie să așteptați %s înainte de a încerca din nou validarea DNS."
+
+msgid "You need to be identified to use this command."
+msgstr "Trebuie să fiți identificat(ă) pentru a utiliza această comandă."
+
+msgid "You will be notified by message and by mail when new memos arrive."
+msgstr "Veți fi notificat(ă) prin mesaj și prin email când sosesc noi misive."
+
+msgid "You will be notified of memos by email as well as any other settings you have."
+msgstr "Veți fi notificat(ă) despre misive prin email, precum și prin orice alte setări pe care le aveți."
+
+msgid "You will be notified of memos when you log on, when you unset /AWAY, and when they are sent to you."
+msgstr "Veți fi notificat(ă) despre misive când vă identificați, când dezactivați /AWAY și când acestea vă sunt trimise."
+
+msgid "You will be notified of new memos at logon and when they arrive, and by mail when they arrive."
+msgstr "Veți fi notificat(ă) despre noile misive la identificare și când acestea sosesc, precum și prin mesaj email."
+
+msgid "You will be notified of new memos at logon and when they arrive."
+msgstr "Veți fi notificat(ă) despre noile misive la identificare și când acestea sosesc."
+
+msgid "You will be notified of new memos at logon, and by mail when they arrive."
+msgstr "Veți fi notificat(ă) despre noile misive la identificare și prin email când acestea sosesc."
+
+msgid "You will be notified of new memos at logon."
+msgstr "Vei fi notificat(ă) despre noile misive la identificare."
+
+msgid "You will be notified when new memos arrive."
+msgstr "Veți fi notificat(ă) când sosesc misive noi."
+
+msgid "You will no longer be able to receive memos."
+msgstr "Nu veți mai putea primi misive."
+
+msgid "You will no longer be informed via email."
+msgstr "Nu veți mai fi informat(ă) prin email."
+
+msgid "You will not be notified of memos by email."
+msgstr "Nu veți fi notificat(ă) prin email despre misive."
+
+msgid "You will not be notified of new memos."
+msgstr "Nu veți fi notificat(ă) despre noile misive."
+
+msgid "You will not receive any notification of memos."
+msgstr "Nu veți primi nicio notificare despre misive."
+
+msgid "You will now be informed about new memos via email."
+msgstr "Veți fi acum informat(ă) prin email despre noile misive."
+
+msgid "You will only be notified of memos when they are sent to you."
+msgstr "Veți fi notificat(ă) despre misive doar atunci când vă sunt trimise."
+
+msgid "You will only be notified of memos when you log on or when you unset /AWAY."
+msgstr "Veți fi notificat(ă) despre misive doar atunci când vă identificați sau când dezactivați /AWAY."
+
+msgid "Your IRCd does not support SVSJOIN."
+msgstr "Serverul dumneavoastră de IRCd nu acceptă SVSJOIN."
+
+msgid "Your IRCd does not support SVSNICK."
+msgstr "Serverul dumneavoastră de IRCd nu acceptă SVSNICK."
+
+msgid "Your IRCd does not support SVSPART."
+msgstr "Serverul dumneavoastră de IRCd nu acceptă SVSPART."
+
+msgid "Your IRCd does not support vidents. If this is incorrect please report this as a possible bug."
+msgstr "Serverul dumneavoastră de IRCd nu acceptă identități virtuale. Dacă acest lucru este incorect, vă rugăm să raportați aceasta ca o posibilă eroare."
+
+#, c-format
+msgid "Your SSL certificate fingerprint %s has been automatically added to your certificate list."
+msgstr "Amprenta electronică a certificatului SSL %s a fost adăugată automat la lista de certificate a dumneavoastră."
+
+#, c-format
+msgid "Your account %s has been successfully created."
+msgstr "Contul dumneavoastră %s a fost creat cu succes."
+
+msgid "Your account is not confirmed. To confirm it, follow the instructions that were emailed to you."
+msgstr "Contul dumneavoastră nu este confirmat. Pentru a-l confirma, urmați instrucțiunile care v-au fost trimise prin email."
+
+#, c-format
+msgid "Your account is not confirmed. To confirm it, type %s."
+msgstr "Contul dumneavoastră nu este confirmat. Pentru a-l confirma, tastați %s."
+
+#, c-format
+msgid "Your account will expire, if not confirmed, in %s."
+msgstr "Contul dumneavoastră va expira, dacă nu este confirmat, în %s."
+
+#, c-format
+msgid "Your email address has been updated to %s"
+msgstr "Adresa de email a dumneavoastră a fost actualizată la %s"
+
+#, c-format
+msgid "Your email address has been updated to %s."
+msgstr "Adresa de email a dumneavoastră a fost actualizată la %s."
+
+msgid "Your email address is not allowed, choose a different one."
+msgstr "Adresa de email a dumneavoastră nu este permisă, alegeți una diferită."
+
+msgid "Your memo limit has been disabled."
+msgstr "Limita de misive a dumneavoastră a fost dezactivată."
+
+#, c-format
+msgid "Your memo limit has been set to %d."
+msgstr "Limita de misive a fost setată la %d."
+
+#, c-format
+msgid "Your memo limit is %d, and may not be changed."
+msgstr "Limita de misive a dumneavoastră este %d iar aceasta nu poate fi modificată."
+
+#, c-format
+msgid "Your memo limit is %d."
+msgstr "Limita de misive a dumneavoastră este %d."
+
+msgid "Your memo limit is 0; you will not receive any new memos."
+msgstr "Limita de misive a dumneavoastră este 0; nu veți primi nicio misivă nouă."
+
+msgid "Your memo limit is 0; you will not receive any new memos. You cannot change this limit."
+msgstr "Limita de misive a dumneavoastră este 0; nu veți primi nicio misivă nouă. Nu puteți schimba această limită."
+
+msgid "Your message has been queued."
+msgstr "Mesajul dumneavoastră a fost pus în coadă."
+
+msgid "Your message queue has been cleared."
+msgstr "Coada de mesaje a dumneavoastră a fost golită."
+
+msgid "Your nick does not belong to an account, you can't ungroup it."
+msgstr "Pseudonimul dumneavoastră nu aparține niciunui cont; nu-l puteți degrupa."
+
+msgid "Your nick has been logged out."
+msgstr "Pseudonimul dumneavoastră a fost deidentificat."
+
+msgid "Your nick is already registered."
+msgstr "Pseudonimul dumneavoastră este deja înregistrat."
+
+#, c-format
+msgid "Your nickname is now being changed to %s"
+msgstr "Pseudonimul dumneavoastră este schimbat acum în %s"
+
+#, c-format
+msgid "Your nickname now belongs to the account %s."
+msgstr "Pseudonimul dumneavoastră aparține acum contului %s."
+
+#, c-format
+msgid "Your nickname will be changed in %s if you do not identify."
+msgstr "Pseudonimul dumneavoastră va fi schimbat în %s dacă nu vă identificați."
+
+msgid "Your oper block doesn't require logging in."
+msgstr "Blocul de operare al dumneavoastră nu necesită autentificare."
+
+#, c-format
+msgid "Your password is too long. It must be shorter than %u characters."
+msgstr "Parola dumneavoastră este prea lungă. Aceasta trebuie să fie mai scurtă de %u caractere."
+
+#, c-format
+msgid "Your password is too short. It must be longer than %u characters."
+msgstr "Parola dumneavoastră este prea scurtă. Aceasta trebuie să fie mai lungă de %u caractere."
+
+msgid "Your requested vhost has been approved."
+msgstr "Gazda virtuală solicitată de dumneavoastră a fost aprobată."
+
+msgid "Your requested vhost has been rejected."
+msgstr "Gazda virtuală solicitată de dumneavoastră a fost respinsă."
+
+#, c-format
+msgid "Your requested vhost has been rejected. Reason: %s"
+msgstr "Gazda virtuală solicitată de dumneavoastră a fost respinsă. Motivul: %s"
+
+msgid "Your requested vhost has been validated via DNS."
+msgstr "Gazda virtuală solicitată de dumneavoastră a fost validată prin DNS."
+
+#, c-format
+msgid "Your vhost %s has been requested."
+msgstr "Gazda virtuală %s a fost solicitată pentru dumneavoastră."
+
+#, c-format
+msgid "Your vhost %s has been requested. If the requested vhost is for a valid DNS name you can add a TXT record for %s with the value %s and automatically approve your vhost using %s."
+msgstr "Gazda virtuală %s a fost solicitată pentru dumneavoastră. Dacă gazda virtuală solicitată este pentru un nume DNS valid, puteți adăuga o înregistrare TXT pentru %s cu valoarea %s și puteți aproba automat gazda virtuală folosind %s."
+
+#, c-format
+msgid "Your vhost of %s is now activated."
+msgstr "Gazda virtuală %s a dumneavoastră a fost activată."
+
+msgid "Your vhost was removed and the normal cloaking restored."
+msgstr "Gazda virtuală a dumneavoastră a fost dezactivată și camuflajul normal a fost restabilit."
+
+msgid "Zone"
+msgstr "Zonă"
+
+#, c-format
+msgid "Zone %s already exists."
+msgstr "Zona %s există deja."
+
+#, c-format
+msgid "Zone %s does not exist."
+msgstr "Zona %s nu există."
+
+#, c-format
+msgid "Zone %s removed."
+msgstr "Zona %s a fost înlăturată."
+
+msgid "Zone: {zone}"
+msgstr "Zona: {zone}"
+
+msgid "Zone: {zone} = {servers}"
+msgstr "Zona: {zone} = {servers}"
+
+msgid "[1|2|3|4|5]"
+msgstr "[1|2|3|4|5]"
+
+#, c-format
+msgid "[Logon News - %s] %s"
+msgstr "[Știri la Conectare - %s] %s"
+
+#, c-format
+msgid "[Logon News] %s"
+msgstr "[Știri la Conectare] %s"
+
+#, c-format
+msgid "[Oper News - %s] %s"
+msgstr "[Știri la Operare - %s] %s"
+
+#, c-format
+msgid "[Oper News] %s"
+msgstr "[Știri la Operare] %s"
+
+#, c-format
+msgid "[Random News - %s] %s"
+msgstr "[Știri Aleatorii - %s] %s"
+
+#, c-format
+msgid "[Random News] %s"
+msgstr "[Știri Aleatorii] %s"
+
+msgid "[account] password"
+msgstr "[cont] parolă"
+
+msgid "[channel [nick]]"
+msgstr "[canal [pseudonim]]"
+
+msgid "[channel] ADD entry"
+msgstr "[canal] ADD intrare"
+
+msgid "[channel] DEL entry"
+msgstr "[canal] DEL intrare"
+
+msgid "[channel] LIST"
+msgstr "[canal] LIST"
+
+msgid "[channel] [list | NEW]"
+msgstr "[canal] [listă | NEW]"
+
+msgid "[channel] [nick]"
+msgstr "[canal] [pseudonim]"
+
+msgid "[channel] {num | list | LAST | ALL}"
+msgstr "[canal] {număr | listă | LAST | ALL}"
+
+msgid "[channel] {num | list | LAST | NEW | ALL}"
+msgstr "[canal] {număr | listă | LAST | NEW | ALL}"
+
+msgid "[key|#X-Y]"
+msgstr "[cheie|#X-Y]"
+
+msgid "[message]"
+msgstr "[mesaj]"
+
+msgid "[nick | channel]"
+msgstr "[pseudonim | canal]"
+
+msgid "[nick]"
+msgstr "[pseudonim]"
+
+msgid "[nickname [REVALIDATE]]"
+msgstr "[pseudonim [REVALIDATE]]"
+
+msgid "[nickname]"
+msgstr "[pseudonim]"
+
+msgid "[nickname] code"
+msgstr "[pseudonim] cod"
+
+msgid "[parameter]"
+msgstr "[parametru]"
+
+msgid "[+daysd] [+limitl] pattern"
+msgstr "[+ziled] [+limităl] model"
+
+msgid "[+expiry] channel reason"
+msgstr "[+expirare] canal motiv"
+
+msgid "[Hostname hidden]"
+msgstr "[Numele de gazdă ascuns]"
+
+msgid "[Suspended]"
+msgstr "[Suspendat]"
+
+msgid "[Unconfirmed]"
+msgstr "[Neconfirmat]"
+
+msgid "[{pattern | channel} [INVISIBLE]]"
+msgstr "[{model | canal} [INVISIBLE]]"
+
+msgid "[{pattern | nick} [SECRET]]"
+msgstr "[{model | pseudonim} [SECRET]]"
+
+msgid "does not expire"
+msgstr "nu exipiră"
+
+#, c-format
+msgid "expires in %s"
+msgstr "expiră în %s"
+
+msgid "expires momentarily"
+msgstr "expiră momentan"
+
+#, c-format
+msgid "letters: %s, words: %s, lines: %s, smileys: %s, actions: %s"
+msgstr "litere: %s, cuvinte: %s, linii: %s, zâmbete: %s, acțiuni: %s"
+
+msgid "not assigned yet"
+msgstr "încă neasociat"
+
+msgid "vhost"
+msgstr "gazdă virtuală"
+
+msgid "{MODIFY|VIEW} [block name item name item value]"
+msgstr "{MODIFY|VIEW} [nume bloc nume element valoare element]"
+
+msgid "{channel | nickname}"
+msgstr "{canal | pseudonim}"
+
+msgid "{nick | channel}"
+msgstr "{pseudonim | canal}"
+
+msgid "{nick | channel} memo-text"
+msgstr "{pseudonim | canal} text-misivă"
+
+msgid "{ON | delay | OFF}"
+msgstr "{ON | întârziere | OFF}"
+
+msgid "{mode} -- created by {creator} on {created}"
+msgstr "{mode} -- creat de {creator} pe {created}"
+
+msgid "{mode} {param} -- created by {creator} on {created}"
+msgstr "{mode} {param} -- creat de {creator} pe {created}"
+
+msgid "{number}: {channel}"
+msgstr "{number}: {channel}"
+
+msgid "{number}: {channel} (key: {key})"
+msgstr "{number}: {channel} (cheie: {key})"
+
+msgid "{number}: {channel} = {access}"
+msgstr "{number}: {channel} = {access}"
+
+msgid "{number}: {channel} = {access} ({description})"
+msgstr "{number}: {channel} = {access} ({description})"
+
+msgid "{number}: {mask}"
+msgstr "{number}: {mask}"
+
+msgid "{number}: {mask} ({description})"
+msgstr "{number}: {mask} ({description})"
+
+msgid "{number}: {mask} ({reason})"
+msgstr "{number}: {mask} ({reason})"
+
+msgid "{number}: {mask} -- added by {creator} on {created}; last used: {last_used}"
+msgstr "{number}: {mask} -- adăugat de {creator} pe {created}; ultima utilizare: {last_used}"
+
+msgid "{number}: {mask} -- added by {creator} on {created}; last used: {last_used} ({reason})"
+msgstr "{number}: {mask} -- adăugat de {creator} pe {created}; ultima utilizare: {last_used} ({reason})"
+
+msgid "{number}: {mask} -- created by {creator} on {created}; {expires} ({reason})"
+msgstr "{number}: {mask} -- creat de {creator} pe {created}; {expires} ({reason})"
+
+msgid "{number}: {mask} -- {limit} sessions ({reason})"
+msgstr "{number}: {mask} -- {limit} sesiuni ({reason})"
+
+msgid "{number}: {mask} -- {limit} sessions; created by {creator} on {created}; {expires} ({reason})"
+msgstr "{number}: {mask} -- {limit} sesiuni; creat de {creator} pe {created}; {expires} ({reason})"
+
+msgid "{number}: {mask} = {flags} -- added by {creator} at {created}"
+msgstr "{number}: {mask} = {flags} -- adăugat de {creator} la {created}"
+
+msgid "{number}: {mask} = {flags} -- added by {creator} at {created} ({description})"
+msgstr "{number}: {mask} = {flags} -- adăugat de {creator} la {created} ({description})"
+
+msgid "{number}: {mask} = {level}"
+msgstr "{number}: {mask} = {level}"
+
+msgid "{number}: {mask} = {level} ({description})"
+msgstr "{number}: {mask} = {level} ({description})"
+
+msgid "{number}: {mask} = {level} -- created by {creator}; last seen {last_seen}"
+msgstr "{number}: {mask} = {level} -- creat de {creator}; ultima dată văzut {last_seen}"
+
+msgid "{number}: {mask} = {level} -- created by {creator}; last seen {last_seen} ({description})"
+msgstr "{number}: {mask} = {level} -- creat de {creator}; ultima dată văzut {last_seen} ({description})"
+
+msgid "{number}: {nick} = {vhost} -- created by {creator} at {created}"
+msgstr "{number}: {nick} = {vhost} -- creat de {creator} la {created}"
+
+msgid "{number}: {word} -- type: {type}"
+msgstr "{number}: {word} -- tip: {type}"
+
+msgid "{number}: [{id}] {mask} -- created by {creator} on {created}; {expires} ({reason})"
+msgstr "{number}: [{id}] {mask} -- creat de {creator} pe {created}; {expires} ({reason})"
+
+msgid "{number}: sent by {sender} at {date/time}"
+msgstr "{number}: trimis de {sender} la {date/time}"
+
+msgid "{number}: {command} on {service}: {method}"
+msgstr "{number}: {command} pe {service}: {method}"
+
+msgid "{number}: {message}"
+msgstr "{number}: {message}"
+
+msgid "{number}: {message} -- created by {creator} at {created}"
+msgstr "{number}: {message} -- creat de {creator} la {created}"
+
+msgid "{number}: {text} -- created by {creator} on {created}"
+msgstr "{number}: {text} -- creat de {creator} pe {created}"


### PR DESCRIPTION
## Summary

I made a translation into Romanian language. I am still evaluating it for possible issues, but at first few checks it looks great.

## Rationale

Romania is a country using IRC since 1998, most popular over Undernet. To this day some Romanians still love to use IRC, but unfortunately they can't move on from the environment of 500 levels of access. Since Romanian language was available on that IRCd services from early years, I believe it strongly contributed to that network's popularity. This is why I try to help Anope grow, and because I also never liked Undernet anyway.

## Testing Environment

I tested this on the latest version of Anope from GitHub, in latest InspIRCD.

OS: Debian 12 Bookworm

## Checks

I have ensured that:

- [x] The Romanian translation I am submitting is my own work.
- [x] Generative AI (Copilot, ChatGPT, etc) was NOT used to create any part of this pull request.
- [x] I have adjusted any meanings in Romanian added by this pull request, fully aware of the old latin expression "traduttore traditore".