### PR TITLE
Fix *_set_misc blocks missing prefix in 'name' and do more thorough config checks

### DIFF
--- a/include/modules/set_misc.h
+++ b/include/modules/set_misc.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#define CHANSERV_SET_MISC_PREFIX "cs_set_misc:"
+#define NICKSERV_SET_MISC_PREFIX "ns_set_misc:"
+
 struct MiscData
 {
 	Anope::string object;

--- a/modules/chanserv/cs_set_misc.cpp
+++ b/modules/chanserv/cs_set_misc.cpp
@@ -17,8 +17,6 @@
 
 static Module *me;
 
-#define MISC_PREFIX "cs_set_misc:"
-
 struct CommandData final
 {
 	Anope::string description;
@@ -107,8 +105,8 @@ static Anope::string GetAttribute(const Anope::string &command)
 {
 	size_t sp = command.rfind(' ');
 	if (sp != Anope::string::npos)
-		return MISC_PREFIX + command.substr(sp + 1);
-	return MISC_PREFIX + command;
+		return CHANSERV_SET_MISC_PREFIX + command.substr(sp + 1);
+	return CHANSERV_SET_MISC_PREFIX + command;
 }
 
 static const char* GetTitle(ExtensibleItem<CSMiscData> *ext)

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1188,9 +1188,8 @@ private:
 			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
-				Log(this) << "Configuration error: " << Module::name << " cs_set_misc entry " << it->second
-					<< " lacks a corresponding chanserv/set/misc command";
-				throw ConfigException(); // Can't check when reading the config becuase cs_set_misc might not be loaded
+				throw ConfigException(this->name + " cs_set_misc entry " + it->second
+					+ " lacks a corresponding chanserv/set/misc command");
 			}
 
 			auto *data = extref->Set(ci);
@@ -1338,9 +1337,8 @@ private:
 			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
-				Log(this) << "Configuration error: " << Module::name << " ns_set_misc entry " << it->second
-					<< " lacks a corresponding nickserv/set/misc command";
-				throw ConfigException(); // Can't check when reading the config becuase ns_set_misc might not be loaded
+				throw ConfigException(this->name + " ns_set_misc entry " + it->second
+					+ " lacks a corresponding nickserv/set/misc command");
 			}
 
 			auto *data = extref->Set(nc);

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1160,7 +1160,9 @@ private:
 			return HandleIgnoreMetadata(ci->name, key, value);
 		else if (key.find(':') == Anope::string::npos)
 		{
-			ExtensibleRef<MiscData> extref("cs_set_misc:" + key.upper());
+			// Make a guess that there could be a ChanServ SET MISC entry w/the mystery key's exact (uppercase) name
+			const Anope::string name = "cs_set_misc:" + key.upper();
+			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
 				Log(this) << "Unknown public channel metadata for " << ci->name << ": " << key << " = " << value;
@@ -1169,11 +1171,12 @@ private:
 
 			auto *data = extref->Set(ci);
 			data->object = ci->name;
-			data->name = key;
+			data->name = name;
 			data->data = value;
 		}
 		else
 		{
+			// Look for a ChanServ SET MISC entry defined in the configuration
 			auto it = csmiscdata.find(key);
 			if (it == csmiscdata.end())
 			{
@@ -1181,16 +1184,18 @@ private:
 				return true;
 			}
 
-			ExtensibleRef<MiscData> extref("cs_set_misc:" + it->second);
+			const Anope::string name = "cs_set_misc:" + it->second;
+			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
-				Log(this) << "Unknown imported channel metadata for " << ci->name << ": " << it->second << " = " << value;
-				return true;
+				Log(this) << "Configuration error: " << Module::name << " cs_set_misc entry " << it->second
+					<< " lacks a corresponding chanserv/set/misc command";
+				throw new ConfigException; // Can't check when reading the config becuase cs_set_misc might not be loaded
 			}
 
 			auto *data = extref->Set(ci);
 			data->object = ci->name;
-			data->name = it->second;
+			data->name = name;
 			data->data = value;
 		}
 
