### PR TITLE
Enhance Atheme database import functionality

### DIFF
--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -1086,6 +1086,16 @@ mail
 	database = "atheme.db"
 
 	/*
+	 * Irrelevant Atheme NickServ falgs to silently ignore.
+	 */
+	ns_ignore_flags = "b"
+
+	/*
+	 * Irrelevant Atheme ChanServ falgs to silently ignore.
+	 */
+	cs_ignore_flags = "v"
+
+	/*
 	 * If you have custom data in your Atheme database that you want converted
 	 * to Anope misc data to be shown with cs_set_misc you can configure that
 	 * using one or more cs_set_misc blocks.

--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -1086,16 +1086,6 @@ mail
 	database = "atheme.db"
 
 	/*
-	 * Irrelevant Atheme NickServ falgs to silently ignore.
-	 */
-	ns_ignore_flags = "b"
-
-	/*
-	 * Irrelevant Atheme ChanServ falgs to silently ignore.
-	 */
-	cs_ignore_flags = "v"
-
-	/*
 	 * If you have custom data in your Atheme database that you want converted
 	 * to Anope misc data to be shown with cs_set_misc you can configure that
 	 * using one or more cs_set_misc blocks.

--- a/include/modules/nickserv/ajoin.h
+++ b/include/modules/nickserv/ajoin.h
@@ -1,0 +1,47 @@
+// Anope IRC Services <https://www.anope.org/>
+//
+// Copyright (C) 2003-2026 Anope Contributors
+//
+// Anope is free software. You can use, modify, and/or distribute it under the
+// terms of version 2 of the GNU General Public License. See docs/LICENSE.txt
+// for the complete terms of this license and docs/AUTHORS.txt for a list of
+// contributors.
+//
+// Based on the original code of Epona by Lara
+// Based on the original code of Services by Andy Church
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#define NICKSERV_AJOIN_LIST_EXT "ajoinlist"
+
+struct AJoinEntry;
+
+struct AJoinList
+	: Serialize::Checker<std::vector<AJoinEntry *> >
+{
+	AJoinList(Extensible *) : Serialize::Checker<std::vector<AJoinEntry *> >("AJoinEntry") { }
+	virtual ~AJoinList() = default;
+};
+
+struct AJoinEntry final
+	: Serializable
+{
+	Serialize::Reference<NickCore> owner;
+	Anope::string channel;
+	Anope::string key;
+
+	AJoinEntry(Extensible *) : Serializable("AJoinEntry") { }
+
+	~AJoinEntry() override
+	{
+		auto *channels = owner->GetExt<AJoinList>(NICKSERV_AJOIN_LIST_EXT);
+		if (channels)
+		{
+			auto it = std::find((*channels)->begin(), (*channels)->end(), this);
+			if (it != (*channels)->end())
+				(*channels)->erase(it);
+		}
+	}
+};

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <algorithm>
 
 #include "module.h"
 #include "modules/botserv/badwords.h"
@@ -21,6 +22,7 @@
 #include "modules/chanserv/mode.h"
 #include "modules/hostserv/request.h"
 #include "modules/info.h"
+#include "modules/nickserv/ajoin.h"
 #include "modules/nickserv/cert.h"
 #include "modules/operserv/forbid.h"
 #include "modules/operserv/news.h"
@@ -135,6 +137,7 @@ struct ChannelData final
 
 struct UserData final
 {
+	Anope::string ajoins;
 	Anope::string info_adder;
 	Anope::string info_message;
 	time_t info_ts = 0;
@@ -172,6 +175,8 @@ private:
 	ServiceReference<XLineManager> sqlinemgr;
 	Anope::map<Anope::string> csmiscdata;
 	Anope::map<Anope::string> nsmiscdata;
+	Anope::string csignoreflags;
+	Anope::string nsignoreflags;
 
 	Anope::map<std::function<bool(DBAtheme*,AthemeRow&)>> rowhandlers = {
 		{ "AC",         &DBAtheme::HandleIgnore    },
@@ -236,21 +241,40 @@ private:
 		{ "XL",         &DBAtheme::HandleXL        },
 	};
 
-	void ApplyAccess(Anope::string &in, char flag, Anope::string &out, std::initializer_list<const char*> privs)
+	static bool removeFirstOccurance(Anope::string& in, char c)
 	{
-		for (const auto *priv : privs)
+		auto pos = in.find(c);
+		if (pos != Anope::string::npos)
 		{
-			auto pos = in.find(flag);
-			if (pos != Anope::string::npos)
+			in.erase(pos, 1);
+			return true;
+		}
+		return false;
+	}
+
+	static void removeAll(Anope::string& in, const Anope::string& unwanted)
+	{
+		auto it = std::remove_if(in.begin(), in.end(), [&](char c){
+			return unwanted.find_first_of(c) != unwanted.npos;
+		});
+		in.erase(it, in.end());
+	}
+
+	bool ApplyAccess(Anope::string &in, char flag, Anope::string &out, std::initializer_list<const char*> privs)
+	{
+		const bool flagFound = removeFirstOccurance(in, flag);
+		if (flagFound)
+		{
+			for (const auto *priv : privs)
 			{
 				auto privchar = flags.find(priv);
 				if (privchar != flags.end())
 				{
 					out.push_back(privchar->second);
-					in.erase(pos, 1);
 				}
 			}
 		}
+		return flagFound;
 	}
 
 	void ApplyFlags(Extensible *ext, Anope::string &flags, char flag, const char *extname, bool extend = true)
@@ -612,7 +636,7 @@ private:
 		auto *nc = NickCore::Find(mask);
 		if (flags.find('b') != Anope::string::npos)
 		{
-			if (ChanServ::akick_service)
+			if (!ChanServ::akick_service)
 			{
 				Log(this) << "Unable to import channel akick for " << ci->name << " as cs_akick is not loaded";
 				return true;
@@ -638,7 +662,6 @@ private:
 		ApplyAccess(flags, 'a', accessflags, { "AUTOPROTECT", "PROTECT", "PROTECTME" });
 		ApplyAccess(flags, 'e', accessflags, { "GETKEY", "NOKICK", "UNBANME" });
 		ApplyAccess(flags, 'f', accessflags, { "ACCESS_CHANGE" });
-		ApplyAccess(flags, 'F', accessflags, { "FOUNDER" });
 		ApplyAccess(flags, 'H', accessflags, { "AUTOHALFOP" });
 		ApplyAccess(flags, 'h', accessflags, { "HALFOP", "HALFOPME" });
 		ApplyAccess(flags, 'i', accessflags, { "INVITE" });
@@ -650,6 +673,14 @@ private:
 		ApplyAccess(flags, 't', accessflags, { "TOPIC" });
 		ApplyAccess(flags, 'V', accessflags, { "AUTOVOICE" });
 		ApplyAccess(flags, 'v', accessflags, { "VOICE", "VOICEME" });
+		if (ApplyAccess(flags, 'F', accessflags, { "FOUNDER" }))
+		{
+			// Atheme allows multiple coequal founders. Anope takes a Highlander approach. First one found wins.
+			if (nc && !ci->GetFounder())
+			{
+				ci->SetFounder(nc);
+			}
+		}
 		if (!accessflags.empty())
 		{
 			auto *access = accessprov->Create();
@@ -660,6 +691,21 @@ private:
 			access->created = modifiedtime;
 			access->AccessUnserialize(accessflags);
 			ci->AddAccess(access);
+		}
+		// 'S' flag is the successor, but it's not always used. 'R' flag roughly corresponds otherwise.
+		if (removeFirstOccurance(flags, 'S') && ci->GetFounder() != nc)
+		{
+			if (NickCore* oldSuccessor = ci->GetSuccessor())
+			{
+				Log(this) << "Changing successor for " << ci->name << " from " << oldSuccessor->display
+					<< " to " << nc->display << " based on +S flag";
+			}
+			ci->SetSuccessor(nc);
+		}
+		if (removeFirstOccurance(flags, 'R') && ci->GetFounder() != nc && ! ci->GetSuccessor() )
+		{
+			Log(this) << "Setting successor for " << ci->name << " to " << nc->display << " based on +R flag";
+			ci->SetSuccessor(nc);
 		}
 
 		if (flags != "+")
@@ -788,7 +834,7 @@ private:
 			return true;
 		}
 
-		auto *xl = new XLine(user + "@" + host, setby, settime + duration, reason);
+		auto *xl = new XLine(user + "@" + host, setby, duration ? settime + duration : 0, reason);
 		xl->id = id;
 		sglinemgr->AddXLine(xl);
 		return true;
@@ -879,6 +925,7 @@ private:
 		ci->last_used = used;
 
 		// No equivalent: elnv
+		removeAll(flags, csignoreflags);
 		ApplyFlags(ci, flags, 'h', "CS_NO_EXPIRE");
 		ApplyFlags(ci, flags, 'k', "KEEPTOPIC");
 		ApplyFlags(ci, flags, 'o', "NOAUTOOP");
@@ -984,6 +1031,10 @@ private:
 			auto akick = data->akicks.find(mask);
 			if (akick != data->akicks.end())
 				akick->second->reason = value;
+		}
+		else if (key == "expires")
+		{
+			Log(this) << "Unable to set access expiration for " << mask << " on " << ci->name << ": unimplemented";
 		}
 		else
 			Log(this) << "Unknown channel access metadata for " << mask << " on " << ci->name << ": " << key << " = " << value;
@@ -1149,7 +1200,14 @@ private:
 		auto value = row.GetRemaining();
 
 		if (!row)
+		{
+			if (key == "private:lastquit:message")
+			{
+				Log(this) << "Ignoring empty last quit message for MDU: " << display;
+				return true;
+			}
 			return row.LogError(this);
+		}
 
 		auto *nc = NickCore::Find(display);
 		if (!nc)
@@ -1160,7 +1218,7 @@ private:
 
 		auto *data = userdata.Require(nc);
 		if (key == "private:autojoin")
-			return true; // TODO
+			data->ajoins = value;
 		else if (key == "private:doenforce")
 			data->protect = true;
 		else if (key == "private:enforcetime")
@@ -1189,6 +1247,12 @@ private:
 			data->info_adder = value;
 		else if (key == "private:mark:timestamp")
 			data->info_ts = Anope::Convert<time_t>(value, 0);
+		else if (key == "private:sendpass:sender")
+			return HandleIgnoreMetadata(nc->display, key, value);
+		else if (key == "private:sendpass:timestamp")
+			return HandleIgnoreMetadata(nc->display, key, value);
+		else if (key == "private:setpass:key")
+			return HandleIgnoreMetadata(nc->display, key, value);
 		else if (key == "private:swhois")
 			return HandleIgnoreMetadata(nc->display, key, value);
 		else if (key == "private:usercloak")
@@ -1410,6 +1474,7 @@ private:
 		ApplyPassword(nc, flags, pass);
 
 		// No equivalent: bglmNQrS
+		removeAll(flags, nsignoreflags);
 		ApplyFlags(nc, flags, 'E', "PROTECT");
 		ApplyFlags(nc, flags, 'e', "MEMO_MAIL");
 		ApplyFlags(nc, flags, 'n', "NEVEROP");
@@ -1583,6 +1648,9 @@ public:
 	{
 		const auto &modconf = conf.GetModule(this);
 
+		nsignoreflags = modconf.Get<const Anope::string>("ns_ignore_flags", "");
+		csignoreflags = modconf.Get<const Anope::string>("cs_ignore_flags", "");
+
 		csmiscdata.clear();
 		for (auto idx = 0; idx < modconf.CountBlock("cs_set_misc"); ++idx)
 		{
@@ -1691,6 +1759,60 @@ public:
 			auto *data = userdata.Get(nc);
 			if (!data)
 				continue;
+
+			if (!data->ajoins.empty())
+			{
+				auto *channels = nc->Require<AJoinList>(NICKSERV_AJOIN_LIST_EXT);
+				if (channels)
+				{
+					commasepstream entries(data->ajoins);
+					Anope::string entry;
+					while (entries.GetToken(entry))
+					{
+						spacesepstream atheme_ajoin_entry(entry);
+						Anope::string channel, key;
+						bool has_key = atheme_ajoin_entry.GetToken(channel);
+						if (has_key)
+						{
+							atheme_ajoin_entry.GetToken(key);
+							Channel *c = Channel::Find(channel);
+							Anope::string k;
+							if (c && c->GetParam("KEY", k) && key != k)
+							{
+								Log(this) << "Skipping ajoin with incorrect key for channel " << channel 
+									<< ", user " << nc->display;
+								continue;
+							}
+						}
+
+						if (!IRCD->IsChannelValid(channel))
+						{
+							Log(this) << "Invalid ajoin channel" << channel << " for " << nc->display;
+						}
+						else
+						{
+							const auto it = std::find_if((*channels)->cbegin(), (*channels)->cend(), [&](const AJoinEntry* a){
+								return a->channel == channel;
+							});
+
+							if (it != (*channels)->cend())
+							{
+								Log(this) << "Skipping duplicate ajoin channel" << channel << " for " << nc->display;
+								continue;
+							}
+							auto* entry = new AJoinEntry(nc);
+							entry->owner = nc;
+							entry->channel = channel;
+							entry->key = key;
+							(*channels)->push_back(entry); // ignore ajoinmax for non-disruptive migration
+						}
+					}
+				}
+				else
+				{
+					Log(this) << "Unable to convert autojoins for " << nc->display << " as ns_ajoin is not loaded";
+				}
+			}
 
 			if (!data->info_message.empty())
 			{

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1564,7 +1564,7 @@ private:
 			return true;
 		}
 
-		auto *xl = new XLine(nick, setby, settime + duration, reason);
+		auto *xl = new XLine(nick, setby, duration ? settime + duration : 0, reason);
 		xl->id = id;
 		sqlinemgr->AddXLine(xl);
 		return true;
@@ -1626,7 +1626,7 @@ private:
 			return true;
 		}
 
-		auto *xl = new XLine(real, setby, settime + duration, reason);
+		auto *xl = new XLine(real, setby, duration ? settime + duration : 0, reason);
 		xl->id = id;
 		snlinemgr->AddXLine(xl);
 		return true;

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -282,7 +282,7 @@ private:
 			in.erase(it, in.end());
 	}
 
-	static bool RemoveFirstOccurance(Anope::string& in, char c)
+	static bool RemoveFirstOccurrence(Anope::string& in, char c)
 	{
 		auto pos = in.find(c);
 		if (pos != Anope::string::npos)
@@ -295,8 +295,8 @@ private:
 
 	bool ApplyAccess(Anope::string &in, char flag, Anope::string &out, std::initializer_list<const char*> privs)
 	{
-		const bool flagFound = RemoveFirstOccurance(in, flag);
-		if (flagFound)
+		const bool flag_found = RemoveFirstOccurrence(in, flag);
+		if (flag_found)
 		{
 			for (const auto *priv : privs)
 			{
@@ -307,7 +307,7 @@ private:
 				}
 			}
 		}
-		return flagFound;
+		return flag_found;
 	}
 
 	void ApplyFlags(Extensible *ext, Anope::string &flags, char flag, const char *extname, bool extend = true)
@@ -720,7 +720,7 @@ private:
 		}
 
 		// Atheme allows multiple founders and picks a successor based on rank if one is not explicitly assigned.
-		bool is_founder_candidate = RemoveFirstOccurance(flags, 'F');
+		bool is_founder_candidate = RemoveFirstOccurrence(flags, 'F');
 		RemoveAll(flags, "SR");
 
 		FounderSuccessorCandidate current_candidate(nc, originalflags, modifiedtime);
@@ -965,7 +965,7 @@ private:
 		ci->last_used = used;
 
 		// No equivalent: elnv
-		RemoveFirstOccurance(flags, 'v'); // verbose, com
+		RemoveFirstOccurrence(flags, 'v'); // verbose, com
 		ApplyFlags(ci, flags, 'h', "CS_NO_EXPIRE");
 		ApplyFlags(ci, flags, 'k', "KEEPTOPIC");
 		ApplyFlags(ci, flags, 'o', "NOAUTOOP");
@@ -1514,7 +1514,7 @@ private:
 		ApplyPassword(nc, flags, pass);
 
 		// No equivalent: bglmNQrS
-		RemoveFirstOccurance(flags, 'b'); // nick b flag is ephemeral, ignore
+		RemoveFirstOccurrence(flags, 'b'); // nick b flag is ephemeral, ignore
 		ApplyFlags(nc, flags, 'E', "PROTECT");
 		ApplyFlags(nc, flags, 'e', "MEMO_MAIL");
 		ApplyFlags(nc, flags, 'n', "NEVEROP");

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -122,6 +122,39 @@ struct ModeLockData final
 	}
 };
 
+struct FounderSuccessorCandidate
+{
+	// Flags ranked from founder down, for founder/successor candidates
+	static const Anope::string FLAG_PRIORITY;
+
+	NickCore* nc;
+	size_t priority;
+	time_t mtime;
+
+	FounderSuccessorCandidate()
+		: nc(nullptr)
+		, priority(99) // arbitrary; for log readability
+		, mtime(std::numeric_limits<std::time_t>::max())
+	{
+	}
+
+	FounderSuccessorCandidate(NickCore *c, const Anope::string &flags, time_t m)
+		: nc(c)
+		, priority(FLAG_PRIORITY.find_first_of(flags))
+		, mtime(m)
+	{
+	}
+
+	bool operator<(const FounderSuccessorCandidate& other)
+	{
+		return std::tie(priority, mtime) < std::tie(other.priority, other.mtime);
+	}
+
+	FounderSuccessorCandidate& operator=(const FounderSuccessorCandidate& other) = default;
+};
+
+const Anope::string FounderSuccessorCandidate::FLAG_PRIORITY = "FSRsaOoHh";
+
 struct ChannelData final
 {
 	Anope::unordered_map<ChanServ::AutoKick *> akicks;
@@ -133,11 +166,13 @@ struct ChannelData final
 	Anope::string suspend_by;
 	Anope::string suspend_reason;
 	time_t suspend_ts = 0;
+	FounderSuccessorCandidate founder_candidate;
+	FounderSuccessorCandidate successor_candidate;
 };
 
 struct UserData final
 {
-	Anope::string ajoins;
+	Anope::map<Anope::string> ajoins;
 	Anope::string info_adder;
 	Anope::string info_message;
 	time_t info_ts = 0;
@@ -175,8 +210,6 @@ private:
 	ServiceReference<XLineManager> sqlinemgr;
 	Anope::map<Anope::string> csmiscdata;
 	Anope::map<Anope::string> nsmiscdata;
-	Anope::string csignoreflags;
-	Anope::string nsignoreflags;
 
 	Anope::map<std::function<bool(DBAtheme*,AthemeRow&)>> rowhandlers = {
 		{ "AC",         &DBAtheme::HandleIgnore    },
@@ -241,6 +274,14 @@ private:
 		{ "XL",         &DBAtheme::HandleXL        },
 	};
 
+	static void removeAll(Anope::string& in, const Anope::string& unwanted)
+	{
+			auto it = std::remove_if(in.begin(), in.end(), [&](char c){
+					return unwanted.find_first_of(c) != unwanted.npos;
+			});
+			in.erase(it, in.end());
+	}
+
 	static bool removeFirstOccurance(Anope::string& in, char c)
 	{
 		auto pos = in.find(c);
@@ -250,14 +291,6 @@ private:
 			return true;
 		}
 		return false;
-	}
-
-	static void removeAll(Anope::string& in, const Anope::string& unwanted)
-	{
-		auto it = std::remove_if(in.begin(), in.end(), [&](char c){
-			return unwanted.find_first_of(c) != unwanted.npos;
-		});
-		in.erase(it, in.end());
 	}
 
 	bool ApplyAccess(Anope::string &in, char flag, Anope::string &out, std::initializer_list<const char*> privs)
@@ -633,6 +666,8 @@ private:
 			return false;
 		}
 
+		auto *data = chandata.Require(ci);
+
 		auto *nc = NickCore::Find(mask);
 		if (flags.find('b') != Anope::string::npos)
 		{
@@ -642,7 +677,6 @@ private:
 				return true;
 			}
 
-			auto *data = chandata.Require(ci);
 			if (nc)
 				data->akicks[mask] = ChanServ::akick_service->AddAKick(ci, setter, nc, "", modifiedtime, modifiedtime);
 			else
@@ -673,14 +707,6 @@ private:
 		ApplyAccess(flags, 't', accessflags, { "TOPIC" });
 		ApplyAccess(flags, 'V', accessflags, { "AUTOVOICE" });
 		ApplyAccess(flags, 'v', accessflags, { "VOICE", "VOICEME" });
-		if (ApplyAccess(flags, 'F', accessflags, { "FOUNDER" }))
-		{
-			// Atheme allows multiple coequal founders. Anope takes a Highlander approach. First one found wins.
-			if (nc && !ci->GetFounder())
-			{
-				ci->SetFounder(nc);
-			}
-		}
 		if (!accessflags.empty())
 		{
 			auto *access = accessprov->Create();
@@ -692,20 +718,33 @@ private:
 			access->AccessUnserialize(accessflags);
 			ci->AddAccess(access);
 		}
-		// 'S' flag is the successor, but it's not always used. 'R' flag roughly corresponds otherwise.
-		if (removeFirstOccurance(flags, 'S') && ci->GetFounder() != nc)
+
+		// Atheme allows multiple founders and picks a successor based on rank if one is not explicitly assigned.
+		removeAll(flags, "FSR"); 
+
+		FounderSuccessorCandidate current_candidate(nc, originalflags, modifiedtime);
+
+		if (nc && current_candidate < data->successor_candidate)
 		{
-			if (NickCore* oldSuccessor = ci->GetSuccessor())
+			if (current_candidate < data->founder_candidate)
 			{
-				Log(this) << "Changing successor for " << ci->name << " from " << oldSuccessor->display
-					<< " to " << nc->display << " based on +S flag";
+				Log(LOG_DEBUG_2) << ci->name << ": Demoting founder candidate ("
+					<< ( data->founder_candidate.nc ? data->founder_candidate.nc->display : "DEFAULT" )
+					<< ", " << data->founder_candidate.priority
+					<< ") to successor; replacing with (" << current_candidate.nc->display
+					<< ", " << current_candidate.priority << ")";
+				data->successor_candidate = data->founder_candidate;
+				data->founder_candidate = current_candidate;
 			}
-			ci->SetSuccessor(nc);
-		}
-		if (removeFirstOccurance(flags, 'R') && ci->GetFounder() != nc && ! ci->GetSuccessor() )
-		{
-			Log(this) << "Setting successor for " << ci->name << " to " << nc->display << " based on +R flag";
-			ci->SetSuccessor(nc);
+			else
+			{
+				Log(LOG_DEBUG_2) << ci->name << ": Replacing successor candidate ("
+					<< ( data->successor_candidate.nc ? data->successor_candidate.nc->display : "DEFAULT" )
+					<< ", " << data->successor_candidate.priority
+					<< ") with (" << current_candidate.nc->display
+					<< ", " << current_candidate.priority << ")";
+				data->successor_candidate = current_candidate;
+			}
 		}
 
 		if (flags != "+")
@@ -925,7 +964,7 @@ private:
 		ci->last_used = used;
 
 		// No equivalent: elnv
-		removeAll(flags, csignoreflags);
+		removeFirstOccurance(flags, 'v'); // verbose, com
 		ApplyFlags(ci, flags, 'h', "CS_NO_EXPIRE");
 		ApplyFlags(ci, flags, 'k', "KEEPTOPIC");
 		ApplyFlags(ci, flags, 'o', "NOAUTOOP");
@@ -1218,7 +1257,17 @@ private:
 
 		auto *data = userdata.Require(nc);
 		if (key == "private:autojoin")
-			data->ajoins = value;
+		{
+			commasepstream autojoins(value, true);
+			for (Anope::string autojoin; autojoins.GetToken(autojoin); )
+			{
+				spacesepstream entry(autojoin);
+				Anope::string cname, ckey;
+				if (entry.GetToken(cname))
+					entry.GetToken(ckey);
+				data->ajoins[cname] = ckey;
+			}
+		}
 		else if (key == "private:doenforce")
 			data->protect = true;
 		else if (key == "private:enforcetime")
@@ -1474,7 +1523,7 @@ private:
 		ApplyPassword(nc, flags, pass);
 
 		// No equivalent: bglmNQrS
-		removeAll(flags, nsignoreflags);
+		removeFirstOccurance(flags, 'b'); // nick b flag is ephemeral, ignore
 		ApplyFlags(nc, flags, 'E', "PROTECT");
 		ApplyFlags(nc, flags, 'e', "MEMO_MAIL");
 		ApplyFlags(nc, flags, 'n', "NEVEROP");
@@ -1648,9 +1697,6 @@ public:
 	{
 		const auto &modconf = conf.GetModule(this);
 
-		nsignoreflags = modconf.Get<const Anope::string>("ns_ignore_flags", "");
-		csignoreflags = modconf.Get<const Anope::string>("cs_ignore_flags", "");
-
 		csmiscdata.clear();
 		for (auto idx = 0; idx < modconf.CountBlock("cs_set_misc"); ++idx)
 		{
@@ -1765,16 +1811,10 @@ public:
 				auto *channels = nc->Require<AJoinList>(NICKSERV_AJOIN_LIST_EXT);
 				if (channels)
 				{
-					commasepstream entries(data->ajoins);
-					Anope::string entry;
-					while (entries.GetToken(entry))
+					for (const auto& [channel, key] : data->ajoins)
 					{
-						spacesepstream atheme_ajoin_entry(entry);
-						Anope::string channel, key;
-						bool has_key = atheme_ajoin_entry.GetToken(channel);
-						if (has_key)
+						if (!key.empty())
 						{
-							atheme_ajoin_entry.GetToken(key);
 							Channel *c = Channel::Find(channel);
 							Anope::string k;
 							if (c && c->GetParam("KEY", k) && key != k)
@@ -1787,7 +1827,7 @@ public:
 
 						if (!IRCD->IsChannelValid(channel))
 						{
-							Log(this) << "Invalid ajoin channel" << channel << " for " << nc->display;
+							Log(this) << "Invalid ajoin channel " << channel << " for " << nc->display;
 						}
 						else
 						{

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -124,7 +124,7 @@ struct ModeLockData final
 
 struct FounderSuccessorCandidate
 {
-	// Flags ranked from founder down, for founder/successor candidates
+	// Flags ranked from founder down, for successor candidate ranking
 	static const Anope::string FLAG_PRIORITY;
 
 	NickCore* nc;
@@ -720,16 +720,17 @@ private:
 		}
 
 		// Atheme allows multiple founders and picks a successor based on rank if one is not explicitly assigned.
-		RemoveAll(flags, "FSR");
+		bool is_founder_candidate = RemoveFirstOccurance(flags, 'F');
+		RemoveAll(flags, "SR");
 
 		FounderSuccessorCandidate current_candidate(nc, originalflags, modifiedtime);
 
 		if (nc && current_candidate < data->successor_candidate)
 		{
-			if (current_candidate < data->founder_candidate)
+			if (is_founder_candidate && current_candidate < data->founder_candidate)
 			{
-				Log(LOG_DEBUG_2) << ci->name << ": Demoting founder candidate ("
-					<< ( data->founder_candidate.nc ? data->founder_candidate.nc->display : "DEFAULT" )
+				Log(LOG_DEBUG) << ci->name << ": Demoting founder candidate ("
+					<< ( data->founder_candidate.nc ? data->founder_candidate.nc->display : "NONE" )
 					<< ", " << data->founder_candidate.priority
 					<< ") to successor; replacing with (" << current_candidate.nc->display
 					<< ", " << current_candidate.priority << ")";
@@ -738,8 +739,8 @@ private:
 			}
 			else
 			{
-				Log(LOG_DEBUG_2) << ci->name << ": Replacing successor candidate ("
-					<< ( data->successor_candidate.nc ? data->successor_candidate.nc->display : "DEFAULT" )
+				Log(LOG_DEBUG) << ci->name << ": Replacing successor candidate ("
+					<< ( data->successor_candidate.nc ? data->successor_candidate.nc->display : "NONE" )
 					<< ", " << data->successor_candidate.priority
 					<< ") with (" << current_candidate.nc->display
 					<< ", " << current_candidate.priority << ")";
@@ -1810,7 +1811,7 @@ public:
 							Anope::string k;
 							if (c && c->GetParam("KEY", k) && key != k)
 							{
-								Log(this) << "Skipping ajoin with incorrect key for channel " << channel 
+								Log(this) << "Skipping ajoin with incorrect key for channel " << channel
 									<< ", user " << nc->display;
 								continue;
 							}

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -75,10 +75,10 @@ public:
 	}
 
 	// Retrieves the remaining data in the row.
-	Anope::string GetRemaining()
+	Anope::string GetRemaining(bool allow_empty = false)
 	{
 		auto remaining = stream.GetRemaining();
-		if (remaining.empty())
+		if (remaining.empty() && !allow_empty)
 			error++;
 		return remaining;
 	}
@@ -159,15 +159,15 @@ struct ChannelData final
 {
 	Anope::unordered_map<ChanServ::AutoKick *> akicks;
 	Anope::string bot;
+	FounderSuccessorCandidate founder_candidate;
 	Anope::string info_adder;
 	Anope::string info_message;
 	time_t info_ts = 0;
 	std::vector<ModeLockData> mlocks;
+	FounderSuccessorCandidate successor_candidate;
 	Anope::string suspend_by;
 	Anope::string suspend_reason;
 	time_t suspend_ts = 0;
-	FounderSuccessorCandidate founder_candidate;
-	FounderSuccessorCandidate successor_candidate;
 };
 
 struct UserData final
@@ -274,7 +274,7 @@ private:
 		{ "XL",         &DBAtheme::HandleXL        },
 	};
 
-	static void removeAll(Anope::string& in, const Anope::string& unwanted)
+	static void RemoveAll(Anope::string& in, const Anope::string& unwanted)
 	{
 			auto it = std::remove_if(in.begin(), in.end(), [&](char c){
 					return unwanted.find_first_of(c) != unwanted.npos;
@@ -282,7 +282,7 @@ private:
 			in.erase(it, in.end());
 	}
 
-	static bool removeFirstOccurance(Anope::string& in, char c)
+	static bool RemoveFirstOccurance(Anope::string& in, char c)
 	{
 		auto pos = in.find(c);
 		if (pos != Anope::string::npos)
@@ -295,7 +295,7 @@ private:
 
 	bool ApplyAccess(Anope::string &in, char flag, Anope::string &out, std::initializer_list<const char*> privs)
 	{
-		const bool flagFound = removeFirstOccurance(in, flag);
+		const bool flagFound = RemoveFirstOccurance(in, flag);
 		if (flagFound)
 		{
 			for (const auto *priv : privs)
@@ -720,7 +720,7 @@ private:
 		}
 
 		// Atheme allows multiple founders and picks a successor based on rank if one is not explicitly assigned.
-		removeAll(flags, "FSR"); 
+		RemoveAll(flags, "FSR");
 
 		FounderSuccessorCandidate current_candidate(nc, originalflags, modifiedtime);
 
@@ -964,7 +964,7 @@ private:
 		ci->last_used = used;
 
 		// No equivalent: elnv
-		removeFirstOccurance(flags, 'v'); // verbose, com
+		RemoveFirstOccurance(flags, 'v'); // verbose, com
 		ApplyFlags(ci, flags, 'h', "CS_NO_EXPIRE");
 		ApplyFlags(ci, flags, 'k', "KEEPTOPIC");
 		ApplyFlags(ci, flags, 'o', "NOAUTOOP");
@@ -1236,17 +1236,7 @@ private:
 		// MDU <display> <key> <value>
 		auto display = row.Get();
 		auto key = row.Get();
-		auto value = row.GetRemaining();
-
-		if (!row)
-		{
-			if (key == "private:lastquit:message")
-			{
-				Log(this) << "Ignoring empty last quit message for MDU: " << display;
-				return true;
-			}
-			return row.LogError(this);
-		}
+		auto value = row.GetRemaining(true);
 
 		auto *nc = NickCore::Find(display);
 		if (!nc)
@@ -1523,7 +1513,7 @@ private:
 		ApplyPassword(nc, flags, pass);
 
 		// No equivalent: bglmNQrS
-		removeFirstOccurance(flags, 'b'); // nick b flag is ephemeral, ignore
+		RemoveFirstOccurance(flags, 'b'); // nick b flag is ephemeral, ignore
 		ApplyFlags(nc, flags, 'E', "PROTECT");
 		ApplyFlags(nc, flags, 'e', "MEMO_MAIL");
 		ApplyFlags(nc, flags, 'n', "NEVEROP");

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1811,8 +1811,9 @@ public:
 				auto *channels = nc->Require<AJoinList>(NICKSERV_AJOIN_LIST_EXT);
 				if (channels)
 				{
-					for (const auto& [channel, key] : data->ajoins)
+					for (const auto& ajoin : data->ajoins)
 					{
+						auto &channel = ajoin.first, &key = ajoin.second;
 						if (!key.empty())
 						{
 							Channel *c = Channel::Find(channel);

--- a/modules/nickserv/ns_ajoin.cpp
+++ b/modules/nickserv/ns_ajoin.cpp
@@ -13,34 +13,15 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include "module.h"
+#include "modules/nickserv/ajoin.h"
 
-struct AJoinEntry;
-
-struct AJoinList final
-	: Serialize::Checker<std::vector<AJoinEntry *> >
+struct AJoinListImpl final : public AJoinList
 {
-	AJoinList(Extensible *) : Serialize::Checker<std::vector<AJoinEntry *> >("AJoinEntry") { }
-	~AJoinList();
-};
-
-struct AJoinEntry final
-	: Serializable
-{
-	Serialize::Reference<NickCore> owner;
-	Anope::string channel;
-	Anope::string key;
-
-	AJoinEntry(Extensible *) : Serializable("AJoinEntry") { }
-
-	~AJoinEntry() override
+	AJoinListImpl(Extensible * e) : AJoinList(e) { }
+	~AJoinListImpl()
 	{
-		auto *channels = owner->GetExt<AJoinList>("ajoinlist");
-		if (channels)
-		{
-			auto it = std::find((*channels)->begin(), (*channels)->end(), this);
-			if (it != (*channels)->end())
-				(*channels)->erase(it);
-		}
+		for (const auto *ajoin : *(*this))
+			delete ajoin;
 	}
 };
 
@@ -92,12 +73,6 @@ struct AJoinEntryType final
 		return aj;
 	}
 };
-
-AJoinList::~AJoinList()
-{
-	for (const auto *ajoin : *(*this))
-		delete ajoin;
-}
 
 class CommandNSAJoin final
 	: public Command
@@ -321,7 +296,7 @@ class NSAJoin final
 	: public Module
 {
 	CommandNSAJoin commandnsajoin;
-	ExtensibleItem<AJoinList> ajoinlist;
+	ExtensibleItem<AJoinListImpl> ajoinlist;
 	AJoinEntryType ajoinentry_type;
 
 public:


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary

Enhancements:
1. Add ajoin import support. This required a slight refactor of ajoin to expose some structures.
2. Add support for setting founders and advisors for imported channels. This is a bit rough due to how differently Atheme handles founders successors.
3. Ignore certain irrelevant flags when importing. 
4. Add log line for unimplemented akick expiration feature (which I hope to implement.)

Bug fixes:
1. ApplyAccess() was broken for Atheme flags associated with multiple Anope privs.
2. Akicks were only added if the module **wasn't** loaded.
3. Permanent X-lines expired immediately.

## Rationale

Atheme imports were missing important features, had bugs, and were excessively chatty about non-issues.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 24.04 under WSL
**Compiler name and version:** GCC 14.2.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [X] I have documented any features added by this pull request (delete if not applicable).
