### PR TITLE
Fix crash on exit when uplink lost and globaloncycledown set

### DIFF
--- a/modules/global/global.cpp
+++ b/modules/global/global.cpp
@@ -157,7 +157,7 @@ public:
 			this->ServerGlobal(sender, server, false, line);
 		else
 		{
-			auto uplink = Servers::GetUplink();
+			auto* uplink = Servers::GetUplink();
 			if (!uplink)
 				return false;
 			this->ServerGlobal(sender, uplink, true, line);

--- a/modules/global/global.cpp
+++ b/modules/global/global.cpp
@@ -156,7 +156,12 @@ public:
 		if (server)
 			this->ServerGlobal(sender, server, false, line);
 		else
-			this->ServerGlobal(sender, Servers::GetUplink(), true, line);
+		{
+			auto uplink = Servers::GetUplink();
+			if (!uplink)
+				return false;
+			this->ServerGlobal(sender, uplink, true, line);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary
Don't attempt to send a global notice when the uplink is unavailable

## Rationale
```
Program received signal SIGSEGV, Segmentation fault.
0x000055555568f0c0 in Server::IsJuped (this=0x0) at /home/kufat/gits/anope/src/servers.cpp:332
332             return juped;
(gdb) where
#0  0x000055555568f0c0 in Server::IsJuped (this=0x0) at /home/kufat/gits/anope/src/servers.cpp:332
#1  0x00007ffff6e32626 in GlobalCore::ServerGlobal (this=0x55555574a3f0, sender=0x555555792700, server=0x0, children=true, message=...)
    at /home/kufat/gits/anope/modules/global/global.cpp:28
#2  0x00007ffff6e33927 in GlobalCore::SendSingle (this=0x55555574a3f0, message=..., source=0x0, sender=0x555555792700, server=0x0)
    at /home/kufat/gits/anope/modules/global/global.cpp:159
#3  0x00007ffff6e331d6 in GlobalCore::OnShutdown (this=0x55555574a3f0) at /home/kufat/gits/anope/modules/global/global.cpp:92
#4  0x0000555555605415 in main (ac=2, av=0x7fffffffe2a8, envp=0x7fffffffe2c0) at /home/kufat/gits/anope/src/main.cpp:203
```
Crash on no uplink if globaloncycledown is set (tries to send the goodbye global, uplink is nullptr)

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Linux 5.10.102.1-microsoft-standard-WSL2/Ubuntu 24.04.4
**Compiler name and version:** g++ 14.2.0

## Checks


I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
