### PR TITLE
Add support for optionally skipping CRs to sendmail (fixes nullmailer)

### DIFF
--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -980,7 +980,7 @@ mail
 	/*
 	 * If set, Anope will end lines with LF rather than CRLF when transmitting
 	 * a message to sendmail. This is nonstandard but necessary for nullmailer
-	 * and probably other mailers.
+	 * and probably some other mailers.
 	 */
 	#dontincludecr = yes
 

--- a/data/anope.example.conf
+++ b/data/anope.example.conf
@@ -978,6 +978,13 @@ mail
 	#dontquoteaddresses = yes
 
 	/*
+	 * If set, Anope will end lines with LF rather than CRLF when transmitting
+	 * a message to sendmail. This is nonstandard but necessary for nullmailer
+	 * and probably other mailers.
+	 */
+	#dontincludecr = yes
+
+	/*
 	 * The content type to use when sending emails.
 	 *
 	 * This directive is optional, and is generally only needed if you want to

--- a/include/mail.h
+++ b/include/mail.h
@@ -38,7 +38,7 @@ namespace Mail
 		Anope::string message;
 		Anope::string content_type;
 		bool dont_quote_addresses;
-		bool dont_include_cr;
+		Anope::string eol;
 
 	public:
 		/** Construct this message. Once constructed call Thread::Start to launch the mail sending.

--- a/include/mail.h
+++ b/include/mail.h
@@ -38,6 +38,7 @@ namespace Mail
 		Anope::string message;
 		Anope::string content_type;
 		bool dont_quote_addresses;
+		bool dont_include_cr;
 
 	public:
 		/** Construct this message. Once constructed call Thread::Start to launch the mail sending.

--- a/src/mail.cpp
+++ b/src/mail.cpp
@@ -51,20 +51,20 @@ void Mail::Message::Run()
 		return;
 	}
 
-	fprintf(pipe, "From: %s%s\n", send_from.c_str(), eol.c_str());
+	fprintf(pipe, "From: %s%s", send_from.c_str(), eol.c_str());
 	if (this->dont_quote_addresses)
-		fprintf(pipe, "To: %s <%s>%s\n", mail_to.c_str(), addr.c_str(), eol.c_str());
+		fprintf(pipe, "To: %s <%s>%s", mail_to.c_str(), addr.c_str(), eol.c_str());
 	else
-		fprintf(pipe, "To: \"%s\" <%s>%s\n", mail_to.replace_all_cs("\\", "\\\\").c_str(), addr.c_str(), eol.c_str());
-	fprintf(pipe, "Subject: %s%s\n", subject.c_str(), eol.c_str());
-	fprintf(pipe, "Content-Type: %s%s\n", content_type.c_str(), eol.c_str());
-	fprintf(pipe, "Content-Transfer-Encoding: 8bit%s\n", eol.c_str());
-	fprintf(pipe, "%s\n", eol.c_str());
+		fprintf(pipe, "To: \"%s\" <%s>%s", mail_to.replace_all_cs("\\", "\\\\").c_str(), addr.c_str(), eol.c_str());
+	fprintf(pipe, "Subject: %s%s", subject.c_str(), eol.c_str());
+	fprintf(pipe, "Content-Type: %s%s", content_type.c_str(), eol.c_str());
+	fprintf(pipe, "Content-Transfer-Encoding: 8bit%s", eol.c_str());
+	fprintf(pipe, "%s", eol.c_str());
 
 	std::stringstream stream(message.str());
 	for (Anope::string line; std::getline(stream, line.str()); )
-		fprintf(pipe, "%s%s\n", line.c_str(), eol.c_str());
-	fprintf(pipe, "%s\n", eol.c_str());
+		fprintf(pipe, "%s%s", line.c_str(), eol.c_str());
+	fprintf(pipe, "%s", eol.c_str());
 
 	auto result = pclose(pipe);
 	if (result > 0)

--- a/src/mail.cpp
+++ b/src/mail.cpp
@@ -28,7 +28,7 @@ Mail::Message::Message(const Anope::string &sf, const Anope::string &mailto, con
 	, message(m)
 	, content_type(Config->GetBlock("mail").Get<const Anope::string>("content_type", "text/plain; charset=UTF-8"))
 	, dont_quote_addresses(Config->GetBlock("mail").Get<bool>("dontquoteaddresses"))
-	, dont_include_cr(Config->GetBlock("mail").Get<bool>("dontincludecr"))
+	, eol(Config->GetBlock("mail").Get<bool>("dontincludecr") ? "\n" : "\r\n")
 {
 }
 
@@ -50,22 +50,21 @@ void Mail::Message::Run()
 		SetExitState();
 		return;
 	}
-	const Anope::string maybe_cr = dont_include_cr ? "" : "\r";
 
-	fprintf(pipe, "From: %s%s\n", send_from.c_str(), maybe_cr.c_str());
+	fprintf(pipe, "From: %s%s\n", send_from.c_str(), eol.c_str());
 	if (this->dont_quote_addresses)
-		fprintf(pipe, "To: %s <%s>%s\n", mail_to.c_str(), addr.c_str(), maybe_cr.c_str());
+		fprintf(pipe, "To: %s <%s>%s\n", mail_to.c_str(), addr.c_str(), eol.c_str());
 	else
-		fprintf(pipe, "To: \"%s\" <%s>%s\n", mail_to.replace_all_cs("\\", "\\\\").c_str(), addr.c_str(), maybe_cr.c_str());
-	fprintf(pipe, "Subject: %s%s\n", subject.c_str(), maybe_cr.c_str());
-	fprintf(pipe, "Content-Type: %s%s\n", content_type.c_str(), maybe_cr.c_str());
-	fprintf(pipe, "Content-Transfer-Encoding: 8bit%s\n", maybe_cr.c_str());
-	fprintf(pipe, "%s\n", maybe_cr.c_str());
+		fprintf(pipe, "To: \"%s\" <%s>%s\n", mail_to.replace_all_cs("\\", "\\\\").c_str(), addr.c_str(), eol.c_str());
+	fprintf(pipe, "Subject: %s%s\n", subject.c_str(), eol.c_str());
+	fprintf(pipe, "Content-Type: %s%s\n", content_type.c_str(), eol.c_str());
+	fprintf(pipe, "Content-Transfer-Encoding: 8bit%s\n", eol.c_str());
+	fprintf(pipe, "%s\n", eol.c_str());
 
 	std::stringstream stream(message.str());
 	for (Anope::string line; std::getline(stream, line.str()); )
-		fprintf(pipe, "%s%s\n", line.c_str(), maybe_cr.c_str());
-	fprintf(pipe, "%s\n", maybe_cr.c_str());
+		fprintf(pipe, "%s%s\n", line.c_str(), eol.c_str());
+	fprintf(pipe, "%s\n", eol.c_str());
 
 	auto result = pclose(pipe);
 	if (result > 0)

--- a/src/mail.cpp
+++ b/src/mail.cpp
@@ -28,6 +28,7 @@ Mail::Message::Message(const Anope::string &sf, const Anope::string &mailto, con
 	, message(m)
 	, content_type(Config->GetBlock("mail").Get<const Anope::string>("content_type", "text/plain; charset=UTF-8"))
 	, dont_quote_addresses(Config->GetBlock("mail").Get<bool>("dontquoteaddresses"))
+	, dont_include_cr(Config->GetBlock("mail").Get<bool>("dontincludecr"))
 {
 }
 
@@ -49,21 +50,22 @@ void Mail::Message::Run()
 		SetExitState();
 		return;
 	}
+	const Anope::string maybe_cr = dont_include_cr ? "" : "\r";
 
-	fprintf(pipe, "From: %s\r\n", send_from.c_str());
+	fprintf(pipe, "From: %s%s\n", send_from.c_str(), maybe_cr.c_str());
 	if (this->dont_quote_addresses)
-		fprintf(pipe, "To: %s <%s>\r\n", mail_to.c_str(), addr.c_str());
+		fprintf(pipe, "To: %s <%s>%s\n", mail_to.c_str(), addr.c_str(), maybe_cr.c_str());
 	else
-		fprintf(pipe, "To: \"%s\" <%s>\r\n", mail_to.replace_all_cs("\\", "\\\\").c_str(), addr.c_str());
-	fprintf(pipe, "Subject: %s\r\n", subject.c_str());
-	fprintf(pipe, "Content-Type: %s\r\n", content_type.c_str());
-	fprintf(pipe, "Content-Transfer-Encoding: 8bit\r\n");
-	fprintf(pipe, "\r\n");
+		fprintf(pipe, "To: \"%s\" <%s>%s\n", mail_to.replace_all_cs("\\", "\\\\").c_str(), addr.c_str(), maybe_cr.c_str());
+	fprintf(pipe, "Subject: %s%s\n", subject.c_str(), maybe_cr.c_str());
+	fprintf(pipe, "Content-Type: %s%s\n", content_type.c_str(), maybe_cr.c_str());
+	fprintf(pipe, "Content-Transfer-Encoding: 8bit%s\n", maybe_cr.c_str());
+	fprintf(pipe, "%s\n", maybe_cr.c_str());
 
 	std::stringstream stream(message.str());
 	for (Anope::string line; std::getline(stream, line.str()); )
-		fprintf(pipe, "%s\r\n", line.c_str());
-	fprintf(pipe, "\r\n");
+		fprintf(pipe, "%s%s\n", line.c_str(), maybe_cr.c_str());
+	fprintf(pipe, "%s\n", maybe_cr.c_str());
 
 	auto result = pclose(pipe);
 	if (result > 0)


### PR DESCRIPTION

## Summary
Added a workaround for mailers that don't like CRLF.
<!--
Briefly describe what this pull request changes.
-->

## Rationale
Nullmailer was inserting extra lines in my emails. It doesn't need the CR before the LF at the end of each line, and it doesn't handle them properly. 
<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->
Fired off a quick email with this enabled. Looked fine.

I have tested this pull request on:

**Operating system name and version:** Ubuntu 26.04/WSL, Linux kernel 5.10.102.1-microsoft-standard-WSL2
**Compiler name and version:** g++ (Ubuntu 15.2.0-16ubuntu1) 15.2.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [X] I have documented any features added by this pull request (delete if not applicable).