@@ -1305,7 +1310,9 @@ private:
 			data->vhost_nick[key.substr(18)] = value;
 		else if (key.find(':') == Anope::string::npos)
 		{
-			ExtensibleRef<MiscData> extref("ns_set_misc:" + key.upper());
+			// Make a guess that there could be a NickServ SET MISC entry w/the mystery key's exact (uppercase) name
+			const Anope::string name = "ns_set_misc:" + key.upper();
+			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
 				Log(this) << "Unknown public account metadata for " << nc->display << ": " << key << " = " << value;
@@ -1314,11 +1321,12 @@ private:
 
 			auto *data = extref->Set(nc);
 			data->object = nc->display;
-			data->name = key;
+			data->name = name;
 			data->data = value;
 		}
 		else
 		{
+			// Look for a NickServ SET MISC entry defined in the configuration
 			auto it = nsmiscdata.find(key);
 			if (it == nsmiscdata.end())
 			{
@@ -1326,16 +1334,18 @@ private:
 				return true;
 			}
 
-			ExtensibleRef<MiscData> extref("ns_set_misc:" + it->second);
+			const Anope::string name = "ns_set_misc:" + it->second;
+			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
-				Log(this) << "Unknown imported account metadata for " << nc->display << ": " << key << " = " << value;
-				return true;
+				Log(this) << "Configuration error: " << Module::name << " ns_set_misc entry " << it->second
+					<< " lacks a corresponding nickserv/set/misc command";
+				throw new ConfigException; // Can't check when reading the config becuase ns_set_misc might not be loaded
 			}
 
 			auto *data = extref->Set(nc);
 			data->object = nc->display;
-			data->name = it->second;
+			data->name = name;
 			data->data = value;
 		}
 
@@ -1693,7 +1703,17 @@ public:
 		{
 			const auto &anope = data.Get<const Anope::string>("anope");
 			const auto &atheme = data.Get<const Anope::string>("atheme");
-			if (!anope.empty() && !atheme.empty())
+			if (anope.empty())
+			{
+				Log(this) << " missing cs_set_misc anope config entry" << (atheme.empty() ? "" : (" for atheme entry " + atheme));
+				throw new ConfigException;
+			}
+			else if (atheme.empty())
+			{
+				Log(this) << " missing cs_set_misc atheme config entry for anope entry " << anope;
+				throw new ConfigException;
+			}
+			else
 				csmiscdata[atheme] = anope.upper();
 		}
 
@@ -1702,7 +1722,17 @@ public:
 		{
 			const auto &anope = data.Get<const Anope::string>("anope");
 			const auto &atheme = data.Get<const Anope::string>("atheme");
-			if (!anope.empty() && !atheme.empty())
+			if (anope.empty())
+			{
+				Log(this) << " missing ns_set_misc anope config entry" << (atheme.empty() ? "" : (" for atheme entry " + atheme));
+				throw new ConfigException;
+			}
+			else if (atheme.empty())
+			{
+				Log(this) << " missing ns_set_misc atheme config entry for anope entry " << anope;
+				throw new ConfigException;
+			}
+			else
 				nsmiscdata[atheme] = anope.upper();
 		}
 

--- a/modules/database/db_atheme.cpp
+++ b/modules/database/db_atheme.cpp
@@ -1161,7 +1161,7 @@ private:
 		else if (key.find(':') == Anope::string::npos)
 		{
 			// Make a guess that there could be a ChanServ SET MISC entry w/the mystery key's exact (uppercase) name
-			const Anope::string name = "cs_set_misc:" + key.upper();
+			const Anope::string name = CHANSERV_SET_MISC_PREFIX + key.upper();
 			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
@@ -1184,13 +1184,13 @@ private:
 				return true;
 			}
 
-			const Anope::string name = "cs_set_misc:" + it->second;
+			const Anope::string name = CHANSERV_SET_MISC_PREFIX + it->second;
 			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
 				Log(this) << "Configuration error: " << Module::name << " cs_set_misc entry " << it->second
 					<< " lacks a corresponding chanserv/set/misc command";
-				throw new ConfigException; // Can't check when reading the config becuase cs_set_misc might not be loaded
+				throw ConfigException(); // Can't check when reading the config becuase cs_set_misc might not be loaded
 			}
 
 			auto *data = extref->Set(ci);
@@ -1311,7 +1311,7 @@ private:
 		else if (key.find(':') == Anope::string::npos)
 		{
 			// Make a guess that there could be a NickServ SET MISC entry w/the mystery key's exact (uppercase) name
-			const Anope::string name = "ns_set_misc:" + key.upper();
+			const Anope::string name = NICKSERV_SET_MISC_PREFIX + key.upper();
 			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
@@ -1334,13 +1334,13 @@ private:
 				return true;
 			}
 
-			const Anope::string name = "ns_set_misc:" + it->second;
+			const Anope::string name = NICKSERV_SET_MISC_PREFIX + it->second;
 			ExtensibleRef<MiscData> extref(name);
 			if (!extref)
 			{
 				Log(this) << "Configuration error: " << Module::name << " ns_set_misc entry " << it->second
 					<< " lacks a corresponding nickserv/set/misc command";
-				throw new ConfigException; // Can't check when reading the config becuase ns_set_misc might not be loaded
+				throw ConfigException(); // Can't check when reading the config becuase ns_set_misc might not be loaded
 			}
 
 			auto *data = extref->Set(nc);
