### PR TITLE
Handle weird corner case where user is 'logged in' as an alias

### DIFF
--- a/modules/protocol/inspircd.cpp
+++ b/modules/protocol/inspircd.cpp
@@ -1817,6 +1817,18 @@ private:
 			auto *nc = NickCore::Find(value);
 			if (nc)
 				u->Login(nc);
+			else
+			{
+				// Handle corner cases around database rollbacks/inconsistency and users
+				// whose display nick recently expired, causing an alias to become the
+				// display nick.
+				auto *na = NickAlias::Find(value);
+				if (na)
+				{
+					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
+					u->Identify(na);
+				}
+			}
 		}
 	}
 

--- a/modules/protocol/inspircd.cpp
+++ b/modules/protocol/inspircd.cpp
@@ -1814,20 +1814,26 @@ private:
 		{
 			// If we're bursting then then the user was probably logged in
 			// during a previous connection.
-			auto *nc = NickCore::Find(value);
-			if (nc)
+			auto *na = NickAlias::Find(value);
+			if (!na)
+			{
+				// Nick has been dropped, force the IRCd to deauth them.
+				IRCD->SendLogout(u);
+				return;
+			}
+
+			NickCore *nc = na->nc;
+			if (na == nc->na)
+			{
+				// User is logged into their display nick.
 				u->Login(nc);
+			}
 			else
 			{
-				// Handle corner cases around database rollbacks/inconsistency and users
-				// whose display nick recently expired, causing an alias to become the
-				// display nick.
-				auto *na = NickAlias::Find(value);
-				if (na)
-				{
-					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
-					u->Identify(na);
-				}
+				// User is logged into a non-display nick, their display has
+				// probably expired due to a config change so reauthenticate
+				// them as their new display nick.
+				u->Identify(nc->na);
 			}
 		}
 	}

--- a/modules/protocol/ngircd.cpp
+++ b/modules/protocol/ngircd.cpp
@@ -329,22 +329,29 @@ struct IRCDMessageMetadata final
 		}
 		if (params[1].equals_cs("accountname"))
 		{
-			NickCore *nc = NickCore::Find(params[2]);
-			if (nc)
-				u->Login(nc);
-			else
+			// If we're bursting then then the user was probably logged in
+			// during a previous connection.
+			auto *na = NickAlias::Find(params[2]);
+			if (!na)
 			{
-				// Handle corner cases around database rollbacks/inconsistency and users
-				// whose display nick recently expired, causing an alias to become the
-				// display nick.
-				auto *na = NickAlias::Find(params[2]);
-				if (na)
-				{
-					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
-					u->Identify(na);
-				}
+				// Nick has been dropped, force the IRCd to deauth them.
+				IRCD->SendLogout(u);
+				return;
 			}
 
+			NickCore *nc = na->nc;
+			if (na == nc->na)
+			{
+				// User is logged into their display nick.
+				u->Login(nc);
+			}
+			else
+			{
+				// User is logged into a non-display nick, their display has
+				// probably expired due to a config change so reauthenticate
+				// them as their new display nick.
+				u->Identify(nc->na);
+			}
 		}
 		else if (params[1].equals_cs("certfp"))
 		{

--- a/modules/protocol/ngircd.cpp
+++ b/modules/protocol/ngircd.cpp
@@ -332,6 +332,19 @@ struct IRCDMessageMetadata final
 			NickCore *nc = NickCore::Find(params[2]);
 			if (nc)
 				u->Login(nc);
+			else
+			{
+				// Handle corner cases around database rollbacks/inconsistency and users
+				// whose display nick recently expired, causing an alias to become the
+				// display nick.
+				auto *na = NickAlias::Find(params[2]);
+				if (na)
+				{
+					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
+					u->Identify(na);
+				}
+			}
+
 		}
 		else if (params[1].equals_cs("certfp"))
 		{

--- a/modules/protocol/plexus.cpp
+++ b/modules/protocol/plexus.cpp
@@ -227,24 +227,30 @@ struct IRCDMessageEncap final
 		if (params[1].equals_cs("SU"))
 		{
 			User *u = User::Find(params[2]);
-			NickCore *nc = NickCore::Find(params[3]);
-			if (u)
+			// If we're bursting then then the user was probably logged in
+			// during a previous connection.
+			auto *na = NickAlias::Find(params[3]);
+			if (!na)
 			{
-				if (nc)
-					u->Login(nc);
-				else
-				{
-					// Handle corner cases around database rollbacks/inconsistency and users
-					// whose display nick recently expired, causing an alias to become the
-					// display nick.
-					auto *na = NickAlias::Find(params[2]);
-					if (na)
-					{
-						Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
-						u->Identify(na);
-					}
-				}
+				// Nick has been dropped, force the IRCd to deauth them.
+				IRCD->SendLogout(u);
+				return;
 			}
+
+			NickCore *nc = na->nc;
+			if (na == nc->na)
+			{
+				// User is logged into their display nick.
+				u->Login(nc);
+			}
+			else
+			{
+				// User is logged into a non-display nick, their display has
+				// probably expired due to a config change so reauthenticate
+				// them as their new display nick.
+				u->Identify(nc->na);
+			}
+
 		}
 
 		/*

--- a/modules/protocol/plexus.cpp
+++ b/modules/protocol/plexus.cpp
@@ -227,6 +227,9 @@ struct IRCDMessageEncap final
 		if (params[1].equals_cs("SU"))
 		{
 			User *u = User::Find(params[2]);
+			if (!u)
+				return; // Should never happen.
+
 			// If we're bursting then then the user was probably logged in
 			// during a previous connection.
 			auto *na = NickAlias::Find(params[3]);

--- a/modules/protocol/plexus.cpp
+++ b/modules/protocol/plexus.cpp
@@ -228,9 +228,22 @@ struct IRCDMessageEncap final
 		{
 			User *u = User::Find(params[2]);
 			NickCore *nc = NickCore::Find(params[3]);
-			if (u && nc)
+			if (u)
 			{
-				u->Login(nc);
+				if (nc)
+					u->Login(nc);
+				else
+				{
+					// Handle corner cases around database rollbacks/inconsistency and users
+					// whose display nick recently expired, causing an alias to become the
+					// display nick.
+					auto *na = NickAlias::Find(params[2]);
+					if (na)
+					{
+						Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
+						u->Identify(na);
+					}
+				}
 			}
 		}
 

--- a/modules/protocol/ratbox.cpp
+++ b/modules/protocol/ratbox.cpp
@@ -158,14 +158,29 @@ struct IRCDMessageEncap final
 			User *u = source.GetUser();
 
 			NickCore *nc = NickCore::Find(params[2]);
-			if (!nc)
-				return;
-			u->Login(nc);
+			if (nc)
+			{
+				u->Login(nc);
+			}
+			else
+			{
+				// Handle corner cases around database rollbacks/inconsistency and users
+				// whose display nick recently expired, causing an alias to become the
+				// display nick.
+				auto *na = NickAlias::Find(params[2]);
+				if (na)
+				{
+					nc = na->nc;
+					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << nc->na->nick << "'.";
+					u->Identify(na);
+				}
+			}
+
 
 			/* Sometimes a user connects, we send them the usual "this nickname is registered" mess (if
 			 * their server isn't syncing) and then we receive this.. so tell them about it.
 			 */
-			if (u->server->IsSynced())
+			if (nc && u->server->IsSynced())
 				u->SendMessage(Config->GetClient("NickServ"), _("You have been logged in as \002%s\002."), nc->display.c_str());
 		}
 	}

