### PR TITLE
Implement chosen channel founder/successor for atheme DB import

### DIFF
--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1786,6 +1786,16 @@ public:
 				si.when = data->suspend_ts;
 				ci->Extend("CS_SUSPENDED", si);
 			}
+
+			if (data->founder_candidate.nc)
+			{
+				ci->SetFounder(data->founder_candidate.nc);
+			}
+
+			if (data->successor_candidate.nc)
+			{
+				ci->SetSuccessor(data->successor_candidate.nc);
+			}
 		}
 
 		for (const auto &[_, nc] : *NickCoreList)

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1788,14 +1788,10 @@ public:
 			}
 
 			if (data->founder_candidate.nc)
-			{
 				ci->SetFounder(data->founder_candidate.nc);
-			}
 
 			if (data->successor_candidate.nc)
-			{
 				ci->SetSuccessor(data->successor_candidate.nc);
-			}
 		}
 
 		for (const auto &[_, nc] : *NickCoreList)


### PR DESCRIPTION
## Summary
Set channel founder/successor based on channel ranks for Atheme import.

## Rationale
Previously added enhanced logic to choose a founder and successor for Atheme database imports. After refactoring, I re-validated the selection logic but not the actual end-to-end outcome.
<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Linux 5.10.102.1-microsoft-standard-WSL2/Ubuntu 24.04.4
**Compiler name and version:** g++ 14.2.0

## Checks

Fully tested (this time.)

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