@@ -1698,52 +1698,44 @@ public:
 	{
 		const auto &modconf = conf.GetModule(this);
 
-		csmiscdata.clear();
+		Anope::map<Anope::string> tmp_csmiscdata;
 		for (const auto &[_,  data] : modconf.GetBlocks("cs_set_misc"))
 		{
 			const auto &anope = data.Get<const Anope::string>("anope");
 			const auto &atheme = data.Get<const Anope::string>("atheme");
 			if (anope.empty())
-			{
-				Log(this) << " missing cs_set_misc anope config entry" << (atheme.empty() ? "" : (" for atheme entry " + atheme));
-				throw new ConfigException;
-			}
+				throw ConfigException(this->name + " missing cs_set_misc anope config entry" + (atheme.empty() ? "" : (" for atheme entry " + atheme)));
 			else if (atheme.empty())
-			{
-				Log(this) << " missing cs_set_misc atheme config entry for anope entry " << anope;
-				throw new ConfigException;
-			}
+				throw ConfigException(this->name + " missing cs_set_misc atheme config entry for anope entry " + anope);
 			else
-				csmiscdata[atheme] = anope.upper();
+				tmp_csmiscdata[atheme] = anope.upper();
 		}
 
-		nsmiscdata.clear();
+		Anope::map<Anope::string> tmp_nsmiscdata;
 		for (const auto &[_,  data] : modconf.GetBlocks("ns_set_misc"))
 		{
 			const auto &anope = data.Get<const Anope::string>("anope");
 			const auto &atheme = data.Get<const Anope::string>("atheme");
 			if (anope.empty())
-			{
-				Log(this) << " missing ns_set_misc anope config entry" << (atheme.empty() ? "" : (" for atheme entry " + atheme));
-				throw new ConfigException;
-			}
+				throw ConfigException(this->name + "missing ns_set_misc anope config entry" + (atheme.empty() ? "" : (" for atheme entry " + atheme)));
 			else if (atheme.empty())
-			{
-				Log(this) << " missing ns_set_misc atheme config entry for anope entry " << anope;
-				throw new ConfigException;
-			}
+				throw ConfigException(this->name + " missing ns_set_misc atheme config entry for anope entry " + anope);
 			else
-				nsmiscdata[atheme] = anope.upper();
+				tmp_nsmiscdata[atheme] = anope.upper();
 		}
 
-		flags.clear();
+		std::map<Anope::string, char> tmp_flags;
 		for (const auto &[_,  priv] : conf.GetBlocks("privilege"))
 		{
 			const Anope::string &name = priv.Get<const Anope::string>("name");
 			const Anope::string &value = priv.Get<const Anope::string>("flag");
 			if (!name.empty() && !value.empty())
-				flags[name] = value[0];
+				tmp_flags[name] = value[0];
 		}
+
+		csmiscdata = tmp_csmiscdata;
+		nsmiscdata = tmp_nsmiscdata;
+		flags = tmp_flags;
 	}
 
 	EventReturn OnLoadDatabase() override

--- a/modules/nickserv/ns_set_misc.cpp
+++ b/modules/nickserv/ns_set_misc.cpp
@@ -17,8 +17,6 @@
 
 static Module *me;
 
-#define MISC_PREFIX "ns_set_misc:"
-
 struct CommandData final
 {
 	Anope::string saset_description;
@@ -110,8 +108,8 @@ static Anope::string GetAttribute(const Anope::string &command)
 {
 	size_t sp = command.rfind(' ');
 	if (sp != Anope::string::npos)
-		return MISC_PREFIX + command.substr(sp + 1);
-	return MISC_PREFIX + command;
+		return CHANSERV_SET_MISC_PREFIX + command.substr(sp + 1);
+	return CHANSERV_SET_MISC_PREFIX + command;
 }
 
 static const char* GetTitle(ExtensibleItem<NSMiscData> *ext)


### PR DESCRIPTION
## Summary

The 'name' field of the serializable set misc objects was set to "FOO" instead of "xs_set_misc:FOO", which led to their working fine on initial import but being unreadable after services were restarted.
Also added some more config checking.
## Rationale

Bug fix: obvious

Fatal errors added on the theory that it's better to have the initial import crash with a clear error than to have services come up only to need to be brought down again once the admin reads the log. (Or, worse, to have the config error go unnoticed until a user asks where their data went a week later.)

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 24.04.4 / Linux 5.10.102 on WSL
**Compiler name and version:** GCC 13.3.0
insp 4.10.1

Tested with various configuration issues for ns_set_misc. Error messages were emitted and Anope terminated. Tested success case and verified that the ns_set_misc prefix was present in anope.json.

## Checks

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.