--- a/modules/protocol/ratbox.cpp
+++ b/modules/protocol/ratbox.cpp
@@ -157,30 +157,34 @@ struct IRCDMessageEncap final
 		{
 			User *u = source.GetUser();
 
-			NickCore *nc = NickCore::Find(params[2]);
-			if (nc)
+			// If we're bursting then then the user was probably logged in
+			// during a previous connection.
+			auto *na = NickAlias::Find(params[2]);
+			if (!na)
 			{
+				// Nick has been dropped, force the IRCd to deauth them.
+				IRCD->SendLogout(u);
+				return;
+			}
+
+			NickCore *nc = na->nc;
+			if (na == nc->na)
+			{
+				// User is logged into their display nick.
 				u->Login(nc);
 			}
 			else
 			{
-				// Handle corner cases around database rollbacks/inconsistency and users
-				// whose display nick recently expired, causing an alias to become the
-				// display nick.
-				auto *na = NickAlias::Find(params[2]);
-				if (na)
-				{
-					nc = na->nc;
-					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << nc->na->nick << "'.";
-					u->Identify(na);
-				}
+				// User is logged into a non-display nick, their display has
+				// probably expired due to a config change so reauthenticate
+				// them as their new display nick.
+				u->Identify(nc->na);
 			}
-
 
 			/* Sometimes a user connects, we send them the usual "this nickname is registered" mess (if
 			 * their server isn't syncing) and then we receive this.. so tell them about it.
 			 */
-			if (nc && u->server->IsSynced())
+			if (u->server->IsSynced())
 				u->SendMessage(Config->GetClient("NickServ"), _("You have been logged in as \002%s\002."), nc->display.c_str());
 		}
 	}

