### PR TITLE
Fix guest nick detection

### DIFF
--- a/modules/nickserv/nickserv.cpp
+++ b/modules/nickserv/nickserv.cpp
@@ -201,10 +201,12 @@ public:
 		const auto minlen = std::min(nick.length(), guestnick.length());
 		for (size_t idx = 0; idx < minlen; ++idx)
 		{
-			if (guestnick[idx] == '#' && !isdigit(nick[idx]))
-				return false;
-
-			if (Anope::tolower(guestnick[idx]) != Anope::tolower(nick[idx]))
+			if (guestnick[idx] == '#')
+			{
+				if (!isdigit(nick[idx]))
+					return false;
+			}
+			else if (Anope::tolower(guestnick[idx]) != Anope::tolower(nick[idx]))
 				return false;
 		}
 		return true;


### PR DESCRIPTION
## Summary

Guest nick routine would return false if not an exact match to 'Guest#####' because the equality checks were still performed after checking for number substitution.
## Rationale

Bugfix
## Testing Environment

Tested this toy version:
```c++
#include <iostream>
#include <string>

inline std::string lower(const std::string &old)
{
	std::string new_string(old);
	for (auto &chr : new_string)
		chr = std::tolower(chr);
	return new_string;
}

bool IsGuestNick(const std::string &nick)
{
	const std::string guestnick = "Guest#####";
	if (guestnick.empty())
		return false; // No guest nick.

	const auto minlen = std::min(nick.length(), guestnick.length());
	for (size_t idx = 0; idx < minlen; ++idx)
	{
	    std::cout << "Index: " << idx << ",";
		if (guestnick[idx] == '#')
		{
		    if (!isdigit(nick[idx]))
			    return false;
		}
		else if (tolower(guestnick[idx]) != tolower(nick[idx]))
			return false;
	}
	return true;
}

int main() {
    std::cout << IsGuestNick("Guest12345");

    return 0;
}
```

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