--- a/modules/protocol/ratbox.cpp
+++ b/modules/protocol/ratbox.cpp
@@ -156,6 +156,8 @@ struct IRCDMessageEncap final
 		if (params[1] == "LOGIN" || params[1] == "SU")
 		{
 			User *u = source.GetUser();
+			if (!u)
+				return; // Should never happen.
 
 			// If we're bursting then then the user was probably logged in
 			// during a previous connection.

--- a/modules/protocol/solanum.cpp
+++ b/modules/protocol/solanum.cpp
@@ -318,24 +318,31 @@ struct IRCDMessageEncap final
 		if (params[1] == "LOGIN" || params[1] == "SU")
 		{
 			User *u = source.GetUser();
-			NickCore *nc = NickCore::Find(params[2]);
-
 			if (!u)
 				return;
 
-			if (nc)
+			// If we're bursting then then the user was probably logged in
+			// during a previous connection.
+			auto *na = NickAlias::Find(params[2]);
+			if (!na)
+			{
+				// Nick has been dropped, force the IRCd to deauth them.
+				IRCD->SendLogout(u);
+				return;
+			}
+
+			NickCore *nc = na->nc;
+			if (na == nc->na)
+			{
+				// User is logged into their display nick.
 				u->Login(nc);
+			}
 			else
 			{
-				// Handle corner cases around database rollbacks/inconsistency and users
-				// whose display nick recently expired, causing an alias to become the
-				// display nick.
-				auto *na = NickAlias::Find(params[2]);
-				if (na)
-				{
-					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
-					u->Identify(na);
-				}
+				// User is logged into a non-display nick, their display has
+				// probably expired due to a config change so reauthenticate
+				// them as their new display nick.
+				u->Identify(nc->na);
 			}
 		}
 		// Received: :42XAAAAAE ENCAP * CERTFP :3f122a9cc7811dbad3566bf2cec3009007c0868f

--- a/modules/protocol/solanum.cpp
+++ b/modules/protocol/solanum.cpp
@@ -320,10 +320,23 @@ struct IRCDMessageEncap final
 			User *u = source.GetUser();
 			NickCore *nc = NickCore::Find(params[2]);
 
-			if (!u || !nc)
+			if (!u)
 				return;
 
-			u->Login(nc);
+			if (nc)
+				u->Login(nc);
+			else
+			{
+				// Handle corner cases around database rollbacks/inconsistency and users
+				// whose display nick recently expired, causing an alias to become the
+				// display nick.
+				auto *na = NickAlias::Find(params[2]);
+				if (na)
+				{
+					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
+					u->Identify(na);
+				}
+			}
 		}
 		// Received: :42XAAAAAE ENCAP * CERTFP :3f122a9cc7811dbad3566bf2cec3009007c0868f
 		else if (params[1] == "CERTFP")

--- a/modules/protocol/unrealircd.cpp
+++ b/modules/protocol/unrealircd.cpp
@@ -1656,6 +1656,18 @@ public:
 			NickCore *nc = NickCore::Find(params[2]);
 			if (nc)
 				u->Login(nc);
+			else
+			{
+				// Handle corner cases around database rollbacks/inconsistency and users
+				// whose display nick recently expired, causing an alias to become the
+				// display nick.
+				auto *na = NickAlias::Find(params[2]);
+				if (na)
+				{
+					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
+					u->Identify(na);
+				}
+			}
 		}
 	}
 };

--- a/modules/protocol/unrealircd.cpp
+++ b/modules/protocol/unrealircd.cpp
@@ -1651,22 +1651,28 @@ public:
 		}
 		else
 		{
-			// If we're bursting then then the user was probably logged
-			// in during a previous connection.
-			NickCore *nc = NickCore::Find(params[2]);
-			if (nc)
+			// If we're bursting then then the user was probably logged in
+			// during a previous connection.
+			auto *na = NickAlias::Find(params[2]);
+			if (!na)
+			{
+				// Nick has been dropped, force the IRCd to deauth them.
+				IRCD->SendLogout(u);
+				return;
+			}
+
+			NickCore *nc = na->nc;
+			if (na == nc->na)
+			{
+				// User is logged into their display nick.
 				u->Login(nc);
+			}
 			else
 			{
-				// Handle corner cases around database rollbacks/inconsistency and users
-				// whose display nick recently expired, causing an alias to become the
-				// display nick.
-				auto *na = NickAlias::Find(params[2]);
-				if (na)
-				{
-					Log() << "User " << u->nick << " is logged in as alias '" << na->nick << "', logging them in as the display nick '" << na->nc->na->nick << "'.";
-					u->Identify(na);
-				}
+				// User is logged into a non-display nick, their display has
+				// probably expired due to a config change so reauthenticate
+				// them as their new display nick.
+				u->Identify(nc->na);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Handle case where, for whatever reason, an IRCd tells us that a user is logged in as a secondary alias rather than the one associated with their NickCore (display name.)

## Rationale
This can come up during slightly wonky database imports.
1. Import database from e.g. Atheme with Anope setting preservedisplay=no
2. User with display name Robert and alias Bob who's currently logged in hasn't used Robert in a year, so Bob becomes the display name
3. Bounce Anope and reimport the database for whatever reason
4. "Bob" isn't a valid display name, since it's back to Robert, so the NickCore isn't found
5. Bob gets Guest-ed.

It's very stupid but it happened.

## Testing Environment

By the time I did my source dive, everyone had re-identified. 
**I have not tested this.** It looks like it should do the thing, though.

Built on:
**Operating system name and version:** Ubuntu 24.04 under WSL
**Compiler name and version:** GCC 14.2.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
